### PR TITLE
Add NUnit report normalizer

### DIFF
--- a/src/main/groovy/wooga/gradle/unity/tasks/Test.groovy
+++ b/src/main/groovy/wooga/gradle/unity/tasks/Test.groovy
@@ -199,15 +199,10 @@ class Test extends AbstractUnityTask implements Reporting<UnityTestTaskReport> {
 
     //https://issues.jenkins-ci.org/browse/JENKINS-44072
     protected void normalizeTestResult() {
-        DefaultArtifactVersion unityVersion = getUnityVersion(getUnityPath())
-        if ((unityVersion.majorVersion == 5 && unityVersion.minorVersion == 6)
-                || (unityVersion.majorVersion == 2017 && unityVersion.minorVersion == 1)) {
-
-            File report = this.getReports().getXml().getDestination()
-            if(report.exists()) {
-                def result = NUnitReportNormalizer.normalize(report)
-                logger.info("NUnitReportNormalizer result ${result}")
-            }
+        File report = this.getReports().getXml().getDestination()
+        if(report.exists()) {
+            def result = NUnitReportNormalizer.normalize(report)
+            logger.info("NUnitReportNormalizer result ${result}")
         }
     }
 

--- a/src/main/groovy/wooga/gradle/unity/tasks/Test.groovy
+++ b/src/main/groovy/wooga/gradle/unity/tasks/Test.groovy
@@ -35,6 +35,7 @@ import wooga.gradle.unity.batchMode.BatchModeFlags
 import wooga.gradle.unity.batchMode.TestPlatform
 import wooga.gradle.unity.testing.UnityTestTaskReport
 import wooga.gradle.unity.testing.UnityTestTaskReportsImpl
+import wooga.gradle.unity.utils.NUnitReportNormalizer
 
 import javax.inject.Inject
 
@@ -46,8 +47,21 @@ class Test extends AbstractUnityTask implements Reporting<UnityTestTaskReport> {
     private final List<Object> categories = new ArrayList()
     private final FileResolver fileResolver
     private TestPlatform testPlatform = TestPlatform.editmode
+    private DefaultArtifactVersion unityVersion
 
     private final UnityTestTaskReport reports
+
+    @Override
+    AbstractUnityTask unityPath(File path) {
+        unityVersion = null
+        return super.unityPath(path)
+    }
+
+    @Override
+    void setUnityPath(File path) {
+        unityVersion = null
+        super.setUnityPath(path)
+    }
 
     @Input
     @Optional
@@ -178,6 +192,23 @@ class Test extends AbstractUnityTask implements Reporting<UnityTestTaskReport> {
 
         args(buildTestArguments(unityVersion))
         super.exec()
+
+        //normalize test result file
+        normalizeTestResult()
+    }
+
+    //https://issues.jenkins-ci.org/browse/JENKINS-44072
+    protected void normalizeTestResult() {
+        DefaultArtifactVersion unityVersion = getUnityVersion(getUnityPath())
+        if ((unityVersion.majorVersion == 5 && unityVersion.minorVersion == 6)
+                || (unityVersion.majorVersion == 2017 && unityVersion.minorVersion == 1)) {
+
+            File report = this.getReports().getXml().getDestination()
+            if(report.exists()) {
+                def result = NUnitReportNormalizer.normalize(report)
+                logger.info("NUnitReportNormalizer result ${result}")
+            }
+        }
     }
 
     protected List<String> buildTestArguments(DefaultArtifactVersion unityVersion) {
@@ -239,6 +270,10 @@ class Test extends AbstractUnityTask implements Reporting<UnityTestTaskReport> {
     }
 
     DefaultArtifactVersion getUnityVersion(File path) {
+        if(unityVersion != null) {
+            return unityVersion
+        }
+
         String osName = System.getProperty("os.name").toLowerCase()
         def versionString = "5.5.0"
 
@@ -281,6 +316,7 @@ class Test extends AbstractUnityTask implements Reporting<UnityTestTaskReport> {
             }
         }
 
-        return new DefaultArtifactVersion(versionString.split(/f|p/).first())
+        unityVersion = new DefaultArtifactVersion(versionString.split(/f|p/).first())
+        unityVersion
     }
 }

--- a/src/main/groovy/wooga/gradle/unity/utils/NUnitReportNormalizer.groovy
+++ b/src/main/groovy/wooga/gradle/unity/utils/NUnitReportNormalizer.groovy
@@ -1,0 +1,87 @@
+package wooga.gradle.unity.utils
+
+import groovy.xml.StreamingMarkupBuilder
+import org.gradle.api.logging.Logger
+import org.gradle.api.logging.Logging
+import org.xml.sax.SAXParseException
+
+import javax.xml.XMLConstants
+import javax.xml.transform.stream.StreamSource
+import javax.xml.validation.SchemaFactory
+import java.nio.file.Files
+import java.nio.file.StandardCopyOption
+
+enum NUnitReportNormalizerResult {
+    SKIPPED, SUCCESS, FAILED
+}
+
+class NUnitReportNormalizer {
+
+    static Logger logger = Logging.getLogger(NUnitReportNormalizer)
+
+    private static final NUnit3Root = "test-run"
+
+    private static final NUnit2Schema = "nunit_25_report.xslt"
+    private static final NUnit3Schema = "nunit_30_report_partial.xslt"
+
+    private File reportFile
+
+    NUnitReportNormalizer(File reportFile) {
+        this.reportFile = reportFile
+    }
+
+    NUnitReportNormalizerResult normalize() {
+
+        if (validNUnit(reportFile, NUnit2Schema)
+                || validNUnit(reportFile, NUnit3Schema)) {
+            logger.debug("normalization skipped for file ${reportFile.path}")
+            return NUnitReportNormalizerResult.SKIPPED
+        }
+
+        Node reportRoot = new XmlParser().parse(reportFile)
+        reportRoot.toString()
+
+        if (reportRoot.name() != NUnit3Root) {
+            def normalized = new Node(null, NUnit3Root)
+            normalized.append(reportRoot)
+
+            def normalizedReport = File.createTempFile(reportFile.name, "", reportFile.parentFile)
+
+            normalizedReport.withWriter('UTF-8') { out ->
+                out << new StreamingMarkupBuilder().bind { mkp.xmlDeclaration(version: "1.0", encoding: "UTF-8") }
+                new XmlNodePrinter(new PrintWriter(out), "    ").print(normalized)
+            }
+
+            if (!validNUnit(normalizedReport, NUnit3Schema)) {
+                logger.debug("normalization failed for file ${reportFile.path}")
+                return NUnitReportNormalizerResult.FAILED
+            }
+
+            Files.move(normalizedReport.toPath(), reportFile.toPath(), StandardCopyOption.ATOMIC_MOVE, StandardCopyOption.REPLACE_EXISTING)
+        }
+
+        logger.debug("normalization success for file ${reportFile.path}")
+        return NUnitReportNormalizerResult.SUCCESS
+    }
+
+    private static Boolean validNUnit(File report, String schema) {
+        InputStream xslt = NUnitReportNormalizer.class.getResourceAsStream("/schema/$schema")
+        StreamSource s = new StreamSource(new FileReader(report))
+
+        try {
+            SchemaFactory.newInstance(XMLConstants.W3C_XML_SCHEMA_NS_URI)
+                    .newSchema(new StreamSource(xslt))
+                    .newValidator()
+                    .validate(s)
+        }
+        catch (SAXParseException parseException) {
+            logger.debug("parse exception in file ${report.path}: ${parseException.message}")
+            return false
+        }
+        return true
+    }
+
+    static NUnitReportNormalizerResult normalize(File report) {
+        new NUnitReportNormalizer(report).normalize()
+    }
+}

--- a/src/main/resources/schema/nunit_25_report.xslt
+++ b/src/main/resources/schema/nunit_25_report.xslt
@@ -1,0 +1,110 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" elementFormDefault="qualified">
+    <xs:complexType name="failureType">
+        <xs:sequence>
+            <xs:element ref="message" />
+            <xs:element ref="stack-trace" />
+        </xs:sequence>
+    </xs:complexType>
+    <xs:complexType name="reasonType">
+        <xs:sequence>
+            <xs:element ref="message" />
+        </xs:sequence>
+    </xs:complexType>
+    <xs:element name="message" type="xs:string" />
+    <xs:complexType name="resultsType">
+        <xs:choice>
+            <xs:element name="test-suite" type="test-suiteType" maxOccurs="unbounded" />
+            <xs:element name="test-case" type="test-caseType" maxOccurs="unbounded" minOccurs="0" />
+        </xs:choice>
+    </xs:complexType>
+    <xs:element name="stack-trace" type="xs:string" />
+    <xs:element name="test-results" type="resultType" />
+    <xs:complexType name="categoriesType">
+        <xs:sequence>
+            <xs:element name="category" type="categoryType" maxOccurs="unbounded" minOccurs="1" />
+        </xs:sequence>
+    </xs:complexType>
+    <xs:complexType name="categoryType">
+        <xs:attribute name="name" type="xs:string" use="required" />
+    </xs:complexType>
+    <xs:complexType name="propertiesType">
+        <xs:sequence>
+            <xs:element name="property" type="propertyType" maxOccurs="unbounded" minOccurs="1" />
+        </xs:sequence>
+    </xs:complexType>
+    <xs:complexType name="propertyType">
+        <xs:attribute name="name" type="xs:string" use="required" />
+        <xs:attribute name="value" type="xs:string" use="required" />
+    </xs:complexType>
+    <xs:complexType name="environmentType">
+        <xs:attribute name="nunit-version" type="xs:string" use="required" />
+        <xs:attribute name="clr-version" type="xs:string" use="required" />
+        <xs:attribute name="os-version" type="xs:string" use="required" />
+        <xs:attribute name="platform" type="xs:string" use="required" />
+        <xs:attribute name="cwd" type="xs:string" use="required" />
+        <xs:attribute name="machine-name" type="xs:string" use="required" />
+        <xs:attribute name="user" type="xs:string" use="required" />
+        <xs:attribute name="user-domain" type="xs:string" use="required" />
+        <xs:attribute name="unity-version" type="xs:string" use="optional" />
+        <xs:attribute name="unity-platform" type="xs:string" use="optional" />
+    </xs:complexType>
+    <xs:complexType name="culture-infoType">
+        <xs:attribute name="current-culture" type="xs:string" use="required" />
+        <xs:attribute name="current-uiculture" type="xs:string" use="required" />
+    </xs:complexType>
+    <xs:complexType name="resultType">
+        <xs:sequence>
+            <xs:element name="environment" type="environmentType" />
+            <xs:element name="culture-info" type="culture-infoType" />
+            <xs:element name="test-suite" type="test-suiteType" />
+        </xs:sequence>
+        <xs:attribute name="name" type="xs:string" use="required" />
+        <xs:attribute name="total" type="xs:decimal" use="required" />
+        <xs:attribute name="errors" type="xs:decimal" use="required" />
+        <xs:attribute name="failures" type="xs:decimal" use="required" />
+        <xs:attribute name="inconclusive" type="xs:decimal" use="required" />
+        <xs:attribute name="not-run" type="xs:decimal" use="required" />
+        <xs:attribute name="ignored" type="xs:decimal" use="required" />
+        <xs:attribute name="skipped" type="xs:decimal" use="required" />
+        <xs:attribute name="invalid" type="xs:decimal" use="required" />
+        <xs:attribute name="date" type="xs:string" use="required" />
+        <xs:attribute name="time" type="xs:string" use="required" />
+    </xs:complexType>
+    <xs:complexType name="test-caseType">
+        <xs:sequence>
+            <xs:element name="categories" type="categoriesType" minOccurs="0" maxOccurs="1" />
+            <xs:element name="properties" type="propertiesType" minOccurs="0" maxOccurs="1" />
+            <xs:choice>
+                <xs:element name="failure" type="failureType" minOccurs="0" />
+                <xs:element name="reason" type="reasonType" minOccurs="0" />
+            </xs:choice>
+        </xs:sequence>
+        <xs:attribute name="name" type="xs:string" use="required" />
+        <xs:attribute name="description" type="xs:string" use="optional" />
+        <xs:attribute name="success" type="xs:string" use="optional" />
+        <xs:attribute name="time" type="xs:string" use="optional" />
+        <xs:attribute name="executed" type="xs:string" use="required" />
+        <xs:attribute name="asserts" type="xs:string" use="optional" />
+        <xs:attribute name="result" type="xs:string" use="required" />
+    </xs:complexType>
+    <xs:complexType name="test-suiteType">
+        <xs:sequence>
+            <xs:element name="categories" type="categoriesType" minOccurs="0" maxOccurs="1" />
+            <xs:element name="properties" type="propertiesType" minOccurs="0" maxOccurs="1" />
+            <xs:choice>
+                <xs:element name="failure" type="failureType" minOccurs="0" />
+                <xs:element name="reason" type="reasonType" minOccurs="0" />
+            </xs:choice>
+            <xs:element name="results" type="resultsType" />
+        </xs:sequence>
+        <xs:attribute name="type" type="xs:string" use="required" />
+        <xs:attribute name="name" type="xs:string" use="required" />
+        <xs:attribute name="description" type="xs:string" use="optional" />
+        <xs:attribute name="success" type="xs:string" use="optional" />
+        <xs:attribute name="time" type="xs:string" use="optional" />
+        <xs:attribute name="executed" type="xs:string" use="required" />
+        <xs:attribute name="asserts" type="xs:string" use="optional" />
+        <xs:attribute name="result" type="xs:string" use="required" />
+    </xs:complexType>
+</xs:schema>

--- a/src/main/resources/schema/nunit_30_report_partial.xslt
+++ b/src/main/resources/schema/nunit_30_report_partial.xslt
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" elementFormDefault="qualified">
+    <xs:element name="test-run" type="testRunType"/>
+
+    <xs:complexType name="testRunType">
+        <xs:sequence>
+            <xs:element name="test-suite"/>
+            <xs:any minOccurs="0"/>
+        </xs:sequence>
+        <xs:anyAttribute/>
+    </xs:complexType>
+</xs:schema>

--- a/src/test/groovy/wooga/gradle/unity/utils/NUnitReportNormalizerSpec.groovy
+++ b/src/test/groovy/wooga/gradle/unity/utils/NUnitReportNormalizerSpec.groovy
@@ -1,0 +1,173 @@
+package wooga.gradle.unity.utils
+
+import groovy.xml.StreamingMarkupBuilder
+import spock.lang.Specification
+import spock.lang.Unroll
+
+class NUnitReportNormalizerSpec extends Specification {
+
+    static final String UNITY_REPORT_5_6 = """
+    <test-suite 
+        type="TestSuite" 
+        id="1000" 
+        name="Wooga.Test" 
+        fullname="Wooga.Test" 
+        runstate="Runnable" 
+        testcasecount="0" 
+        result="Passed" 
+        start-time="2017-08-25 13:57:41Z" 
+        end-time="2017-08-25 13:57:41Z" 
+        duration="0.005744" 
+        total="0" 
+        passed="1" 
+        failed="0" 
+        inconclusive="0" 
+        skipped="0" 
+        asserts="0">
+        <test-case 
+            id="1176" name="shouldAddCorrectly" 
+            fullname="Tests.Specs.Core.Data.shouldAddCorrectly" 
+            methodname="shouldAddCorrectly" 
+            classname="Adder" 
+            runstate="Runnable" 
+            seed="1536878189" 
+            result="Passed" 
+            start-time="2017-09-04 15:08:00Z" 
+            end-time="2017-09-04 15:08:00Z" 
+            duration="0.008622" 
+            asserts="2" />
+    </test-suite>
+    """.stripIndent().trim()
+
+    static final String NUNIT_3_REPORT = """
+    <test-run>
+        ${UNITY_REPORT_5_6}
+    </test-run>
+    """.stripIndent().trim()
+
+    static final String UNITY_REPORT_5_5 = """
+    <!--This file represents the results of running a test suite-->
+    <test-results
+        name="Unity Tests"
+        total="1"
+        errors="0"
+        failures="0"
+        not-run="0"
+        inconclusive="0"
+        ignored="0"
+        skipped="0"
+        invalid="0"
+        date="2017-09-04"
+        time="17:01:44">
+        <environment
+            nunit-version="2.6.4-Unity"
+            clr-version="2.0.50727.1433"
+            os-version="Unix 16.6.0.0"
+            platform="Unix"
+            cwd="/Wooga.Tests"
+            machine-name="Test.local"
+            user="test"
+            user-domain="Test.local"
+            unity-version="5.5.3f1"
+            unity-platform="OSXEditor"/>
+        <culture-info
+            current-culture="en-US" 
+            current-uiculture="en-US" />
+        <test-suite 
+            name="Wooga.Test" 
+            type="Assembly" 
+            executed="True" 
+            result="Success" 
+            success="True" 
+            time="19.446">
+            <results>
+                <test-case 
+                    name="LogTests.Tests" 
+                    executed="True" 
+                    result="Success" 
+                    success="True" 
+                    time="0.012">
+                </test-case>
+            </results>
+        </test-suite>
+    </test-results>
+    """.stripIndent().trim()
+
+    File report
+
+    Boolean checkRootNode(File file, String name) {
+        def node = new XmlParser().parse(file)
+        node.name() == name
+    }
+
+    void containsXMLDeclaration(File file) {
+        assert file.readLines()[0] =~ /<\?xml version=("|')1.0("|') encoding=("|')UTF-8("|')\?>/
+    }
+
+    def setup() {
+        report = File.createTempFile("testReport", ".xml")
+        report.deleteOnExit()
+        report << '<?xml version="1.0" encoding="UTF-8"?>'
+    }
+
+    def cleanup() {
+        report.delete()
+    }
+
+    def "normalize broken test report from unity"() {
+        given: "Test report produced by Unity 5.6 || 2017.1"
+        report << UNITY_REPORT_5_6
+        assert !checkRootNode(report, "test-run")
+
+        when:
+        def result = NUnitReportNormalizer.normalize(report)
+
+        then:
+        result == NUnitReportNormalizerResult.SUCCESS
+        checkRootNode(report, "test-run")
+        containsXMLDeclaration(report)
+    }
+
+    @Unroll
+    def "Skips valid #reportType reports"() {
+        given: "Test report produced by Unity 5.5"
+        report << reportContent
+        assert checkRootNode(report, expectedRootNode)
+
+        when:
+        def result = NUnitReportNormalizer.normalize(report)
+
+        then:
+        result == NUnitReportNormalizerResult.SKIPPED
+        checkRootNode(report, expectedRootNode)
+        containsXMLDeclaration(report)
+
+        where:
+        reportType  | reportContent    | expectedRootNode
+        "NUnit 2.x" | UNITY_REPORT_5_5 | "test-results"
+        "NUnit 3.x" | NUNIT_3_REPORT   | "test-run"
+    }
+
+    def "fails for other xml formats"() {
+        given: "A bogus XML"
+        report << """
+        <someRoot>
+            <someItem/>
+            <someItem/>
+            <someItem/>
+        </someRoot>
+        """.stripIndent().trim()
+
+        and: "the content as text"
+        def content = report.text
+
+        when:
+
+        def result = NUnitReportNormalizer.normalize(report)
+
+        then:
+        result == NUnitReportNormalizerResult.FAILED
+        report.text == content
+        containsXMLDeclaration(report)
+    }
+}


### PR DESCRIPTION
Versions of Unity >= 5.6 use NUnit 3. The generated reports from unity are missing the root node `test-run`. The normalizer will __try__ to do this after the tests have run.