### PR TITLE
Add gradle version support tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,12 +77,12 @@ task(performMultipleBuilds) {
     doLast {
         unity.batchMode {
             unityPath = project.file("/Applications/Unity-5.5.3f1/Unity.app/Contents/MacOS/Unity")
-            args "-executeMethod", "MyEditorScript.PerformBuild"           
+            args "-executeMethod", "MyEditorScript.PerformBuild"
         }
 
         unity.batchMode {
             unityPath = project.file("/Applications/Unity-5.6.0f3/Unity.app/Contents/MacOS/Unity")
-            args "-executeMethod", "MyEditorScript.PerformBuild"           
+            args "-executeMethod", "MyEditorScript.PerformBuild"
         }
     }
 }
@@ -177,9 +177,18 @@ Built with Oracle JDK7
 Tested with Oracle JDK8
 
 | Gradle Version | Works |
-| :------------: | :---: |
+| :------------- | :---: |
+| <= 2.13        | no    |
+| 2.14           | yes   |
+| 3.0            | yes   |
+| 3.1            | yes   |
+| 3.2            | yes   |
+| 3.4            | yes   |
 | 3.4.1          | yes   |
 | 3.5            | yes   |
+| 3.5.1          | yes   |
+| 4.0            | yes   |
+
 
 LICENSE
 =======

--- a/src/integrationTest/groovy/wooga/gradle/unity/GradleVersionSupportSpec.groovy
+++ b/src/integrationTest/groovy/wooga/gradle/unity/GradleVersionSupportSpec.groovy
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package wooga.gradle.unity
+
+import spock.lang.Unroll
+
+class GradleVersionSupportSpec extends UnityIntegrationSpec {
+
+    def gradleVersions() {
+        ["2.14", "3.0", "3.1", "3.2", "3.4", "3.4.1", "3.5", "3.5.1", "4.0"]
+    }
+
+    @Unroll("verify plugin activation with gradle #gradleVersionToTest")
+    def "activates with multiple gradle versions"() {
+        given: "a buildfile with unity plugin applied"
+        buildFile << """
+            group = 'test'
+            ${applyPlugin(wooga.gradle.unity.UnityPlugin)}
+        """.stripIndent()
+
+        gradleVersion = gradleVersionToTest
+
+        expect:
+        runTasksSuccessfully("tasks")
+
+        where:
+        gradleVersionToTest << gradleVersions()
+    }
+
+    @Unroll("verify build task works with gradle #gradleVersionToTest")
+    def "runs basic tasks with multiple gradle versions"() {
+        given: "a buildfile with unity plugin applied"
+        buildFile << """
+            group = 'test'
+            ${applyPlugin(wooga.gradle.unity.UnityPlugin)}
+        """.stripIndent()
+
+        gradleVersion = gradleVersionToTest
+
+        expect:
+        runTasksSuccessfully("build")
+
+        where:
+        gradleVersionToTest << gradleVersions()
+    }
+}


### PR DESCRIPTION
The `GradleVersionSupportSpec` will test basic plugin apply and `build`
tasks against a list of gradle versions.

Document supported versions in README