### PR TITLE
Add default build target

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,7 @@
 .gradle
 build/
+.idea/
+out/
 
 # Ignore Gradle GUI config
 gradle-app.setting

--- a/src/integrationTest/groovy/wooga/gradle/unity/PluginConfigurationSpec.groovy
+++ b/src/integrationTest/groovy/wooga/gradle/unity/PluginConfigurationSpec.groovy
@@ -60,4 +60,32 @@ class PluginConfigurationSpec extends UnityIntegrationSpec {
 
         status = shouldRun ? "executed" : "not executed"
     }
+
+    def "sets defaultBuildTarget for all tasks"() {
+        given: "a build script"
+        buildFile << """
+            
+            task (createProject, type: wooga.gradle.unity.tasks.Unity) {
+                args "-createProject", "Test"
+            }
+            
+            unity {
+                defaultBuildTarget = "android"
+            }
+            
+            task (customTest, type: wooga.gradle.unity.tasks.Test) {
+                doLast{
+                    print customTest.buildTarget
+                }
+            }
+            
+        """.stripIndent()
+
+        when:
+        def result = runTasks("customTest")
+
+        then:
+        result.standardOutput.contains("android")
+
+    }
 }

--- a/src/integrationTest/groovy/wooga/gradle/unity/PluginConfigurationSpec.groovy
+++ b/src/integrationTest/groovy/wooga/gradle/unity/PluginConfigurationSpec.groovy
@@ -31,15 +31,15 @@ class PluginConfigurationSpec extends UnityIntegrationSpec {
             task (createProject, type: wooga.gradle.unity.tasks.Unity) {
                 args "-createProject", "Test"
             }
-            
+
             task (customTest, type: wooga.gradle.unity.tasks.Test) {
             }
-            
+
             task (customExport, type: wooga.gradle.unity.tasks.UnityPackage) {
             }
-            
+
             task (emptyTask)
-            
+
         """.stripIndent()
 
         when:
@@ -61,31 +61,34 @@ class PluginConfigurationSpec extends UnityIntegrationSpec {
         status = shouldRun ? "executed" : "not executed"
     }
 
+    @Unroll("sets buildTarget with #taskConfig #useOverride")
     def "sets defaultBuildTarget for all tasks"() {
         given: "a build script"
         buildFile << """
-            
-            task (createProject, type: wooga.gradle.unity.tasks.Unity) {
-                args "-createProject", "Test"
-            }
-            
             unity {
                 defaultBuildTarget = "android"
             }
-            
+
             task (customTest, type: wooga.gradle.unity.tasks.Test) {
+                $taskConfig
                 doLast{
                     print customTest.buildTarget
                 }
             }
-            
+
         """.stripIndent()
 
         when:
         def result = runTasks("customTest")
 
         then:
-        result.standardOutput.contains("android")
+        result.standardOutput.contains(expected)
 
-    }
+        where:
+        taskConfig            | expected
+        'buildTarget = "ios"' | "ios"
+        ''                    | "android"
+
+        useOverride = taskConfig != '' ? "use override" : "fallback to default"
+      }
 }

--- a/src/main/groovy/wooga/gradle/unity/UnityPlugin.groovy
+++ b/src/main/groovy/wooga/gradle/unity/UnityPlugin.groovy
@@ -35,6 +35,7 @@ import org.gradle.api.specs.Spec
 import org.gradle.api.tasks.Delete
 import org.gradle.internal.reflect.Instantiator
 import org.gradle.language.base.plugins.LifecycleBasePlugin
+import wooga.gradle.unity.batchMode.BuildTarget
 import wooga.gradle.unity.batchMode.TestPlatform
 import wooga.gradle.unity.tasks.*
 
@@ -120,6 +121,7 @@ class UnityPlugin implements Plugin<Project> {
         addDefaultReportTasks(extension)
         configureArchiveDefaults(convention)
         configureUnityTaskDependencies()
+        configureUnityDefaultBuildTarget(extension)
         configureCleanObjects()
         project.afterEvaluate(new Action<Project>() {
             @Override
@@ -364,6 +366,20 @@ class UnityPlugin implements Plugin<Project> {
             @Override
             void execute(AbstractUnityTask task) {
                 task.dependsOn project.tasks[SETUP_TASK_NAME]
+            }
+        })
+    }
+
+    private void configureUnityDefaultBuildTarget(final UnityPluginExtension extension) {
+        project.tasks.withType(AbstractUnityTask, new Action<AbstractUnityTask>() {
+            @Override
+            void execute(AbstractUnityTask task) {
+                ConventionMapping mapping = ((IConventionAware) task).conventionMapping
+                mapping.map("buildTarget", new Callable<BuildTarget>() {
+                    BuildTarget call() {
+                        extension.defaultBuildTarget
+                    }
+                })
             }
         })
     }

--- a/src/main/groovy/wooga/gradle/unity/UnityPluginExtension.groovy
+++ b/src/main/groovy/wooga/gradle/unity/UnityPluginExtension.groovy
@@ -26,6 +26,7 @@ import wooga.gradle.unity.batchMode.ActivationSpec
 import wooga.gradle.unity.batchMode.BaseBatchModeSpec
 import wooga.gradle.unity.batchMode.BatchModeAction
 import wooga.gradle.unity.batchMode.BatchModeSpec
+import wooga.gradle.unity.batchMode.BuildTarget
 
 import static org.gradle.util.ConfigureUtil.configureUsing
 
@@ -104,4 +105,13 @@ interface UnityPluginExtension {
     void setAndroidResourceCopyMethod(AndroidResourceCopyMethod value)
 
     UnityPluginExtension androidResourceCopyMethod(AndroidResourceCopyMethod value)
+
+    BuildTarget getDefaultBuildTarget()
+
+    void setDefaultBuildTarget(BuildTarget value)
+
+    void setDefaultBuildTarget(Object value)
+
+    UnityPluginExtension defaultBuildTarget(BuildTarget value)
+
 }

--- a/src/test/groovy/wooga/gradle/unity/DefaultUnityPluginExtensionSpec.groovy
+++ b/src/test/groovy/wooga/gradle/unity/DefaultUnityPluginExtensionSpec.groovy
@@ -20,12 +20,13 @@ package wooga.gradle.unity
 import org.gradle.api.Project
 import org.gradle.api.internal.file.FileResolver
 import org.gradle.internal.reflect.Instantiator
-import spock.lang.IgnoreIf
 import spock.lang.Specification
+import spock.lang.Unroll
+import wooga.gradle.unity.batchMode.BuildTarget
 
 class DefaultUnityPluginExtensionSpec extends Specification {
 
-    def subject
+    UnityPluginExtension subject
 
     def setup() {
         def projectMock = Mock(Project)
@@ -79,5 +80,23 @@ class DefaultUnityPluginExtensionSpec extends Specification {
 
         then: "file path points to props path"
         f == null
+    }
+
+    @Unroll("use defaultBuildTarget with #source|#result")
+    def "set defaultBuildTarget "() {
+        given: "calling set defaultBuildTarget"
+        subject.defaultBuildTarget = source
+
+        when: "calling get defaultBuildTarget"
+        def defaultBuildTarget = subject.defaultBuildTarget
+
+        then: "file path points to props path"
+        defaultBuildTarget == result
+
+        where:
+        source                          | result
+        BuildTarget.webgl               | BuildTarget.webgl
+        "ios"                           | BuildTarget.ios
+        { it -> BuildTarget.android }   | BuildTarget.android
     }
 }

--- a/src/test/groovy/wooga/gradle/unity/UnityPluginSpec.groovy
+++ b/src/test/groovy/wooga/gradle/unity/UnityPluginSpec.groovy
@@ -22,6 +22,7 @@ import nebula.test.ProjectSpec
 import org.gradle.api.DefaultTask
 import org.gradle.language.base.plugins.LifecycleBasePlugin
 import spock.lang.Unroll
+import wooga.gradle.unity.batchMode.BuildTarget
 import wooga.gradle.unity.batchMode.TestPlatform
 import wooga.gradle.unity.tasks.Test
 import wooga.gradle.unity.tasks.UnityPackage
@@ -88,9 +89,9 @@ class UnityPluginSpec extends ProjectSpec {
         checkTask.dependsOn.contains(testTask)
 
         where:
-        taskName                                 | testPlatform
-        UnityPlugin.TEST_EDITOMODE_TASK_NAME     | TestPlatform.editmode
-        UnityPlugin.TEST_PLAYMODE_TASK_NAME      | TestPlatform.playmode
+        taskName                             | testPlatform
+        UnityPlugin.TEST_EDITOMODE_TASK_NAME | TestPlatform.editmode
+        UnityPlugin.TEST_PLAYMODE_TASK_NAME  | TestPlatform.playmode
     }
 
     @Unroll
@@ -107,5 +108,29 @@ class UnityPluginSpec extends ProjectSpec {
 
         where:
         pluginToAdd << ['base', 'reporting-base']
+    }
+
+    def 'defaultBuildTarget not set'() {
+        given:
+        project.plugins.apply(PLUGIN_NAME)
+
+        when:
+        def extension = project.extensions.findByName(UnityPlugin.EXTENSION_NAME) as DefaultUnityPluginExtension
+
+        then:
+        extension.defaultBuildTarget == BuildTarget.undefined
+    }
+
+    @Unroll
+    def 'applies defaultBuildTarget from buildFile'() {
+        given:
+        project.plugins.apply(PLUGIN_NAME)
+
+        when:
+        def extension = project.extensions.findByName(UnityPlugin.EXTENSION_NAME) as DefaultUnityPluginExtension
+        extension.defaultBuildTarget = BuildTarget.ios
+
+        then:
+        extension.defaultBuildTarget == BuildTarget.ios
     }
 }


### PR DESCRIPTION
## Description
A defined `defaultBuildTarget` will be applied to all Tasks of type `AbstractUnityTask` as `buildTarget` property

Example:

```
unity {
    defaultBuildTarget = "android"
}
```