### PR TITLE
Generate multiple tests by build targets

### DIFF
--- a/src/integrationTest/groovy/wooga/gradle/unity/PluginConfigurationSpec.groovy
+++ b/src/integrationTest/groovy/wooga/gradle/unity/PluginConfigurationSpec.groovy
@@ -30,7 +30,7 @@ class PluginConfigurationSpec extends UnityIntegrationSpec {
         buildFile << """
             task (createProject, type: wooga.gradle.unity.tasks.Unity) {
                 args "-createProject", "Test"
-            }
+0           }
 
             task (customTest, type: wooga.gradle.unity.tasks.Test) {
             }
@@ -51,7 +51,6 @@ class PluginConfigurationSpec extends UnityIntegrationSpec {
 
         where:
         taskName                             | shouldRun
-        UnityPlugin.TEST_TASK_NAME           | true
         UnityPlugin.EXPORT_PACKAGE_TASK_NAME | true
         "createProject"                      | true
         "customTest"                         | true

--- a/src/integrationTest/groovy/wooga/gradle/unity/PluginConfigurationSpec.groovy
+++ b/src/integrationTest/groovy/wooga/gradle/unity/PluginConfigurationSpec.groovy
@@ -30,7 +30,7 @@ class PluginConfigurationSpec extends UnityIntegrationSpec {
         buildFile << """
             task (createProject, type: wooga.gradle.unity.tasks.Unity) {
                 args "-createProject", "Test"
-0           }
+            }
 
             task (customTest, type: wooga.gradle.unity.tasks.Test) {
             }

--- a/src/integrationTest/groovy/wooga/gradle/unity/TestTaskExecutionSpec.groovy
+++ b/src/integrationTest/groovy/wooga/gradle/unity/TestTaskExecutionSpec.groovy
@@ -1,0 +1,28 @@
+package wooga.gradle.unity
+
+import spock.lang.Unroll
+
+class TestTaskExecutionSpec extends UnityIntegrationSpec {
+
+    @Unroll
+    def "Test tasks dependencies for :#task"() {
+
+        given: "a build file with testBuildTargets"
+        buildFile << """    
+        unity.testBuildTargets = $testBuildTargets
+        """.stripIndent()
+
+        when:
+        def result = runTasksSuccessfully(task)
+
+        then:
+        includedTasks.every { result.wasExecuted(it) }
+        excludedTasks.every { !result.wasExecuted(it) }
+
+        where:
+        task              | testBuildTargets     | includedTasks                                                               | excludedTasks
+        "test"            | '["ios", "android"]' | ["setup", "test", "testPlayMode", "testPlayModeAndroid", "testPlayModeIos"] | ["check"]
+        "testPlayMode"    | '["android"]'        | ["setup", "testPlayMode", "testPlayModeAndroid"]                            | ["test", "testPlayModeIos"]
+        "testPlayModeIos" | '["ios"]'            | ["setup", "testPlayModeIos"]                                                | ["test", "testPlayMode"]
+    }
+}

--- a/src/integrationTest/groovy/wooga/gradle/unity/TestTaskExecutionSpec.groovy
+++ b/src/integrationTest/groovy/wooga/gradle/unity/TestTaskExecutionSpec.groovy
@@ -25,4 +25,45 @@ class TestTaskExecutionSpec extends UnityIntegrationSpec {
         "testPlayMode"    | '["android"]'        | ["setup", "testPlayMode", "testPlayModeAndroid"]                            | ["test", "testPlayModeIos"]
         "testPlayModeIos" | '["ios"]'            | ["setup", "testPlayModeIos"]                                                | ["test", "testPlayMode"]
     }
+
+    @Unroll
+    def "verify testBuildTargets fallback order with #message"() {
+        given: "a build file"
+        buildFile << """
+        $buildFileTestBuildTargets
+        $defaultBuildTarget
+        """.stripIndent()
+
+        and: "a properties file"
+        createFile("gradle.properties") << """
+        $propertyFileTestBuildTargets
+        """.stripIndent()
+
+        when:
+        def result = runTasksSuccessfully("check", commandlineTestBuildTargets)
+
+        then:
+        taskShouldRun.each { String task ->
+            assert result.wasExecuted(task)
+        }
+
+        where:
+        message                                    | buildFileTestBuildTargets                    | propertyFileTestBuildTargets         | commandlineTestBuildTargets         | defaultBuildTarget               | expectedTasksToRun
+        "nothing"                                  | ""                                           | ""                                   | "-Pnothing=true"                    | ""                               | []
+        "build.gradle"                             | "unity.testBuildTargets = ['ios']"           | ""                                   | "-Pnothing=true"                    | ""                               | ["testPlayModeIos", "testEditModeIos"]
+        "multiple build.gradle"                    | "unity.testBuildTargets = ['ios','android']" | ""                                   | "-Pnothing=true"                    | ""                               | ["testPlayModeIos", "testEditModeIos", "testPlayModeAndroid", "testEditModeAndroid"]
+        "gradle.properties"                        | ""                                           | "unity.testBuildTargets=webgl"       | "-Pnothing=true"                    | ""                               | ["testPlayModeWebgl", "testEditModeWebgl"]
+        "multiple gradle.properties"               | ""                                           | "unity.testBuildTargets=webgl,linux" | "-Pnothing=true"                    | ""                               | ["testPlayModeWebgl", "testEditModeWebgl", "testPlayModeLinux", "testEditModeLinux"]
+        "commandline"                              | ""                                           | ""                                   | "-Punity.testBuildTargets=ps4"      | ""                               | ["testPlayModePs4", "testEditModePs4"]
+        "multiple commandline"                     | ""                                           | ""                                   | "-Punity.testBuildTargets=ps4,psp2" | ""                               | ["testPlayModePs4", "testEditModePs4", "testPlayModePsp2", "testEditModePsp2"]
+        "defaultBuildTarget"                       | ""                                           | ""                                   | "-Pnothing=true"                    | "unity.defaultBuildTarget='web'" | ["testPlayModeWeb", "testEditModeWeb"]
+        "build.gradle and gradle.properties"       | "unity.testBuildTargets = ['ios']"           | "unity.testBuildTargets=webgl"       | "-Pnothing=true"                    | ""                               | ["testPlayModeIos", "testEditModeIos"]
+        "build.gradle and commandline"             | "unity.testBuildTargets = ['ios']"           | ""                                   | "-Punity.testBuildTargets=ps4,psp2" | ""                               | ["testPlayModeIos", "testEditModeIos"]
+        "build.gradle and defaultBuildTarget"      | "unity.testBuildTargets = ['ios']"           | ""                                   | "-Pnothing=true"                    | "unity.defaultBuildTarget='web'" | ["testPlayModeIos", "testEditModeIos"]
+        "commandline and defaultBuildTarget"       | ""                                           | ""                                   | "-Punity.testBuildTargets=ps4,psp2" | "unity.defaultBuildTarget='web'" | ["testPlayModePs4", "testEditModePs4", "testPlayModePsp2", "testEditModePsp2"]
+        "commandline and gradle.properties "       | ""                                           | "unity.testBuildTargets=webgl,linux" | "-Punity.testBuildTargets=ps4,psp2" | ""                               | ["testPlayModePs4", "testEditModePs4", "testPlayModePsp2", "testEditModePsp2"]
+        "gradle.properties and defaultBuildTarget" | ""                                           | "unity.testBuildTargets=webgl,linux" | "-Pnothing=true"                    | "unity.defaultBuildTarget='web'" | ["testPlayModeWebgl", "testEditModeWebgl", "testPlayModeLinux", "testEditModeLinux"]
+
+        taskShouldRun = expectedTasksToRun << "test" << "testPlayMode" << "testEditMode"
+    }
 }

