### PR TITLE
fix fallback to default target

### DIFF
--- a/src/integrationTest/groovy/wooga/gradle/unity/PluginConfigurationSpec.groovy
+++ b/src/integrationTest/groovy/wooga/gradle/unity/PluginConfigurationSpec.groovy
@@ -71,9 +71,6 @@ class PluginConfigurationSpec extends UnityIntegrationSpec {
 
             task (customTest, type: wooga.gradle.unity.tasks.Test) {
                 $taskConfig
-                doLast{
-                    print customTest.buildTarget
-                }
             }
 
         """.stripIndent()
@@ -86,8 +83,8 @@ class PluginConfigurationSpec extends UnityIntegrationSpec {
 
         where:
         taskConfig            | expected
-        'buildTarget = "ios"' | "ios"
-        ''                    | "android"
+        'buildTarget = "ios"' | "-buildTarget ios"
+        ''                    | "-buildTarget android"
 
         useOverride = taskConfig != '' ? "use override" : "fallback to default"
       }

--- a/src/main/groovy/wooga/gradle/unity/UnityPlugin.groovy
+++ b/src/main/groovy/wooga/gradle/unity/UnityPlugin.groovy
@@ -121,7 +121,6 @@ class UnityPlugin implements Plugin<Project> {
         addDefaultReportTasks(extension)
         configureArchiveDefaults(convention)
         configureUnityTaskDependencies()
-        configureUnityDefaultBuildTarget(extension)
         configureCleanObjects()
         project.afterEvaluate(new Action<Project>() {
             @Override
@@ -366,20 +365,6 @@ class UnityPlugin implements Plugin<Project> {
             @Override
             void execute(AbstractUnityTask task) {
                 task.dependsOn project.tasks[SETUP_TASK_NAME]
-            }
-        })
-    }
-
-    private void configureUnityDefaultBuildTarget(final UnityPluginExtension extension) {
-        project.tasks.withType(AbstractUnityTask, new Action<AbstractUnityTask>() {
-            @Override
-            void execute(AbstractUnityTask task) {
-                ConventionMapping mapping = ((IConventionAware) task).conventionMapping
-                mapping.map("buildTarget", new Callable<BuildTarget>() {
-                    BuildTarget call() {
-                        extension.defaultBuildTarget
-                    }
-                })
             }
         })
     }

--- a/src/main/groovy/wooga/gradle/unity/batchMode/DefaultBatchModeAction.groovy
+++ b/src/main/groovy/wooga/gradle/unity/batchMode/DefaultBatchModeAction.groovy
@@ -34,6 +34,7 @@ class DefaultBatchModeAction extends DefaultExecHandleBuilder implements BatchMo
 
     private File customUnityPath
     private File customProjectPath
+    private BuildTarget customBuildTarget
 
     File getUnityPath() {
         if(customUnityPath) {
@@ -73,7 +74,13 @@ class DefaultBatchModeAction extends DefaultExecHandleBuilder implements BatchMo
         logFile = fileResolver.resolveLater(file)
     }
 
-    BuildTarget buildTarget = BuildTarget.undefined
+    BuildTarget getBuildTarget() {
+        if(customBuildTarget && customBuildTarget != BuildTarget.undefined) {
+            return customBuildTarget
+        }
+
+        extension.defaultBuildTarget
+    }
 
     Boolean quit = true
     Boolean batchMode = true
@@ -157,8 +164,13 @@ class DefaultBatchModeAction extends DefaultExecHandleBuilder implements BatchMo
 
     @Override
     DefaultBatchModeAction buildTarget(BuildTarget target) {
-        this.buildTarget = target
+        this.customBuildTarget = target
         this
+    }
+
+    @Override
+    void setBuildTarget(BuildTarget target) {
+        buildTarget(target)
     }
 
     @Override

--- a/src/main/groovy/wooga/gradle/unity/tasks/Test.groovy
+++ b/src/main/groovy/wooga/gradle/unity/tasks/Test.groovy
@@ -309,8 +309,8 @@ class Test extends AbstractUnityTask implements Reporting<UnityTestTaskReport> {
                 }
             })
             if (readResult.exitValue == 0) {
-                versionString = standardOutput.toString().trim()
-                def versionMatch = versionString =~ /(\d+)\.(\d+)\.(\d+)/
+                def wmicOut = standardOutput.toString().trim()
+                def versionMatch = wmicOut =~ /(\d+)\.(\d+)\.(\d+)/
                 if (versionMatch) {
                     versionString = versionMatch[0][0]
                     logger.info("Found unity version $versionString")


### PR DESCRIPTION
## Description

We introduced 2 smaller issues with the last releases that will break integration tests. I did these changes already in #9 but will pull them out again.

## Changes

![FIX] fallback to default build target
![FIX] unity version check when file at path has no version

[NEW]:https://atlas-resources.wooga.com/icons/icon_new.svg "New"
[ADD]:http://resources.atlas.wooga.com/icons/icon_add.svg "Add"
[IMPROVE]:http://resources.atlas.wooga.com/icons/icon_improve.svg "IMPROVE"
[CHANGE]:http://resources.atlas.wooga.com/icons/icon_change.svg "Change"
[FIX]:http://resources.atlas.wooga.com/icons/icon_fix.svg "Fix"
[UPDATE]:http://resources.atlas.wooga.com/icons/icon_update.svg "Update"

[BREAK]:http://resources.atlas.wooga.com/icons/icon_break.svg "Remove"
[REMOVE]:http://resources.atlas.wooga.com/icons/icon_remove.svg "Remove"
[IOS]:http://resources.atlas.wooga.com/icons/icon_iOS.svg "iOS"
[ANDROID]:http://resources.atlas.wooga.com/icons/icon_android.svg "Android"
[WEBGL]:http://resources.atlas.wooga.com/icons/icon_webGL.svg "Web:GL"