### PR TITLE
Catch invalid/binary settings file content

### DIFF
--- a/src/integrationTest/groovy/wooga/gradle/unity/TestIntegrationSpec.groovy
+++ b/src/integrationTest/groovy/wooga/gradle/unity/TestIntegrationSpec.groovy
@@ -128,4 +128,26 @@ class TestIntegrationSpec extends UnityIntegrationSpec {
         then:
         result.standardOutput.contains("PlayMode tests not activated")
     }
+
+    def "Auto-detect for playmode tests with binary settings file"() {
+
+        given: "a build script with fake test unity location"
+        buildFile << """
+            task (mUnity, type: wooga.gradle.unity.tasks.Test) {
+                testPlatform = "playmode"
+            }
+        """.stripIndent()
+
+        and: "a mocked project setting with binary content"
+        def settings = createFile("ProjectSettings/ProjectSettings.asset")
+        settings.bytes = [ 0, 1, 0, 1, 1, 0, 1, 0 ] as byte[]
+        and: "unity version > 5.5"
+
+        when:
+        def result = runTasksSuccessfully("mUnity", "-PdefaultUnityTestVersion=2017.1.1f3")
+
+        then:
+        result.standardOutput.contains("PlayMode tests not activated")
+
+    }
 }

--- a/src/main/groovy/wooga/gradle/unity/UnityPluginExtension.groovy
+++ b/src/main/groovy/wooga/gradle/unity/UnityPluginExtension.groovy
@@ -18,17 +18,9 @@
 package wooga.gradle.unity
 
 import org.gradle.api.Action
-import org.gradle.api.artifacts.repositories.PasswordCredentials
 import org.gradle.internal.Factory
 import org.gradle.process.ExecResult
-import wooga.gradle.unity.batchMode.ActivationAction
-import wooga.gradle.unity.batchMode.ActivationSpec
-import wooga.gradle.unity.batchMode.BaseBatchModeSpec
-import wooga.gradle.unity.batchMode.BatchModeAction
-import wooga.gradle.unity.batchMode.BatchModeSpec
-import wooga.gradle.unity.batchMode.BuildTarget
-
-import static org.gradle.util.ConfigureUtil.configureUsing
+import wooga.gradle.unity.batchMode.*
 
 interface UnityPluginExtension extends UnityPluginTestExtension {
 

--- a/src/test/groovy/wooga/gradle/unity/utils/ProjectSettingsSpec.groovy
+++ b/src/test/groovy/wooga/gradle/unity/utils/ProjectSettingsSpec.groovy
@@ -1,7 +1,6 @@
 package wooga.gradle.unity.utils
 
 import spock.lang.Specification
-import spock.lang.Shared
 import spock.lang.Unroll
 
 class ProjectSettingsSpec extends Specification {
@@ -27,6 +26,16 @@ class ProjectSettingsSpec extends Specification {
         wiiUProfilerLibPath: 
         playModeTestRunnerEnabled: 1
         actionOnDotNetUnhandledException: 1
+    
+    """.stripIndent()
+
+    static String TEMPLATE_CONTENT_INVALID = """      
+    0000 be6d 0000 c9e7 0000 0011 0000 be90
+    0000 0000 3230 3137 2e31 2e30 6633 00fe
+    ffff ff01 0100 0000 8100 0000 00ff ffa0
+    fc36 4045 ea85 96ed 5478 598b 4e1b 87d8
+    0500 00d9 3100 000c 0000 0000 0000 0037
+    0000 80ff ffff ff00 0000 0000 8000 0001
     
     """.stripIndent()
 
@@ -89,5 +98,13 @@ class ProjectSettingsSpec extends Specification {
         then:
         result.readLines().every { !it.matches(/%TAG !u! tag:unity3d.com,.*:/) }
         result.readLines().every { !it.matches(/(--- )!u!\d+( &\d+)/) }
+    }
+
+    def "parse invalid project settings file"() {
+        when: "initialize projectSettings with binary content"
+        def settings = new ProjectSettings(TEMPLATE_CONTENT_INVALID)
+
+        then:
+        !settings.playModeTestRunnerEnabled
     }
 }


### PR DESCRIPTION
Unity supports both formats for `.asset` files (text/binary). Currently, we are only able to parse text-based project settings files.

* Add unit test
* Add integration test