--- a/src/integrationTest/groovy/wooga/gradle/unity/UnityActivationIntegrationSpec.groovy
+++ b/src/integrationTest/groovy/wooga/gradle/unity/UnityActivationIntegrationSpec.groovy
@@ -25,6 +25,17 @@ import wooga.gradle.unity.batchMode.BatchModeFlags
  */
 class UnityActivationIntegrationSpec extends UnityIntegrationSpec {
 
+
+    def setup() {
+        buildFile << """
+        unity{
+             testBuildTargets = ["android"]
+        }
+        
+        """.stripIndent()
+    }
+
+
     def "skips activation when authentication is empty"() {
         given: "a build script with fake test unity location"
         buildFile << """

--- a/src/main/groovy/wooga/gradle/unity/DefaultUnityPluginExtension.groovy
+++ b/src/main/groovy/wooga/gradle/unity/DefaultUnityPluginExtension.groovy
@@ -358,10 +358,19 @@ class DefaultUnityPluginExtension implements UnityPluginExtension {
 
     @Override
     Set<BuildTarget> getTestBuildTargets() {
+      if(testBuildTargets.empty && getDefaultBuildTarget() == BuildTarget.undefined) {
+        return EnumSet.noneOf(BuildTarget)
+      }
+
       List<BuildTarget> targets = new ArrayList<BuildTarget>()
       for (Object t : testBuildTargets) {
           targets.add(t.toString() as BuildTarget)
       }
+
+      if(getDefaultBuildTarget() != BuildTarget.undefined) {
+        targets.add(getDefaultBuildTarget())
+      }
+
       return EnumSet.copyOf(targets)
     }
 }

--- a/src/main/groovy/wooga/gradle/unity/DefaultUnityPluginExtension.groovy
+++ b/src/main/groovy/wooga/gradle/unity/DefaultUnityPluginExtension.groovy
@@ -336,41 +336,43 @@ class DefaultUnityPluginExtension implements UnityPluginExtension {
 
     @Override
     UnityPluginTestExtension testBuildTargets(Object... targets) {
-      if (targets == null) {
-          throw new IllegalArgumentException("targets == null!")
-      }
-      testBuildTargets.addAll(Arrays.asList(targets))
-      return this
+        if (targets == null) {
+            throw new IllegalArgumentException("targets == null!")
+        }
+        testBuildTargets.addAll(Arrays.asList(targets))
+        return this
     }
 
     @Override
     UnityPluginTestExtension testBuildTargets(Iterable<?> targets) {
-      GUtil.addToCollection(testBuildTargets, targets)
-      return this
+        GUtil.addToCollection(testBuildTargets, targets)
+        return this
     }
 
     @Override
     UnityPluginTestExtension setTestBuildTargets(Iterable<?> targets) {
-      testBuildTargets.clear()
-      testBuildTargets.addAll(targets)
-      return this
+        testBuildTargets.clear()
+        testBuildTargets.addAll(targets)
+        return this
     }
 
     @Override
     Set<BuildTarget> getTestBuildTargets() {
-      if(testBuildTargets.empty && getDefaultBuildTarget() == BuildTarget.undefined) {
-        return EnumSet.noneOf(BuildTarget)
-      }
+        if (testBuildTargets.empty && getDefaultBuildTarget() == BuildTarget.undefined) {
+            return EnumSet.noneOf(BuildTarget)
+        }
 
-      List<BuildTarget> targets = new ArrayList<BuildTarget>()
-      for (Object t : testBuildTargets) {
-          targets.add(t.toString() as BuildTarget)
-      }
+        List<BuildTarget> targets = new ArrayList<BuildTarget>()
+        for (Object t : testBuildTargets) {
+            if (t != BuildTarget.undefined) {
+                targets.add(t.toString() as BuildTarget)
+            }
+        }
 
-      if(getDefaultBuildTarget() != BuildTarget.undefined) {
-        targets.add(getDefaultBuildTarget())
-      }
+        if (getDefaultBuildTarget() != BuildTarget.undefined) {
+            targets.add(getDefaultBuildTarget())
+        }
 
-      return EnumSet.copyOf(targets)
+        return EnumSet.copyOf(targets)
     }
 }

--- a/src/main/groovy/wooga/gradle/unity/DefaultUnityPluginExtension.groovy
+++ b/src/main/groovy/wooga/gradle/unity/DefaultUnityPluginExtension.groovy
@@ -23,6 +23,7 @@ import org.gradle.api.internal.file.FileResolver
 import org.gradle.internal.Factory
 import org.gradle.internal.reflect.Instantiator
 import org.gradle.process.ExecResult
+import org.gradle.util.GUtil
 import wooga.gradle.unity.batchMode.*
 
 import java.util.concurrent.Callable
@@ -79,6 +80,7 @@ class DefaultUnityPluginExtension implements UnityPluginExtension {
     private Factory<File> pluginsDir
     private Factory<File> customUnityPath
     private Object defaultBuildTarget
+    private final List<Object> testBuildTargets = new ArrayList<Object>()
 
     File getUnityPathFromEnv(Map<String, ?> properties, Map<String, String> env) {
         String unityPath = properties[UNITY_PATH_OPTION] ?: env[UNITY_PATH_ENV_VAR]
@@ -330,5 +332,36 @@ class DefaultUnityPluginExtension implements UnityPluginExtension {
         ActivationAction activationAction = activationActionFactory.create()
         action.execute(activationAction)
         return activationAction.returnLicense()
+    }
+
+    @Override
+    UnityPluginTestExtension testBuildTargets(Object... targets) {
+      if (targets == null) {
+          throw new IllegalArgumentException("targets == null!")
+      }
+      testBuildTargets.addAll(Arrays.asList(targets))
+      return this
+    }
+
+    @Override
+    UnityPluginTestExtension testBuildTargets(Iterable<?> targets) {
+      GUtil.addToCollection(testBuildTargets, targets)
+      return this
+    }
+
+    @Override
+    UnityPluginTestExtension setTestBuildTargets(Iterable<?> targets) {
+      testBuildTargets.clear()
+      testBuildTargets.addAll(targets)
+      return this
+    }
+
+    @Override
+    Set<BuildTarget> getTestBuildTargets() {
+      List<BuildTarget> targets = new ArrayList<BuildTarget>()
+      for (Object t : testBuildTargets) {
+          targets.add(t.toString() as BuildTarget)
+      }
+      return EnumSet.copyOf(targets)
     }
 }

--- a/src/main/groovy/wooga/gradle/unity/DefaultUnityPluginExtension.groovy
+++ b/src/main/groovy/wooga/gradle/unity/DefaultUnityPluginExtension.groovy
@@ -358,12 +358,18 @@ class DefaultUnityPluginExtension implements UnityPluginExtension {
 
     @Override
     Set<BuildTarget> getTestBuildTargets() {
-        if (testBuildTargets.empty && getDefaultBuildTarget() == BuildTarget.undefined) {
+        if (testBuildTargets.empty && project.properties.containsKey("unity.testBuildTargets")) {
+            return EnumSet.copyOf(project.properties.get("unity.testBuildTargets").toString().split(",").collect({
+                it as BuildTarget
+            }))
+        } else if (testBuildTargets.empty && getDefaultBuildTarget() == BuildTarget.undefined) {
             return EnumSet.noneOf(BuildTarget)
         }
 
         List<BuildTarget> targets = new ArrayList<BuildTarget>()
-        for (Object t : testBuildTargets) {
+        for (
+                Object t
+                        : testBuildTargets) {
             if (t != BuildTarget.undefined) {
                 targets.add(t.toString() as BuildTarget)
             }
@@ -375,4 +381,5 @@ class DefaultUnityPluginExtension implements UnityPluginExtension {
 
         return EnumSet.copyOf(targets)
     }
+
 }

--- a/src/main/groovy/wooga/gradle/unity/UnityPlugin.groovy
+++ b/src/main/groovy/wooga/gradle/unity/UnityPlugin.groovy
@@ -109,7 +109,7 @@ class UnityPlugin implements Plugin<Project> {
         BasePluginConvention convention = new BasePluginConvention(project)
 
         addLifecycleTasks()
-        createTestTasks(extension)
+        addTestTasks(extension)
         addPackageTask()
         addActivateAndReturnLicenseTasks(extension)
 
@@ -166,10 +166,10 @@ class UnityPlugin implements Plugin<Project> {
     }
 
     private void addLifecycleTasks() {
-        def assembleTask = project.tasks.create(name: ASSEMBLE_RESOURCES_TASK_NAME, group: GROUP)
-        assembleTask.description = "gathers all iOS and Android resources into Plugins/ directory of the unity project"
-        project.tasks.create(name: SETUP_TASK_NAME, group: GROUP, dependsOn: assembleTask)
-        project.tasks[BasePlugin.ASSEMBLE_TASK_NAME].dependsOn assembleTask
+        def assembleResourcesTask = project.tasks.create(name: ASSEMBLE_RESOURCES_TASK_NAME, group: GROUP)
+        assembleResourcesTask.description = "gathers all iOS and Android resources into Plugins/ directory of the unity project"
+        project.tasks.create(name: SETUP_TASK_NAME, group: GROUP, dependsOn: assembleResourcesTask)
+        project.tasks[BasePlugin.ASSEMBLE_TASK_NAME].dependsOn assembleResourcesTask
     }
 
     private void addResourceCopyTasks() {
@@ -268,7 +268,7 @@ class UnityPlugin implements Plugin<Project> {
         project.tasks[BasePlugin.ASSEMBLE_TASK_NAME].dependsOn task
     }
 
-    private void createTestTasks(final UnityPluginExtension extension) {
+    private void addTestTasks(final UnityPluginExtension extension) {
         def testTask = project.tasks.create(name: TEST_TASK_NAME, group: GROUP)
         def testEditModeTask = project.tasks.create(name: TEST_EDITOMODE_TASK_NAME, group: GROUP)
         def testPlayModeTask = project.tasks.create(name: TEST_PLAYMODE_TASK_NAME, group: GROUP)

--- a/src/main/groovy/wooga/gradle/unity/UnityPlugin.groovy
+++ b/src/main/groovy/wooga/gradle/unity/UnityPlugin.groovy
@@ -269,28 +269,27 @@ class UnityPlugin implements Plugin<Project> {
     }
 
     private void createTestTasks(final UnityPluginExtension extension) {
-      def testTask = project.tasks.create(name: TEST_TASK_NAME, group: GROUP)
-      def testEditModeTask = project.tasks.create(name: TEST_EDITOMODE_TASK_NAME, group: GROUP)
-      def testplayModeTask = project.tasks.create(name: TEST_PLAYMODE_TASK_NAME, group: GROUP)
-      testTask.dependsOn testEditModeTask, testplayModeTask
+        def testTask = project.tasks.create(name: TEST_TASK_NAME, group: GROUP)
+        def testEditModeTask = project.tasks.create(name: TEST_EDITOMODE_TASK_NAME, group: GROUP)
+        def testPlayModeTask = project.tasks.create(name: TEST_PLAYMODE_TASK_NAME, group: GROUP)
+        testTask.dependsOn testEditModeTask, testPlayModeTask
 
-      project.afterEvaluate {
-        extension.testBuildTargets.each { target ->
-          def suffix = target.toString().capitalize()
-
-          testEditModeTask.dependsOn createTestTask(TEST_EDITOMODE_TASK_NAME + suffix, TestPlatform.editmode, target)
-          testplayModeTask.dependsOn   createTestTask(TEST_PLAYMODE_TASK_NAME + suffix, TestPlatform.playmode, target)
+        project.afterEvaluate {
+            extension.testBuildTargets.each { target ->
+                def suffix = target.toString().capitalize()
+                testEditModeTask.dependsOn createTestTask(TEST_EDITOMODE_TASK_NAME + suffix, TestPlatform.editmode, target)
+                testPlayModeTask.dependsOn createTestTask(TEST_PLAYMODE_TASK_NAME + suffix, TestPlatform.playmode, target)
+            }
         }
-      }
 
-      project.tasks[LifecycleBasePlugin.CHECK_TASK_NAME].dependsOn testTask
+        project.tasks[LifecycleBasePlugin.CHECK_TASK_NAME].dependsOn testTask
     }
 
-    private Test createTestTask(String name, TestPlatform testPlatform, BuildTarget testBuildTarget){
-      def task = project.tasks.create(name: name, type: Test, group: GROUP) as Test
-      task.testPlatform = testPlatform
-      task.buildTarget = testBuildTarget
-      task
+    private Test createTestTask(String name, TestPlatform testPlatform, BuildTarget testBuildTarget) {
+        def task = project.tasks.create(name: name, type: Test, group: GROUP) as Test
+        task.testPlatform = testPlatform
+        task.buildTarget = testBuildTarget
+        task
     }
 
     private void addDefaultReportTasks(final UnityPluginExtension extension) {

--- a/src/main/groovy/wooga/gradle/unity/UnityPlugin.groovy
+++ b/src/main/groovy/wooga/gradle/unity/UnityPlugin.groovy
@@ -74,7 +74,7 @@ class UnityPlugin implements Plugin<Project> {
         this.project = project
         project.pluginManager.apply(BasePlugin.class)
         project.pluginManager.apply(ReportingBasePlugin.class)
-        UnityPluginExtension extension = project.extensions.create("unity", DefaultUnityPluginExtension, project, fileResolver, instantiator)
+        UnityPluginExtension extension = project.extensions.create(EXTENSION_NAME, DefaultUnityPluginExtension, project, fileResolver, instantiator)
 
         final ReportingExtension reportingExtension = (ReportingExtension) project.getExtensions().getByName(ReportingExtension.NAME)
         ConventionMapping unityExtensionMapping = ((IConventionAware) extension).getConventionMapping()
@@ -109,7 +109,7 @@ class UnityPlugin implements Plugin<Project> {
         BasePluginConvention convention = new BasePluginConvention(project)
 
         addLifecycleTasks()
-        addTestTasks()
+        createTestTasks(extension)
         addPackageTask()
         addActivateAndReturnLicenseTasks(extension)
 
@@ -268,17 +268,29 @@ class UnityPlugin implements Plugin<Project> {
         project.tasks[BasePlugin.ASSEMBLE_TASK_NAME].dependsOn task
     }
 
-    private void addTestTasks() {
-        def editModeTask = project.tasks.create(name: TEST_EDITOMODE_TASK_NAME, type: Test, group: GROUP) as Test
-        editModeTask.testPlatform = TestPlatform.editmode
+    private void createTestTasks(final UnityPluginExtension extension) {
+      def testTask = project.tasks.create(name: TEST_TASK_NAME, group: GROUP)
+      def testEditModeTask = project.tasks.create(name: TEST_EDITOMODE_TASK_NAME, group: GROUP)
+      def testplayModeTask = project.tasks.create(name: TEST_PLAYMODE_TASK_NAME, group: GROUP)
+      testTask.dependsOn testEditModeTask, testplayModeTask
 
-        def playModeTask = project.tasks.create(name: TEST_PLAYMODE_TASK_NAME, type: Test, group: GROUP) as Test
-        playModeTask.testPlatform = TestPlatform.playmode
+      project.afterEvaluate {
+        extension.testBuildTargets.each { target ->
+          def suffix = target.toString().capitalize()
 
-        def testTask = project.tasks.create(name: TEST_TASK_NAME, group: GROUP)
-        testTask.dependsOn editModeTask, playModeTask
+          testEditModeTask.dependsOn createTestTask(TEST_EDITOMODE_TASK_NAME + suffix, TestPlatform.editmode, target)
+          testplayModeTask.dependsOn   createTestTask(TEST_PLAYMODE_TASK_NAME + suffix, TestPlatform.playmode, target)
+        }
+      }
 
-        project.tasks[LifecycleBasePlugin.CHECK_TASK_NAME].dependsOn testTask
+      project.tasks[LifecycleBasePlugin.CHECK_TASK_NAME].dependsOn testTask
+    }
+
+    private Test createTestTask(String name, TestPlatform testPlatform, BuildTarget testBuildTarget){
+      def task = project.tasks.create(name: name, type: Test, group: GROUP) as Test
+      task.testPlatform = testPlatform
+      task.buildTarget = testBuildTarget
+      task
     }
 
     private void addDefaultReportTasks(final UnityPluginExtension extension) {

--- a/src/main/groovy/wooga/gradle/unity/UnityPluginExtension.groovy
+++ b/src/main/groovy/wooga/gradle/unity/UnityPluginExtension.groovy
@@ -30,7 +30,7 @@ import wooga.gradle.unity.batchMode.BuildTarget
 
 import static org.gradle.util.ConfigureUtil.configureUsing
 
-interface UnityPluginExtension {
+interface UnityPluginExtension extends UnityPluginTestExtension {
 
     File getUnityPath()
 

--- a/src/main/groovy/wooga/gradle/unity/UnityPluginTestExtension.groovy
+++ b/src/main/groovy/wooga/gradle/unity/UnityPluginTestExtension.groovy
@@ -1,0 +1,32 @@
+package wooga.gradle.unity
+
+import wooga.gradle.unity.batchMode.BuildTarget
+
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+interface UnityPluginTestExtension {
+
+  UnityPluginTestExtension testBuildTargets(Object... var1)
+
+  UnityPluginTestExtension testBuildTargets(Iterable<?> var1)
+
+  UnityPluginTestExtension setTestBuildTargets(Iterable<?> var1)
+
+  Set<BuildTarget> getTestBuildTargets()
+
+}

--- a/src/test/groovy/wooga/gradle/unity/DefaultUnityPluginExtensionSpec.groovy
+++ b/src/test/groovy/wooga/gradle/unity/DefaultUnityPluginExtensionSpec.groovy
@@ -94,9 +94,74 @@ class DefaultUnityPluginExtensionSpec extends Specification {
         defaultBuildTarget == result
 
         where:
-        source                          | result
-        BuildTarget.webgl               | BuildTarget.webgl
-        "ios"                           | BuildTarget.ios
-        { it -> BuildTarget.android }   | BuildTarget.android
+        source            | result
+        BuildTarget.webgl | BuildTarget.webgl
+        "ios"             | BuildTarget.ios
+                { it -> BuildTarget.android } | BuildTarget.android
+    }
+
+    @Unroll
+    def "testBuildTargets with List #source"() {
+        given: "calling testBuildTargets"
+        subject.testBuildTargets(source)
+
+        expect:
+        def targets = subject.testBuildTargets
+        targets.size() == 2
+        targets.every { BuildTarget.isInstance(it) }
+
+        where:
+        source << [[BuildTarget.android, BuildTarget.ios], ["ios", "android"], [new BuildTargetTestObject("ios"), new BuildTargetTestObject("android")]]
+    }
+
+    @Unroll
+    def "testBuildTargets with variadic arguments #source"() {
+        given: "calling testBuildTargets"
+        subject.testBuildTargets(source[0], source[1])
+
+        expect:
+        def targets = subject.testBuildTargets
+        targets.size() == 2
+        targets.every { BuildTarget.isInstance(it) }
+
+        where:
+        source << [[BuildTarget.android, BuildTarget.ios], ["ios", "android"], [new BuildTargetTestObject("ios"), new BuildTargetTestObject("android")]]
+    }
+
+    @Unroll
+    def "setTestBuildTargets assigns build targets"() {
+        given: "calling testBuildTargets"
+        subject.testBuildTargets = source
+
+        when:
+        def targets = subject.testBuildTargets
+
+        then:
+        targets.size() == 2
+        targets.every { BuildTarget.isInstance(it) }
+
+        when:
+        subject.testBuildTargets = [override]
+        targets = subject.testBuildTargets
+        then:
+        targets.size() == 1
+
+        where:
+        source << [[BuildTarget.android, BuildTarget.ios], ["ios", "android"], [new BuildTargetTestObject("ios"), new BuildTargetTestObject("android")]]
+        override << [BuildTarget.web, "web", new BuildTargetTestObject("web")]
+    }
+
+    class BuildTargetTestObject {
+
+        private def testValue
+
+        BuildTargetTestObject(String value) {
+            this.testValue = value
+        }
+
+        @Override
+        String toString(){
+            return testValue
+        }
     }
 }

--- a/src/test/groovy/wooga/gradle/unity/DefaultUnityPluginExtensionSpec.groovy
+++ b/src/test/groovy/wooga/gradle/unity/DefaultUnityPluginExtensionSpec.groovy
@@ -118,27 +118,30 @@ class DefaultUnityPluginExtensionSpec extends Specification {
 
         then:
         subject.getTestBuildTargets().size() == expectedSize
-        if(!expectedTestBuildTargets.empty) {
+        if (!expectedTestBuildTargets.empty) {
             expectedTestBuildTargets.each {
-              subject.testBuildTargets.contains(it)
+                subject.testBuildTargets.contains(it)
             }
         }
 
         where:
-        timing    | defaultBuildTarget    | beforeTestBuildTargets             | afterTestBuildTargets | expectedTestBuildTargets                                | useSetter
-        "via"     | BuildTarget.ios       | []                                 | []                    | [BuildTarget.ios]                                       | true
-        "via"     | BuildTarget.ios       | []                                 | []                    | [BuildTarget.ios]                                       | false
-        "before"  | BuildTarget.android   | [BuildTarget.ios, BuildTarget.web] | []                    | [BuildTarget.ios, BuildTarget.web, BuildTarget.android] | true
-        "before"  | BuildTarget.android   | [BuildTarget.ios, BuildTarget.web] | []                    | [BuildTarget.ios, BuildTarget.web, BuildTarget.android] | false
-        "after"   | BuildTarget.android   | []                                 | [BuildTarget.ios]     | [BuildTarget.ios, BuildTarget.android]                  | true
-        "after"   | BuildTarget.android   | []                                 | [BuildTarget.ios]     | [BuildTarget.ios, BuildTarget.android]                  | false
-        "before"  | BuildTarget.android   | [BuildTarget.ios]                  | [BuildTarget.web]     | [BuildTarget.web, BuildTarget.android]                  | true
-        "before"  | BuildTarget.android   | [BuildTarget.ios]                  | [BuildTarget.web]     | [BuildTarget.ios, BuildTarget.web, BuildTarget.android] | false
-        "without" | BuildTarget.undefined | []                                 | [BuildTarget.ios]     | [BuildTarget.ios]                                       | true
-        "without" | BuildTarget.undefined | []                                 | [BuildTarget.ios]     | [BuildTarget.ios]                                       | false
-        "and"     | BuildTarget.ios       | [BuildTarget.ios]                  | [BuildTarget.ios]     | [BuildTarget.ios]                                       | true
-        "and"     | BuildTarget.ios       | [BuildTarget.ios]                  | [BuildTarget.ios]     | [BuildTarget.ios]                                       | false
-        "via"     | BuildTarget.undefined | []                                 | []                    | []                                                      | false
+        timing    | defaultBuildTarget    | beforeTestBuildTargets             | afterTestBuildTargets   | expectedTestBuildTargets                                | useSetter
+        "via"     | BuildTarget.ios       | []                                 | []                      | [BuildTarget.ios]                                       | true
+        "via"     | BuildTarget.ios       | []                                 | []                      | [BuildTarget.ios]                                       | false
+        "before"  | BuildTarget.android   | [BuildTarget.ios, BuildTarget.web] | []                      | [BuildTarget.ios, BuildTarget.web, BuildTarget.android] | true
+        "before"  | BuildTarget.android   | [BuildTarget.ios, BuildTarget.web] | []                      | [BuildTarget.ios, BuildTarget.web, BuildTarget.android] | false
+        "after"   | BuildTarget.android   | []                                 | [BuildTarget.ios]       | [BuildTarget.ios, BuildTarget.android]                  | true
+        "after"   | BuildTarget.android   | []                                 | [BuildTarget.ios]       | [BuildTarget.ios, BuildTarget.android]                  | false
+        "before"  | BuildTarget.android   | [BuildTarget.ios]                  | [BuildTarget.web]       | [BuildTarget.web, BuildTarget.android]                  | true
+        "before"  | BuildTarget.android   | [BuildTarget.ios]                  | [BuildTarget.web]       | [BuildTarget.ios, BuildTarget.web, BuildTarget.android] | false
+        "without" | BuildTarget.undefined | []                                 | [BuildTarget.ios]       | [BuildTarget.ios]                                       | true
+        "without" | BuildTarget.undefined | []                                 | [BuildTarget.ios]       | [BuildTarget.ios]                                       | false
+        "and"     | BuildTarget.ios       | [BuildTarget.ios]                  | [BuildTarget.ios]       | [BuildTarget.ios]                                       | true
+        "and"     | BuildTarget.ios       | [BuildTarget.ios]                  | [BuildTarget.ios]       | [BuildTarget.ios]                                       | false
+        "via"     | BuildTarget.undefined | []                                 | []                      | []                                                      | false
+        "via"     | BuildTarget.android   | []                                 | [BuildTarget.undefined] | [BuildTarget.android]                                   | false
+        "via"     | BuildTarget.android   | []                                 | [BuildTarget.undefined] | [BuildTarget.android]                                   | true
+
 
         expectedSize = expectedTestBuildTargets.size
         initialSize = beforeTestBuildTargets.size

--- a/src/test/groovy/wooga/gradle/unity/DefaultUnityPluginExtensionSpec.groovy
+++ b/src/test/groovy/wooga/gradle/unity/DefaultUnityPluginExtensionSpec.groovy
@@ -101,6 +101,51 @@ class DefaultUnityPluginExtensionSpec extends Specification {
     }
 
     @Unroll
+    def "set testBuildTargets #timing defaultBuildTarget with #method"() {
+        given:
+        if (!beforeTestBuildTargets.empty) {
+            subject.testBuildTargets(beforeTestBuildTargets)
+        }
+        assert subject.getTestBuildTargets().size() == initialSize
+
+        and: "extension with defaultBuildTarget"
+        subject.defaultBuildTarget = defaultBuildTarget
+
+        when:
+        if (!afterTestBuildTargets.empty) {
+            subject.invokeMethod(method, afterTestBuildTargets)
+        }
+
+        then:
+        subject.getTestBuildTargets().size() == expectedSize
+        if(!expectedTestBuildTargets.empty) {
+            expectedTestBuildTargets.each {
+              subject.testBuildTargets.contains(it)
+            }
+        }
+
+        where:
+        timing    | defaultBuildTarget    | beforeTestBuildTargets             | afterTestBuildTargets | expectedTestBuildTargets                                | useSetter
+        "via"     | BuildTarget.ios       | []                                 | []                    | [BuildTarget.ios]                                       | true
+        "via"     | BuildTarget.ios       | []                                 | []                    | [BuildTarget.ios]                                       | false
+        "before"  | BuildTarget.android   | [BuildTarget.ios, BuildTarget.web] | []                    | [BuildTarget.ios, BuildTarget.web, BuildTarget.android] | true
+        "before"  | BuildTarget.android   | [BuildTarget.ios, BuildTarget.web] | []                    | [BuildTarget.ios, BuildTarget.web, BuildTarget.android] | false
+        "after"   | BuildTarget.android   | []                                 | [BuildTarget.ios]     | [BuildTarget.ios, BuildTarget.android]                  | true
+        "after"   | BuildTarget.android   | []                                 | [BuildTarget.ios]     | [BuildTarget.ios, BuildTarget.android]                  | false
+        "before"  | BuildTarget.android   | [BuildTarget.ios]                  | [BuildTarget.web]     | [BuildTarget.web, BuildTarget.android]                  | true
+        "before"  | BuildTarget.android   | [BuildTarget.ios]                  | [BuildTarget.web]     | [BuildTarget.ios, BuildTarget.web, BuildTarget.android] | false
+        "without" | BuildTarget.undefined | []                                 | [BuildTarget.ios]     | [BuildTarget.ios]                                       | true
+        "without" | BuildTarget.undefined | []                                 | [BuildTarget.ios]     | [BuildTarget.ios]                                       | false
+        "and"     | BuildTarget.ios       | [BuildTarget.ios]                  | [BuildTarget.ios]     | [BuildTarget.ios]                                       | true
+        "and"     | BuildTarget.ios       | [BuildTarget.ios]                  | [BuildTarget.ios]     | [BuildTarget.ios]                                       | false
+        "via"     | BuildTarget.undefined | []                                 | []                    | []                                                      | false
+
+        expectedSize = expectedTestBuildTargets.size
+        initialSize = beforeTestBuildTargets.size
+        method = (useSetter) ? "setTestBuildTargets" : "testBuildTargets"
+    }
+
+    @Unroll
     def "testBuildTargets with List #source"() {
         given: "calling testBuildTargets"
         subject.testBuildTargets(source)
@@ -160,7 +205,7 @@ class DefaultUnityPluginExtensionSpec extends Specification {
         }
 
         @Override
-        String toString(){
+        String toString() {
             return testValue
         }
     }

--- a/src/test/groovy/wooga/gradle/unity/UnityPluginSpec.groovy
+++ b/src/test/groovy/wooga/gradle/unity/UnityPluginSpec.groovy
@@ -20,7 +20,6 @@ package wooga.gradle.unity
 import nebula.test.PluginProjectSpec
 import nebula.test.ProjectSpec
 import org.gradle.api.DefaultTask
-import org.gradle.language.base.plugins.LifecycleBasePlugin
 import spock.lang.Unroll
 import wooga.gradle.unity.batchMode.BuildTarget
 import wooga.gradle.unity.batchMode.TestPlatform
@@ -140,13 +139,13 @@ class UnityPluginSpec extends ProjectSpec {
         }
 
         where:
-        baseTestTaskName                     | testPlatform          | testBuildTarget                        | name
-        UnityPlugin.TEST_EDITOMODE_TASK_NAME | TestPlatform.editmode | [BuildTarget.android]                  | "single"
-        UnityPlugin.TEST_PLAYMODE_TASK_NAME  | TestPlatform.playmode | [BuildTarget.android]                  | "single"
-        UnityPlugin.TEST_EDITOMODE_TASK_NAME | TestPlatform.editmode | [BuildTarget.android, BuildTarget.ios] | "two"
-        UnityPlugin.TEST_PLAYMODE_TASK_NAME  | TestPlatform.playmode | [BuildTarget.android, BuildTarget.ios] | "two"
-        UnityPlugin.TEST_PLAYMODE_TASK_NAME  | TestPlatform.editmode | EnumSet.allOf(BuildTarget).toList()    | "all"
-        UnityPlugin.TEST_PLAYMODE_TASK_NAME  | TestPlatform.playmode | EnumSet.allOf(BuildTarget).toList()    | "all"
+        baseTestTaskName                     | testPlatform          | testBuildTarget                                                | name
+        UnityPlugin.TEST_EDITOMODE_TASK_NAME | TestPlatform.editmode | [BuildTarget.android]                                          | "single"
+        UnityPlugin.TEST_PLAYMODE_TASK_NAME  | TestPlatform.playmode | [BuildTarget.android]                                          | "single"
+        UnityPlugin.TEST_EDITOMODE_TASK_NAME | TestPlatform.editmode | [BuildTarget.android, BuildTarget.ios]                         | "two"
+        UnityPlugin.TEST_PLAYMODE_TASK_NAME  | TestPlatform.playmode | [BuildTarget.android, BuildTarget.ios]                         | "two"
+        UnityPlugin.TEST_PLAYMODE_TASK_NAME  | TestPlatform.editmode | EnumSet.range(BuildTarget.ios, BuildTarget.samsungtv).toList() | "all"
+        UnityPlugin.TEST_PLAYMODE_TASK_NAME  | TestPlatform.playmode | EnumSet.range(BuildTarget.ios, BuildTarget.samsungtv).toList() | "all"
 
         taskNames = testBuildTarget.collect { baseTestTaskName + it.toString().capitalize() }
     }

--- a/src/test/groovy/wooga/gradle/unity/UnityPluginSpec.groovy
+++ b/src/test/groovy/wooga/gradle/unity/UnityPluginSpec.groovy
@@ -64,34 +64,11 @@ class UnityPluginSpec extends ProjectSpec {
         where:
         taskName                                 | taskType
         UnityPlugin.TEST_TASK_NAME               | DefaultTask
-        UnityPlugin.TEST_EDITOMODE_TASK_NAME     | Test
-        UnityPlugin.TEST_PLAYMODE_TASK_NAME      | Test
+        UnityPlugin.TEST_EDITOMODE_TASK_NAME     | DefaultTask
+        UnityPlugin.TEST_PLAYMODE_TASK_NAME      | DefaultTask
         UnityPlugin.EXPORT_PACKAGE_TASK_NAME     | UnityPackage
         UnityPlugin.ASSEMBLE_RESOURCES_TASK_NAME | DefaultTask
         UnityPlugin.SETUP_TASK_NAME              | DefaultTask
-    }
-
-    @Unroll("configure as test task #taskName #testPlatform")
-    def 'configures tasks for platform '(String taskName, TestPlatform testPlatform) {
-        given:
-        assert !project.plugins.hasPlugin(PLUGIN_NAME)
-        assert !project.tasks.findByName(taskName)
-
-        when:
-        project.plugins.apply(PLUGIN_NAME)
-
-        then:
-        def task = project.tasks.findByName(taskName) as Test
-        task.testPlatform == testPlatform
-        def testTask = project.tasks.findByName(UnityPlugin.TEST_TASK_NAME)
-        testTask.dependsOn.contains(task)
-        def checkTask = project.tasks.findByName(LifecycleBasePlugin.CHECK_TASK_NAME)
-        checkTask.dependsOn.contains(testTask)
-
-        where:
-        taskName                             | testPlatform
-        UnityPlugin.TEST_EDITOMODE_TASK_NAME | TestPlatform.editmode
-        UnityPlugin.TEST_PLAYMODE_TASK_NAME  | TestPlatform.playmode
     }
 
     @Unroll
@@ -132,5 +109,45 @@ class UnityPluginSpec extends ProjectSpec {
 
         then:
         extension.defaultBuildTarget == BuildTarget.ios
+    }
+
+    @Unroll("configure test for #name testPlatforms")
+    def 'configures tasks for platform '() {
+        given:
+        assert !project.plugins.hasPlugin(PLUGIN_NAME)
+        taskNames.each { taskName ->
+            assert !project.tasks.findByName(taskName)
+        }
+
+        and:
+        project.plugins.apply(PLUGIN_NAME)
+        def extension = project.extensions.getByName(UnityPlugin.EXTENSION_NAME) as UnityPluginExtension
+        extension.testBuildTargets(testBuildTarget)
+
+        when:
+        project.evaluate()
+
+
+        then:
+        def testTask = project.tasks.findByName(baseTestTaskName)
+
+        taskNames.each { taskName ->
+            def task = project.tasks.findByName(taskName) as Test
+            task != null
+            task.testPlatform == testPlatform
+
+            testTask.dependsOn.contains(task)
+        }
+
+        where:
+        baseTestTaskName                     | testPlatform          | testBuildTarget                        | name
+        UnityPlugin.TEST_EDITOMODE_TASK_NAME | TestPlatform.editmode | [BuildTarget.android]                  | "single"
+        UnityPlugin.TEST_PLAYMODE_TASK_NAME  | TestPlatform.playmode | [BuildTarget.android]                  | "single"
+        UnityPlugin.TEST_EDITOMODE_TASK_NAME | TestPlatform.editmode | [BuildTarget.android, BuildTarget.ios] | "two"
+        UnityPlugin.TEST_PLAYMODE_TASK_NAME  | TestPlatform.playmode | [BuildTarget.android, BuildTarget.ios] | "two"
+        UnityPlugin.TEST_PLAYMODE_TASK_NAME  | TestPlatform.editmode | EnumSet.allOf(BuildTarget).toList()    | "all"
+        UnityPlugin.TEST_PLAYMODE_TASK_NAME  | TestPlatform.playmode | EnumSet.allOf(BuildTarget).toList()    | "all"
+
+        taskNames = testBuildTarget.collect { baseTestTaskName + it.toString().capitalize() }
     }
 }


### PR DESCRIPTION
## Description 
Generate Tasks on all combinations of `TestPlatforms` (eg `PlayMode`, `EditMode`) and `BuildTargets` (eg `ios`, `android` ...).

### Breaking Changes
The `testEditMode` and `testPlayMode` have been converted to life cycle tasks. The new task tree might look like this:

*task dependencies with `testBuildTargets: ios, android`*

```
:check
\--- :test
     +--- :testEditMode
     |    +--- :testEditModeAndroid
     |    \--- :testEditModeIos
     \--- :testPlayMode
          +--- :testPlayModeAndroid
          \--- :testPlayModeIos
```



## Changes
![ADD] `testPlatforms` property in `UnityExtension`
![ADD] logic to set `testPlatforms` via properties with `unity.testPlatforms=ios,android,...` 
![CHANGE] `testEditMode` and `testPlayMode` task types to `DefaultTask`

[NEW]:https://atlas-resources.wooga.com/icons/icon_new.svg "New"
[ADD]:http://resources.atlas.wooga.com/icons/icon_add.svg "Add"
[IMPROVE]:http://resources.atlas.wooga.com/icons/icon_improve.svg "IMPROVE"
[CHANGE]:http://resources.atlas.wooga.com/icons/icon_change.svg "Change"
[FIX]:http://resources.atlas.wooga.com/icons/icon_fix.svg "Fix"
[UPDATE]:http://resources.atlas.wooga.com/icons/icon_update.svg "Update"

[BREAK]:http://resources.atlas.wooga.com/icons/icon_break.svg "Remove"
[REMOVE]:http://resources.atlas.wooga.com/icons/icon_remove.svg "Remove"
[IOS]:http://resources.atlas.wooga.com/icons/icon_iOS.svg "iOS"
[ANDROID]:http://resources.atlas.wooga.com/icons/icon_android.svg "Android"
[WEBGL]:http://resources.atlas.wooga.com/icons/icon_webGL.svg "Web:GL"