### PR TITLE
Fix ProjectSettings parser

### DIFF
--- a/src/main/groovy/wooga/gradle/unity/utils/ProjectSettings.groovy
+++ b/src/main/groovy/wooga/gradle/unity/utils/ProjectSettings.groovy
@@ -32,10 +32,27 @@ class ProjectSettings {
     ProjectSettings(String templateContent) {
 
         Yaml parser = new Yaml()
-        content = parser.load(templateContent)
+        content = parser.load(stripUnityInstructions(templateContent))
     }
 
     boolean getPlayModeTestRunnerEnabled() {
         content['PlayerSettings'] && content['PlayerSettings']['playModeTestRunnerEnabled'] && content['PlayerSettings']['playModeTestRunnerEnabled'] == 1
+    }
+
+    static String stripUnityInstructions(String content) {
+        def lines = content.readLines()
+        lines.collect {
+            if(it.matches(/%TAG !u! tag:unity3d.com,.*:/)) {
+                return ""
+            }
+
+            def m = it =~ /(--- )!u!\d+( &\d+)/
+            if(m) {
+                return "${m[0][1]}${m[0][2]}"
+            }
+
+            return it
+        }
+        .join("\n")
     }
 }


### PR DESCRIPTION
## Description

Unity has a slightly custom YAML format for all internal models. The
yaml parser can't read this out of the box. This pull request adresses
this issue by pre processing the file like described at
https://stackoverflow.com/a/27117480/1380824

## Changes

![FIX] `ProjectSettings` parser

[NEW]:https://atlas-resources.wooga.com/icons/icon_new.svg "New"
[ADD]:http://resources.atlas.wooga.com/icons/icon_add.svg "Add"
[IMPROVE]:http://resources.atlas.wooga.com/icons/icon_improve.svg "IMPROVE"
[CHANGE]:http://resources.atlas.wooga.com/icons/icon_change.svg "Change"
[FIX]:http://resources.atlas.wooga.com/icons/icon_fix.svg "Fix"
[UPDATE]:http://resources.atlas.wooga.com/icons/icon_update.svg "Update"

[BREAK]:http://resources.atlas.wooga.com/icons/icon_break.svg "Remove"
[REMOVE]:http://resources.atlas.wooga.com/icons/icon_remove.svg "Remove"
[IOS]:http://resources.atlas.wooga.com/icons/icon_iOS.svg "iOS"
[ANDROID]:http://resources.atlas.wooga.com/icons/icon_android.svg "Android"
[WEBGL]:http://resources.atlas.wooga.com/icons/icon_webGL.svg "Web:GL"
