### PR TITLE
assemble external resources

### DIFF
--- a/src/integrationTest/groovy/wooga/gradle/unity/AssembleResourcesIntegrationSpec.groovy
+++ b/src/integrationTest/groovy/wooga/gradle/unity/AssembleResourcesIntegrationSpec.groovy
@@ -51,6 +51,16 @@ class AssembleResourcesIntegrationSpec extends IntegrationSpec {
         out.close()
     }
 
+    def createFrameworkZip(File path) {
+        String frameworkName = path.name.replace('.zip', '')
+        ZipOutputStream out = new ZipOutputStream(new FileOutputStream(path))
+
+        out.putNextEntry(new ZipEntry("$frameworkName/"))
+        out.putNextEntry(new ZipEntry("$frameworkName/binary"))
+        out.putNextEntry(new ZipEntry("$frameworkName/Headers/"))
+        out.putNextEntry(new ZipEntry("$frameworkName/Versions/"))
+        out.close()
+    }
 
     def "skips copy tasks when no dependencies are set"() {
         given: "a build file without external dependencies"
@@ -74,8 +84,8 @@ class AssembleResourcesIntegrationSpec extends IntegrationSpec {
         given: "a test class to copy"
         createFile("WGTestClass.mm", iOSResourcebase)
 
-        and: "a .framework mock"
-        createFile("Test.framework", iOSResourcebase)
+        and: "a .framework zip mock"
+        createFrameworkZip(createFile("Test.framework.zip", iOSResourcebase))
 
         and: "an empty output directory"
         assert !iOSPlugins.list()
@@ -200,7 +210,7 @@ class AssembleResourcesIntegrationSpec extends IntegrationSpec {
         createFile("WGDeviceInfo.jar", androidResourcebase)
 
         and: "a .framework mock"
-        createFile("Test.framework", iOSResourcebase)
+        createFrameworkZip(createFile("Test.framework.zip", iOSResourcebase))
 
         and: "custom set pluginsDir"
         androidPlugins = new File(projectDir, pluginsDir + '/Android')

--- a/src/integrationTest/groovy/wooga/gradle/unity/AssembleResourcesIntegrationSpec.groovy
+++ b/src/integrationTest/groovy/wooga/gradle/unity/AssembleResourcesIntegrationSpec.groovy
@@ -1,0 +1,195 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package wooga.gradle.unity
+
+import nebula.test.IntegrationSpec
+
+import java.util.zip.ZipEntry
+import java.util.zip.ZipOutputStream
+
+class AssembleResourcesIntegrationSpec extends IntegrationSpec {
+
+    File iOSResourcebase
+    File androidResourcebase
+
+
+    File androidPlugins
+    File iOSPlugins
+
+    def setup() {
+        androidPlugins = new File(projectDir, "Assets/Plugins/Android")
+        iOSPlugins = new File(projectDir, "Assets/Plugins/iOS")
+
+        def resourcesBase = new File(projectDir, "test/resources")
+        iOSResourcebase = new File(resourcesBase, "iOS")
+        androidResourcebase = new File(resourcesBase, "android")
+
+        iOSResourcebase.mkdirs()
+        androidResourcebase.mkdirs()
+    }
+
+    def createAARPackage(File path) {
+        ZipOutputStream out = new ZipOutputStream(new FileOutputStream(path))
+        out.putNextEntry(new ZipEntry("classes.jar"))
+        out.putNextEntry(new ZipEntry("AndroidManifest.xml"))
+        out.close()
+    }
+
+
+    def "skips copy tasks when no dependencies are set"() {
+        given: "a build file without external dependencies"
+
+        buildFile << """
+            ${applyPlugin(wooga.gradle.unity.UnityPlugin)}
+        """.stripIndent()
+
+        when: "running the setup task"
+        def result = runTasksSuccessfully(UnityPlugin.SETUP_TASK_NAME)
+
+        then:
+        result.wasExecuted(UnityPlugin.ASSEMBLE_RESOURCES_TASK_NAME)
+        result.wasExecuted("assembleIOSResources")
+        result.wasExecuted("assembleAndroidResources")
+        !androidPlugins.list()
+        !iOSPlugins.list()
+    }
+
+    def "syncs iOS resources when configured"() {
+        given: "a test class to copy"
+        createFile("WGTestClass.mm", iOSResourcebase)
+
+        and: "a .framework mock"
+        createFile("Test.framework", iOSResourcebase)
+
+        and: "an empty output directory"
+        assert !iOSPlugins.list()
+
+        and: "a build file with artifact dependency to that file"
+        buildFile << """
+            ${applyPlugin(wooga.gradle.unity.UnityPlugin)}
+
+            dependencies {
+                ios fileTree(dir: "${iOSResourcebase.path.replace('\\', '/')}")
+            }
+
+        """.stripIndent()
+
+        when: "running the setup task"
+        runTasksSuccessfully(UnityPlugin.SETUP_TASK_NAME)
+
+        then:
+        !androidPlugins.list()
+        iOSPlugins.list()
+        iOSPlugins.list().contains('WGTestClass.mm')
+        iOSPlugins.list().contains('Test.framework')
+    }
+
+    def "syncs android resources when configured"() {
+        given: "a jar file mock to copy"
+        createFile("WGDeviceInfo.jar", androidResourcebase)
+
+        and: "an aar file mock"
+        createAARPackage(createFile("WGDeviceInfo.aar", androidResourcebase))
+
+        and: "an empty output directory"
+        assert !androidPlugins.list()
+
+        and: "a build file with artifact dependency to that file"
+        buildFile << """
+            ${applyPlugin(wooga.gradle.unity.UnityPlugin)}
+
+            dependencies {
+                android fileTree(dir: "${androidResourcebase.path.replace('\\', '/')}")
+            }
+
+        """.stripIndent()
+
+        when: "running the setup task"
+        runTasksSuccessfully(UnityPlugin.SETUP_TASK_NAME)
+
+        then:
+        !iOSPlugins.list()
+        androidPlugins.list()
+        androidPlugins.list().contains('WGDeviceInfo.jar')
+        androidPlugins.list().contains('WGDeviceInfo.aar')
+    }
+
+    def "syncs android resources and unpacks aars"() {
+        given: "a jar file mock to copy"
+        createFile("WGDeviceInfo.jar", androidResourcebase)
+
+        and: "a test aar package"
+        createAARPackage(createFile("WGDeviceInfo.aar", androidResourcebase))
+
+        and: "an empty output directory"
+        assert !androidPlugins.list()
+
+        and: "a build file with artifact dependency to that file"
+        buildFile << """
+            ${applyPlugin(wooga.gradle.unity.UnityPlugin)}
+
+            unity.androidResourceCopyMethod = "arrUnpack"
+            
+            dependencies {
+                android fileTree(dir: "${androidResourcebase.path.replace('\\', '/')}")
+            }
+
+        """.stripIndent()
+
+        when: "running the setup task"
+        runTasksSuccessfully(UnityPlugin.SETUP_TASK_NAME)
+
+        then:
+        def unpackedAARDir = new File(androidPlugins, "WGDeviceInfo")
+        def libsDir = new File(androidPlugins, "libs")
+
+        !iOSPlugins.list()
+        androidPlugins.list()
+        unpackedAARDir.exists()
+        unpackedAARDir.list().contains("WGDeviceInfo.jar")
+        unpackedAARDir.list().contains("AndroidManifest.xml")
+        libsDir.exists()
+        libsDir.list().contains("WGDeviceInfo.jar")
+    }
+
+    def "can set plugins folder in extension"() {
+        given: "a jar file mock to copy"
+        createFile("WGDeviceInfo.jar", androidResourcebase)
+
+        and: "a custom plugins directory"
+        androidPlugins = new File(projectDir, "Assets/Plugins/Custom/Android")
+
+        and: "a build file with artifact dependency to that file"
+        buildFile << """
+            ${applyPlugin(wooga.gradle.unity.UnityPlugin)}
+
+            unity.pluginsDir = "${androidPlugins.path.replace('\\','/')}"
+            
+            dependencies {
+                android fileTree(dir: "${androidResourcebase.path.replace('\\', '/')}")
+            }
+
+        """.stripIndent()
+
+        when: "running the setup task"
+        runTasksSuccessfully(UnityPlugin.SETUP_TASK_NAME)
+
+        then:
+        androidPlugins.list()
+    }
+}

--- a/src/integrationTest/groovy/wooga/gradle/unity/GradleVersionSupportSpec.groovy
+++ b/src/integrationTest/groovy/wooga/gradle/unity/GradleVersionSupportSpec.groovy
@@ -17,12 +17,21 @@
 
 package wooga.gradle.unity
 
+import spock.lang.Ignore
 import spock.lang.Unroll
 
+@Ignore
 class GradleVersionSupportSpec extends UnityIntegrationSpec {
 
     def gradleVersions() {
         ["2.14", "3.0", "3.1", "3.2", "3.4", "3.4.1", "3.5", "3.5.1", "4.0"]
+    }
+
+    def setup() {
+
+        jvmArguments = ['-Xms1g', '-Xmx2g']
+        fork = true
+        memorySafeMode = true
     }
 
     @Unroll("verify plugin activation with gradle #gradleVersionToTest")

--- a/src/integrationTest/groovy/wooga/gradle/unity/PluginConfigurationSpec.groovy
+++ b/src/integrationTest/groovy/wooga/gradle/unity/PluginConfigurationSpec.groovy
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package wooga.gradle.unity
+
+import spock.lang.Unroll
+
+/**
+ * Spec test for basic configuration of the plugin
+ */
+class PluginConfigurationSpec extends UnityIntegrationSpec {
+
+    @Unroll("verify setup task is #status when running #taskName")
+    def "binds all unity tasks to setup task"() {
+        given: "a build script"
+        buildFile << """
+            task (createProject, type: wooga.gradle.unity.tasks.Unity) {
+                args "-createProject", "Test"
+            }
+            
+            task (customTest, type: wooga.gradle.unity.tasks.Test) {
+            }
+            
+            task (customExport, type: wooga.gradle.unity.tasks.UnityPackage) {
+            }
+            
+            task (emptyTask)
+            
+        """.stripIndent()
+
+        when:
+        def result = runTasks(taskName)
+
+        then:
+        result.wasExecuted(UnityPlugin.SETUP_TASK_NAME) == shouldRun
+        result.wasExecuted(UnityPlugin.ASSEMBLE_RESOURCES_TASK_NAME) == shouldRun
+
+        where:
+        taskName                             | shouldRun
+        UnityPlugin.TEST_TASK_NAME           | true
+        UnityPlugin.EXPORT_PACKAGE_TASK_NAME | true
+        "createProject"                      | true
+        "customTest"                         | true
+        "customExport"                       | true
+        "emptyTask"                          | false
+
+        status = shouldRun ? "executed" : "not executed"
+    }
+}

--- a/src/main/groovy/wooga/gradle/unity/AndroidResourceCopyMethod.groovy
+++ b/src/main/groovy/wooga/gradle/unity/AndroidResourceCopyMethod.groovy
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package wooga.gradle.unity
+
+enum AndroidResourceCopyMethod {
+    sync, arrUnpack
+}

--- a/src/main/groovy/wooga/gradle/unity/DefaultUnityPluginExtension.groovy
+++ b/src/main/groovy/wooga/gradle/unity/DefaultUnityPluginExtension.groovy
@@ -62,6 +62,8 @@ class DefaultUnityPluginExtension implements UnityPluginExtension {
     private Boolean autoReturnLicense
     private Boolean autoActivateUnity
 
+    private AndroidResourceCopyMethod androidResourceCopyMethod
+
     private final Instantiator instantiator
     private final FileResolver fileResolver
     private final Project project
@@ -71,6 +73,8 @@ class DefaultUnityPluginExtension implements UnityPluginExtension {
     Factory<ActivationAction> activationActionFactory
 
     private Factory<File> reportsDir
+    private Factory<File> assetsDir
+    private Factory<File> pluginsDir
     private Factory<File> customUnityPath
 
     File getUnityPathFromEnv(Map<String, ?> properties, Map<String, String> env) {
@@ -127,6 +131,44 @@ class DefaultUnityPluginExtension implements UnityPluginExtension {
 
     void setReportsDir(Object file) {
         reportsDir = fileResolver.resolveLater(file)
+    }
+
+    @Override
+    File getPluginsDir() {
+        if (pluginsDir) {
+            return pluginsDir.create()
+        }
+
+        return null
+    }
+
+    @Override
+    void setPluginsDir(File reportsDir) {
+        pluginsDir = fileResolver.resolveLater(reportsDir)
+    }
+
+    @Override
+    void setPluginsDir(Object reportsDir) {
+        pluginsDir = fileResolver.resolveLater(reportsDir)
+    }
+
+    @Override
+    File getAssetsDir() {
+        if (assetsDir) {
+            return assetsDir.create()
+        }
+
+        return null
+    }
+
+    @Override
+    void setAssetsDir(File path) {
+        assetsDir = fileResolver.resolveLater(path)
+    }
+
+    @Override
+    void setAssetsDir(Object path) {
+        assetsDir = fileResolver.resolveLater(path)
     }
 
     File projectPath
@@ -191,6 +233,22 @@ class DefaultUnityPluginExtension implements UnityPluginExtension {
     @Override
     UnityPluginExtension autoActivateUnity(Boolean value) {
         autoActivateUnity = value
+        return this
+    }
+
+    @Override
+    AndroidResourceCopyMethod getAndroidResourceCopyMethod() {
+        return androidResourceCopyMethod
+    }
+
+    @Override
+    void setAndroidResourceCopyMethod(AndroidResourceCopyMethod value) {
+        androidResourceCopyMethod = value
+    }
+
+    @Override
+    UnityPluginExtension androidResourceCopyMethod(AndroidResourceCopyMethod value) {
+        androidResourceCopyMethod = value
         return this
     }
 

--- a/src/main/groovy/wooga/gradle/unity/UnityPlugin.groovy
+++ b/src/main/groovy/wooga/gradle/unity/UnityPlugin.groovy
@@ -45,6 +45,8 @@ class UnityPlugin implements Plugin<Project> {
     static String ACTIVATE_TASK_NAME = "activateUnity"
     static String RETURN_LICENSE_TASK_NAME = "returnUnityLicense"
     static String EXPORT_PACKAGE_TASK_NAME = "exportUnityPackage"
+    static String ASSEMBLE_RESOURCES_TASK_NAME = "assembleResources"
+    static String SETUP_TASK_NAME = "setup"
     static String EXTENSION_NAME = "unity"
     static String UNITY_PACKAGE_CONFIGURATION_NAME = "unitypackage"
     static String GROUP = "unity"
@@ -76,6 +78,7 @@ class UnityPlugin implements Plugin<Project> {
 
         BasePluginConvention convention = new BasePluginConvention(project)
 
+        addLifecycleTasks()
         addTestTask()
         addPackageTask()
         addActivateAndReturnLicenseTasks(extension)
@@ -125,6 +128,13 @@ class UnityPlugin implements Plugin<Project> {
                 return cliReturnLicense || (activateDidWork && didRunUnityTasks)
             }
         })
+    }
+
+    private void addLifecycleTasks() {
+        def assembleTask = project.tasks.create(name: ASSEMBLE_RESOURCES_TASK_NAME, group: GROUP)
+        assembleTask.description 'gathers all iOS and Android resources into Plugins/ directory of the unity project'
+        project.tasks.create(name: SETUP_TASK_NAME, group: GROUP, dependsOn: assembleTask)
+
     }
 
     private void addPackageTask() {

--- a/src/main/groovy/wooga/gradle/unity/UnityPlugin.groovy
+++ b/src/main/groovy/wooga/gradle/unity/UnityPlugin.groovy
@@ -182,10 +182,10 @@ class UnityPlugin implements Plugin<Project> {
         iOSResourceCopy.from({ iOSResources })
         iOSResourceCopy.into({ "${extension.getPluginsDir()}/iOS" })
 
-        Task androidResouceCopy = project.tasks.create(name: "assembleAndroidResources", group: GROUP)
-        androidResouceCopy.description = "gathers all *.jar and AndroidManifest.xml files into the Plugins/Android directory of the unity project"
-        androidResouceCopy.dependsOn(androidResources)
-        androidResouceCopy.doLast(new Action<Task>() {
+        Task androidResourceCopy = project.tasks.create(name: "assembleAndroidResources", group: GROUP)
+        androidResourceCopy.description = "gathers all *.jar and AndroidManifest.xml files into the Plugins/Android directory of the unity project"
+        androidResourceCopy.dependsOn(androidResources)
+        androidResourceCopy.doLast(new Action<Task>() {
             @Override
             void execute(Task task) {
                 String collectDir = "${extension.pluginsDir}/Android"
@@ -229,7 +229,7 @@ class UnityPlugin implements Plugin<Project> {
             }
         })
 
-        assembleTask.dependsOn androidResouceCopy
+        assembleTask.dependsOn androidResourceCopy
         assembleTask.dependsOn iOSResourceCopy
     }
 

--- a/src/main/groovy/wooga/gradle/unity/UnityPlugin.groovy
+++ b/src/main/groovy/wooga/gradle/unity/UnityPlugin.groovy
@@ -33,7 +33,6 @@ import org.gradle.api.reporting.Report
 import org.gradle.api.reporting.ReportingExtension
 import org.gradle.api.specs.Spec
 import org.gradle.api.tasks.Delete
-import org.gradle.api.tasks.Sync
 import org.gradle.internal.reflect.Instantiator
 import org.gradle.language.base.plugins.LifecycleBasePlugin
 import wooga.gradle.unity.tasks.*
@@ -238,7 +237,7 @@ class UnityPlugin implements Plugin<Project> {
                                 copySpec.from project.zipTree(artifact)
                                 copySpec.into "$collectDir/$artifactName"
                                 copySpec.include 'AndroidManifest.xml'
-                                copySpec.include '*.jar'
+                                copySpec.include '**/*.jar'
                                 copySpec.rename(/classes\.jar/, "${artifactName}.jar")
                             }
                         })

--- a/src/main/groovy/wooga/gradle/unity/UnityPlugin.groovy
+++ b/src/main/groovy/wooga/gradle/unity/UnityPlugin.groovy
@@ -302,7 +302,7 @@ class UnityPlugin implements Plugin<Project> {
     }
 
     private void configureCleanObjects() {
-        UnityPluginExtension extension = project.extensions.getByName(EXTENSION_NAME)
+        UnityPluginExtension extension = (UnityPluginExtension) project.extensions.getByName(EXTENSION_NAME)
         Delete cleanTask = (Delete) project.tasks[BasePlugin.CLEAN_TASK_NAME]
 
         cleanTask.delete({ new File(extension.getPluginsDir(), "iOS") })

--- a/src/main/groovy/wooga/gradle/unity/UnityPlugin.groovy
+++ b/src/main/groovy/wooga/gradle/unity/UnityPlugin.groovy
@@ -117,6 +117,7 @@ class UnityPlugin implements Plugin<Project> {
 
         addDefaultReportTasks(extension)
         configureArchiveDefaults(convention)
+        configureUnityTaskDependencies()
         configureCleanObjects()
         project.afterEvaluate(new Action<Project>() {
             @Override
@@ -317,6 +318,15 @@ class UnityPlugin implements Plugin<Project> {
                         new File(extension.reportsDir, task.name + "/" + task.name + "." + report.name)
                     }
                 })
+            }
+        })
+    }
+
+    private void configureUnityTaskDependencies() {
+        project.tasks.withType(AbstractUnityTask, new Action<AbstractUnityTask>() {
+            @Override
+            void execute(AbstractUnityTask task) {
+                task.dependsOn project.tasks[SETUP_TASK_NAME]
             }
         })
     }

--- a/src/main/groovy/wooga/gradle/unity/UnityPlugin.groovy
+++ b/src/main/groovy/wooga/gradle/unity/UnityPlugin.groovy
@@ -32,6 +32,7 @@ import org.gradle.api.plugins.ReportingBasePlugin
 import org.gradle.api.reporting.Report
 import org.gradle.api.reporting.ReportingExtension
 import org.gradle.api.specs.Spec
+import org.gradle.api.tasks.Delete
 import org.gradle.api.tasks.Sync
 import org.gradle.internal.reflect.Instantiator
 import org.gradle.language.base.plugins.LifecycleBasePlugin
@@ -116,6 +117,7 @@ class UnityPlugin implements Plugin<Project> {
 
         addDefaultReportTasks(extension)
         configureArchiveDefaults(convention)
+        configureCleanObjects()
         project.afterEvaluate(new Action<Project>() {
             @Override
             void execute(Project p) {
@@ -296,6 +298,14 @@ class UnityPlugin implements Plugin<Project> {
         Configuration runtimeConfiguration = project.configurations.maybeCreate(RUNTIME_CONFIGURATION_NAME)
         runtimeConfiguration.transitive = true
         runtimeConfiguration.extendsFrom(androidConfiguration, iosConfiguration)
+    }
+
+    private void configureCleanObjects() {
+        UnityPluginExtension extension = project.extensions.getByName(EXTENSION_NAME)
+        Delete cleanTask = (Delete) project.tasks[BasePlugin.CLEAN_TASK_NAME]
+
+        cleanTask.delete({ new File(extension.getPluginsDir(), "iOS") })
+        cleanTask.delete({ new File(extension.getPluginsDir(), "Android") })
     }
 
     private void configureUnityReportDefaults(final UnityPluginExtension extension, final Test task) {

--- a/src/main/groovy/wooga/gradle/unity/UnityPluginExtension.groovy
+++ b/src/main/groovy/wooga/gradle/unity/UnityPluginExtension.groovy
@@ -49,6 +49,18 @@ interface UnityPluginExtension {
 
     void setReportsDir(Object reportsDir)
 
+    File getPluginsDir()
+
+    void setPluginsDir(File reportsDir)
+
+    void setPluginsDir(Object reportsDir)
+
+    File getAssetsDir()
+
+    void setAssetsDir(File reportsDir)
+
+    void setAssetsDir(Object reportsDir)
+
     UnityPluginExtension projectPath(File path)
 
     ExecResult batchMode(Closure closure)
@@ -86,4 +98,10 @@ interface UnityPluginExtension {
     UnityPluginExtension authentication(Closure closure)
 
     UnityPluginExtension authentication(Action<? super UnityAuthentication> action)
+
+    AndroidResourceCopyMethod getAndroidResourceCopyMethod()
+
+    void setAndroidResourceCopyMethod(AndroidResourceCopyMethod value)
+
+    UnityPluginExtension androidResourceCopyMethod(AndroidResourceCopyMethod value)
 }

--- a/src/test/groovy/wooga/gradle/unity/UnityPluginSpec.groovy
+++ b/src/test/groovy/wooga/gradle/unity/UnityPluginSpec.groovy
@@ -19,6 +19,7 @@ package wooga.gradle.unity
 
 import nebula.test.PluginProjectSpec
 import nebula.test.ProjectSpec
+import org.gradle.api.DefaultTask
 import spock.lang.Unroll
 import wooga.gradle.unity.tasks.Test
 import wooga.gradle.unity.tasks.UnityPackage
@@ -45,7 +46,7 @@ class UnityPluginSpec extends ProjectSpec {
     }
 
     @Unroll("creates the task #taskName")
-    def 'Creates the test  task'(String taskName, Class taskType) {
+    def 'Creates needed tasks'(String taskName, Class taskType) {
         given:
         assert !project.plugins.hasPlugin(PLUGIN_NAME)
         assert !project.tasks.findByName(taskName)
@@ -58,9 +59,11 @@ class UnityPluginSpec extends ProjectSpec {
         taskType.isInstance(task)
 
         where:
-        taskName                                  | taskType
-        UnityPlugin.TEST_TASK_NAME                | Test
-        UnityPlugin.EXPORT_PACKAGE_TASK_NAME      | UnityPackage
+        taskName                                 | taskType
+        UnityPlugin.TEST_TASK_NAME               | Test
+        UnityPlugin.EXPORT_PACKAGE_TASK_NAME     | UnityPackage
+        UnityPlugin.ASSEMBLE_RESOURCES_TASK_NAME | DefaultTask
+        UnityPlugin.SETUP_TASK_NAME              | DefaultTask
     }
 
     @Unroll


### PR DESCRIPTION
This pull request brings in logic to define external dependencies for `iOS` and `Android`.
The plugin introduces a new phase at runtime. The lifecycle task `setup` will call `assembleResources`. This task will copy and unpack the dependencies provided in the `dependencies` block into the `Assets/Plugins` directory.

**example**
```
plugins {
    id "net.wooga.unity" version "0.10.0"
}

dependencies {
    android fileTree(dir: "libs", include: "*.jar")
    android project(':android:SubProject')
    
    ios fileTree(dir: "ios/classes")
    ios project(':android:SubProject') //which bundles an .framework.zip
}
```

See more information in the changed `README.md`