### PR TITLE
Use convention mapping for task properties

### DIFF
--- a/src/main/groovy/wooga/gradle/unity/DefaultUnityPluginExtension.groovy
+++ b/src/main/groovy/wooga/gradle/unity/DefaultUnityPluginExtension.groovy
@@ -321,7 +321,7 @@ class DefaultUnityPluginExtension implements UnityPluginExtension {
         BatchModeAction batchModeAction = batchModeActionFactory.create()
 
         def conventionMapper = batchModeAction.conventionMapping
-        UnityPlugin.applyConvention(conventionMapper, project.extensions.getByType(UnityPluginExtension))
+        UnityPlugin.applyBaseConvention(conventionMapper, project.extensions.getByType(UnityPluginExtension))
 
         action.execute(batchModeAction)
         return batchModeAction.execute()

--- a/src/main/groovy/wooga/gradle/unity/DefaultUnityPluginExtension.groovy
+++ b/src/main/groovy/wooga/gradle/unity/DefaultUnityPluginExtension.groovy
@@ -305,8 +305,8 @@ class DefaultUnityPluginExtension implements UnityPluginExtension {
         this.fileResolver = fileResolver
         this.instantiator = instantiator
         this.authentication = new UnityAuthentication(project.rootProject.properties, System.getenv())
-        this.batchModeActionFactory = instantiator.newInstance(DefaultBatchModeActionFactory, this, instantiator, fileResolver)
-        this.activationActionFactory = instantiator.newInstance(DefaultActivationActionFactory, this, instantiator, fileResolver, authentication)
+        this.batchModeActionFactory = instantiator.newInstance(DefaultBatchModeActionFactory, project, instantiator, fileResolver)
+        this.activationActionFactory = instantiator.newInstance(DefaultActivationActionFactory, project, instantiator, fileResolver, authentication)
         projectPath = project.projectDir
 
         autoActivateUnity = true
@@ -319,6 +319,10 @@ class DefaultUnityPluginExtension implements UnityPluginExtension {
 
     ExecResult batchMode(Action<? super BatchModeSpec> action) {
         BatchModeAction batchModeAction = batchModeActionFactory.create()
+
+        def conventionMapper = batchModeAction.conventionMapping
+        UnityPlugin.applyConvention(conventionMapper, project.extensions.getByType(UnityPluginExtension))
+
         action.execute(batchModeAction)
         return batchModeAction.execute()
     }

--- a/src/main/groovy/wooga/gradle/unity/UnityPlugin.groovy
+++ b/src/main/groovy/wooga/gradle/unity/UnityPlugin.groovy
@@ -22,7 +22,6 @@ import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.gradle.api.Task
 import org.gradle.api.artifacts.Configuration
-import org.gradle.api.file.CopySpec
 import org.gradle.api.internal.ConventionMapping
 import org.gradle.api.internal.IConventionAware
 import org.gradle.api.internal.file.FileResolver
@@ -32,7 +31,6 @@ import org.gradle.api.plugins.ReportingBasePlugin
 import org.gradle.api.reporting.Report
 import org.gradle.api.reporting.ReportingExtension
 import org.gradle.api.specs.Spec
-import org.gradle.api.tasks.Delete
 import org.gradle.internal.reflect.Instantiator
 import org.gradle.language.base.plugins.LifecycleBasePlugin
 import wooga.gradle.unity.batchMode.BuildTarget
@@ -118,27 +116,26 @@ class UnityPlugin implements Plugin<Project> {
             @Override
             void execute(AbstractUnityTask task) {
                 ConventionMapping taskConventionMapping = task.conventionMapping
-                applyConvention(taskConventionMapping, extension)
+                applyBaseConvention(taskConventionMapping, extension)
                 taskConventionMapping.logFile = {
-                    project.file("${project.buildDir}/logs${task.getLogCategory()}/${task.name}.log")
+                    project.file("${project.buildDir}/logs/${task.name}.log")
                 }
             }
         })
     }
 
-    static void applyConvention(ConventionMapping taskConventionMapping, UnityPluginExtension extension) {
+    static void applyBaseConvention(ConventionMapping taskConventionMapping, UnityPluginExtension extension) {
         taskConventionMapping.map "unityPath", { extension.unityPath }
-        //taskConventionMapping.unityPath = { extension.unityPath }
-        taskConventionMapping.logCategory = { extension.logCategory }
     }
 
     private void configureAutoActivationDeactivation(final Project project, final UnityPluginExtension extension) {
         Task activationTask = project.tasks[ACTIVATE_TASK_NAME]
         Task returnLicenseTask = project.tasks[RETURN_LICENSE_TASK_NAME]
 
-        project.getTasks().withType(AbstractUnityTask, new Action<AbstractUnityTask>() {
+        project.getTasks().withType(AbstractBatchModeTask, new Action<AbstractBatchModeTask>() {
             @Override
-            void execute(AbstractUnityTask task) {
+            void execute(AbstractBatchModeTask task) {
+
                 if (extension.autoActivateUnity) {
                     task.dependsOn activationTask
                 }

--- a/src/main/groovy/wooga/gradle/unity/UnityPlugin.groovy
+++ b/src/main/groovy/wooga/gradle/unity/UnityPlugin.groovy
@@ -96,6 +96,8 @@ class UnityPlugin implements Plugin<Project> {
 
         BasePluginConvention convention = new BasePluginConvention(project)
 
+
+        configureUnityTasks(extension)
         addTestTasks(extension)
         addPackageTask()
         addActivateAndReturnLicenseTasks(extension)
@@ -109,6 +111,25 @@ class UnityPlugin implements Plugin<Project> {
                 configureAutoActivationDeactivation(p, extension)
             }
         })
+    }
+
+    def configureUnityTasks(UnityPluginExtension extension) {
+        project.getTasks().withType(AbstractUnityTask, new Action<AbstractUnityTask>() {
+            @Override
+            void execute(AbstractUnityTask task) {
+                ConventionMapping taskConventionMapping = task.conventionMapping
+                applyConvention(taskConventionMapping, extension)
+                taskConventionMapping.logFile = {
+                    project.file("${project.buildDir}/logs${task.getLogCategory()}/${task.name}.log")
+                }
+            }
+        })
+    }
+
+    static void applyConvention(ConventionMapping taskConventionMapping, UnityPluginExtension extension) {
+        taskConventionMapping.map "unityPath", { extension.unityPath }
+        //taskConventionMapping.unityPath = { extension.unityPath }
+        taskConventionMapping.logCategory = { extension.logCategory }
     }
 
     private void configureAutoActivationDeactivation(final Project project, final UnityPluginExtension extension) {

--- a/src/main/groovy/wooga/gradle/unity/batchMode/ActivationSpec.groovy
+++ b/src/main/groovy/wooga/gradle/unity/batchMode/ActivationSpec.groovy
@@ -18,9 +18,10 @@
 package wooga.gradle.unity.batchMode
 
 import org.gradle.api.Action
+import org.gradle.api.internal.IConventionAware
 import wooga.gradle.unity.UnityAuthentication
 
-interface ActivationSpec extends BaseBatchModeSpec {
+interface ActivationSpec extends BaseBatchModeSpec, IConventionAware {
 
     UnityAuthentication getAuthentication()
     void setAuthentication(UnityAuthentication authentication)

--- a/src/main/groovy/wooga/gradle/unity/batchMode/BaseBatchModeSpec.groovy
+++ b/src/main/groovy/wooga/gradle/unity/batchMode/BaseBatchModeSpec.groovy
@@ -17,7 +17,9 @@
 
 package wooga.gradle.unity.batchMode
 
-interface BaseBatchModeSpec {
+import org.gradle.api.internal.IConventionAware
+
+interface BaseBatchModeSpec extends IConventionAware {
     File getUnityPath()
 
     BaseBatchModeSpec unityPath(File path)

--- a/src/main/groovy/wooga/gradle/unity/batchMode/BatchModeAction.groovy
+++ b/src/main/groovy/wooga/gradle/unity/batchMode/BatchModeAction.groovy
@@ -17,9 +17,10 @@
 
 package wooga.gradle.unity.batchMode
 
+import org.gradle.api.internal.IConventionAware
 import org.gradle.process.ExecResult
 import org.gradle.process.internal.ExecException
 
-interface BatchModeAction extends BatchModeSpec{
+interface BatchModeAction extends BatchModeSpec, IConventionAware{
     ExecResult execute() throws ExecException
 }

--- a/src/main/groovy/wooga/gradle/unity/batchMode/BatchModeSpec.groovy
+++ b/src/main/groovy/wooga/gradle/unity/batchMode/BatchModeSpec.groovy
@@ -19,7 +19,7 @@ package wooga.gradle.unity.batchMode
 
 import org.gradle.process.BaseExecSpec
 
-interface BatchModeSpec extends BaseBatchModeSpec, BaseExecSpec{
+interface BatchModeSpec extends BaseBatchModeSpec, BaseExecSpec {
     BatchModeSpec args(Object... var1)
 
     BatchModeSpec args(Iterable<?> var1)
@@ -31,20 +31,24 @@ interface BatchModeSpec extends BaseBatchModeSpec, BaseExecSpec{
     BuildTarget getBuildTarget()
 
     BatchModeSpec buildTarget(BuildTarget target)
+
     void setBuildTarget(BuildTarget target)
 
     Boolean getQuit()
 
     BatchModeSpec quit(Boolean value)
+
     void setQuit(Boolean value)
 
     Boolean getBatchMode()
 
     BatchModeSpec batchMode(Boolean value)
+
     void setBatchMode(Boolean value)
 
     Boolean getNoGraphics()
 
     BatchModeSpec noGraphics(Boolean value)
+
     void setNoGraphics(Boolean value)
 }

--- a/src/main/groovy/wooga/gradle/unity/batchMode/DefaultActivationAction.groovy
+++ b/src/main/groovy/wooga/gradle/unity/batchMode/DefaultActivationAction.groovy
@@ -19,6 +19,7 @@ package wooga.gradle.unity.batchMode
 
 import org.gradle.api.Action
 import org.gradle.api.GradleException
+import org.gradle.api.Project
 import org.gradle.internal.file.PathToFileResolver
 import org.gradle.process.ExecResult
 import org.gradle.process.internal.ExecException
@@ -55,8 +56,8 @@ class DefaultActivationAction extends DefaultBatchModeAction implements Activati
         return this
     }
 
-    DefaultActivationAction(UnityPluginExtension extension, PathToFileResolver fileResolver, UnityAuthentication authentication) {
-        super(extension, fileResolver)
+    DefaultActivationAction(Project project, PathToFileResolver fileResolver, UnityAuthentication authentication) {
+        super(project, fileResolver)
         this.authentication = authentication
     }
 

--- a/src/main/groovy/wooga/gradle/unity/batchMode/DefaultActivationActionFactory.groovy
+++ b/src/main/groovy/wooga/gradle/unity/batchMode/DefaultActivationActionFactory.groovy
@@ -17,28 +17,28 @@
 
 package wooga.gradle.unity.batchMode
 
+import org.gradle.api.Project
 import org.gradle.api.internal.file.FileResolver
 import org.gradle.internal.Factory
 import org.gradle.internal.reflect.Instantiator
 import wooga.gradle.unity.UnityAuthentication
-import wooga.gradle.unity.UnityPluginExtension
 
 class DefaultActivationActionFactory implements Factory<ActivationAction> {
 
     private final Instantiator instantiator
     private final FileResolver fileResolver
-    private final UnityPluginExtension extension
+    private final Project project
     private final UnityAuthentication authentication
 
-    DefaultActivationActionFactory(UnityPluginExtension extension, Instantiator instantiator, FileResolver fileResolver, UnityAuthentication authentication) {
+    DefaultActivationActionFactory(Project project, Instantiator instantiator, FileResolver fileResolver, UnityAuthentication authentication) {
         this.instantiator = instantiator
         this.fileResolver = fileResolver
-        this.extension = extension
+        this.project = project
         this.authentication = authentication
     }
 
     @Override
     ActivationAction create() {
-        instantiator.newInstance(DefaultActivationAction.class, extension, fileResolver, authentication)
+        instantiator.newInstance(DefaultActivationAction.class, project, fileResolver, authentication)
     }
 }

--- a/src/main/groovy/wooga/gradle/unity/batchMode/DefaultBatchModeAction.groovy
+++ b/src/main/groovy/wooga/gradle/unity/batchMode/DefaultBatchModeAction.groovy
@@ -18,6 +18,10 @@
 package wooga.gradle.unity.batchMode
 
 import org.gradle.api.GradleException
+import org.gradle.api.Project
+import org.gradle.api.internal.ConventionAwareHelper
+import org.gradle.api.internal.ConventionMapping
+import org.gradle.api.internal.IConventionAware
 import org.gradle.internal.Factory
 import org.gradle.internal.file.PathToFileResolver
 import org.gradle.internal.io.LineBufferingOutputStream
@@ -27,12 +31,14 @@ import org.gradle.process.internal.DefaultExecHandleBuilder
 import org.gradle.process.internal.ExecException
 import org.gradle.process.internal.ExecHandle
 import wooga.gradle.FileUtils
+import wooga.gradle.unity.UnityPlugin
 import wooga.gradle.unity.UnityPluginExtension
 import wooga.gradle.unity.utils.ForkTextStream
 
-class DefaultBatchModeAction extends DefaultExecHandleBuilder implements BatchModeAction {
+class DefaultBatchModeAction extends DefaultExecHandleBuilder implements BatchModeAction, IConventionAware {
     private final UnityPluginExtension extension
     private final PathToFileResolver fileResolver
+    private final ConventionMapping conventionMapping
 
     private File customUnityPath
     private File customProjectPath
@@ -106,10 +112,11 @@ class DefaultBatchModeAction extends DefaultExecHandleBuilder implements BatchMo
     Boolean batchMode = true
     Boolean noGraphics = false
 
-    DefaultBatchModeAction(UnityPluginExtension extension, PathToFileResolver fileResolver) {
+    DefaultBatchModeAction(Project project, PathToFileResolver fileResolver) {
         super(fileResolver)
         this.fileResolver = fileResolver
-        this.extension = extension
+        this.extension = project.getExtensions().findByName(UnityPlugin.EXTENSION_NAME) as UnityPluginExtension
+        this.conventionMapping = new ConventionAwareHelper(this, project.getConvention())
 
     }
 
@@ -254,5 +261,10 @@ class DefaultBatchModeAction extends DefaultExecHandleBuilder implements BatchMo
     @Override
     DefaultBatchModeAction setArgs(Iterable<?> arguments) {
         return DefaultBatchModeAction.cast(super.setArgs(arguments))
+    }
+
+    @Override
+    ConventionMapping getConventionMapping() {
+        return conventionMapping
     }
 }

--- a/src/main/groovy/wooga/gradle/unity/batchMode/DefaultBatchModeActionFactory.groovy
+++ b/src/main/groovy/wooga/gradle/unity/batchMode/DefaultBatchModeActionFactory.groovy
@@ -17,26 +17,25 @@
 
 package wooga.gradle.unity.batchMode
 
+import org.gradle.api.Project
 import org.gradle.api.internal.file.FileResolver
 import org.gradle.internal.Factory
 import org.gradle.internal.reflect.Instantiator
-import wooga.gradle.unity.UnityPluginExtension
-
 
 class DefaultBatchModeActionFactory implements Factory<BatchModeAction> {
 
     private final Instantiator instantiator
     private final FileResolver fileResolver
-    private final UnityPluginExtension extension
+    private final Project project
 
-    DefaultBatchModeActionFactory(UnityPluginExtension extension, Instantiator instantiator, FileResolver fileResolver) {
+    DefaultBatchModeActionFactory(Project project, Instantiator instantiator, FileResolver fileResolver) {
         this.instantiator = instantiator
         this.fileResolver = fileResolver
-        this.extension = extension
+        this.project = project
     }
 
     @Override
     BatchModeAction create() {
-        return instantiator.newInstance(DefaultBatchModeAction.class, extension, fileResolver)
+        return instantiator.newInstance(DefaultBatchModeAction.class, project, fileResolver)
     }
 }

--- a/src/main/groovy/wooga/gradle/unity/tasks/AbstractBatchModeTask.groovy
+++ b/src/main/groovy/wooga/gradle/unity/tasks/AbstractBatchModeTask.groovy
@@ -1,0 +1,50 @@
+package wooga.gradle.unity.tasks
+
+import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.Optional
+import wooga.gradle.unity.batchMode.BatchModeSpec
+import wooga.gradle.unity.batchMode.BuildTarget
+
+abstract class AbstractBatchModeTask extends AbstractUnityTask implements BatchModeSpec {
+
+    AbstractBatchModeTask(Class taskType) {
+        super(taskType)
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Optional
+    @Input
+    List<String> getArgs() {
+        return batchModeAction.getArgs()
+    }
+
+    @Optional
+    @Input
+    @Override
+    BuildTarget getBuildTarget() {
+        batchModeAction.buildTarget
+    }
+
+    @Optional
+    @Input
+    @Override
+    Boolean getQuit() {
+        return batchModeAction.quit
+    }
+
+    @Optional
+    @Input
+    @Override
+    Boolean getBatchMode() {
+        return batchModeAction.batchMode
+    }
+
+    @Optional
+    @Input
+    @Override
+    Boolean getNoGraphics() {
+        batchModeAction.noGraphics
+    }
+}

--- a/src/main/groovy/wooga/gradle/unity/tasks/AbstractBatchModeTask.groovy
+++ b/src/main/groovy/wooga/gradle/unity/tasks/AbstractBatchModeTask.groovy
@@ -2,13 +2,33 @@ package wooga.gradle.unity.tasks
 
 import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.Optional
+import org.gradle.api.tasks.TaskAction
+import org.gradle.process.ExecResult
+import wooga.gradle.unity.batchMode.BaseBatchModeSpec
+import wooga.gradle.unity.batchMode.BatchModeAction
 import wooga.gradle.unity.batchMode.BatchModeSpec
 import wooga.gradle.unity.batchMode.BuildTarget
 
 abstract class AbstractBatchModeTask extends AbstractUnityTask implements BatchModeSpec {
 
+    @Delegate(excludeTypes = [ExecuteExclude.class], interfaces = false)
+    protected BatchModeAction batchModeAction
+
+    private ExecResult batchModeResult
+
     AbstractBatchModeTask(Class taskType) {
         super(taskType)
+        this.batchModeAction = retrieveBatchModeActionFactory().create()
+    }
+
+    @Override
+    BaseBatchModeSpec retrieveAction() {
+        return batchModeAction
+    }
+
+    @TaskAction
+    protected void exec() {
+        batchModeResult = batchModeAction.execute()
     }
 
     /**
@@ -46,5 +66,13 @@ abstract class AbstractBatchModeTask extends AbstractUnityTask implements BatchM
     @Override
     Boolean getNoGraphics() {
         batchModeAction.noGraphics
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Input
+    boolean isIgnoreExitValue() {
+        return batchModeAction.isIgnoreExitValue()
     }
 }

--- a/src/main/groovy/wooga/gradle/unity/tasks/AbstractUnityTask.groovy
+++ b/src/main/groovy/wooga/gradle/unity/tasks/AbstractUnityTask.groovy
@@ -17,11 +17,9 @@
 
 package wooga.gradle.unity.tasks
 
-import org.gradle.api.DefaultTask
 import org.gradle.api.InvalidUserDataException
 import org.gradle.api.internal.ConventionMapping
 import org.gradle.api.internal.ConventionTask
-import org.gradle.api.internal.IConventionAware
 import org.gradle.api.logging.Logger
 import org.gradle.api.logging.Logging
 import org.gradle.api.tasks.Input
@@ -32,13 +30,12 @@ import org.gradle.internal.Factory
 import org.gradle.process.ExecResult
 import org.gradle.process.internal.ExecException
 import wooga.gradle.unity.UnityPluginExtension
+import wooga.gradle.unity.batchMode.BaseBatchModeSpec
 import wooga.gradle.unity.batchMode.BatchModeAction
-import wooga.gradle.unity.batchMode.BatchModeSpec
-import wooga.gradle.unity.batchMode.BuildTarget
 
 import java.util.concurrent.Callable
 
-abstract class AbstractUnityTask<T extends AbstractUnityTask> extends ConventionTask implements BatchModeSpec, IConventionAware, ConventionMapping {
+abstract class AbstractUnityTask<T extends AbstractUnityTask> extends ConventionTask implements BaseBatchModeSpec, ConventionMapping {
 
     static Logger logger = Logging.getLogger(AbstractUnityTask)
 
@@ -49,7 +46,7 @@ abstract class AbstractUnityTask<T extends AbstractUnityTask> extends Convention
     }
 
     @Delegate(excludeTypes = [ExecuteExclude.class], interfaces = false)
-    private BatchModeAction batchModeAction
+    protected BatchModeAction batchModeAction
 
     private ExecResult batchModeResult
 
@@ -96,43 +93,6 @@ abstract class AbstractUnityTask<T extends AbstractUnityTask> extends Convention
         batchModeAction.logFile
     }
 
-    @Optional
-    @Input
-    @Override
-    BuildTarget getBuildTarget() {
-        batchModeAction.buildTarget
-    }
-
-    @Optional
-    @Input
-    @Override
-    Boolean getBatchMode() {
-        return batchModeAction.batchMode
-    }
-
-    @Optional
-    @Input
-    @Override
-    Boolean getQuit() {
-        return batchModeAction.quit
-    }
-
-    @Optional
-    @Input
-    @Override
-    Boolean getNoGraphics() {
-        batchModeAction.noGraphics
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    @Optional
-    @Input
-    List<String> getArgs() {
-        return batchModeAction.getArgs()
-    }
-
     /**
      * {@inheritDoc}
      */
@@ -151,14 +111,18 @@ abstract class AbstractUnityTask<T extends AbstractUnityTask> extends Convention
         return batchModeResult
     }
 
+    ConventionMapping retrieveActionMapping() {
+        this.batchModeAction.conventionMapping
+    }
+
     @Override
     ConventionMapping.MappedProperty map(String propertyName, Closure<?> value) {
 
         def result
-        try{
-            result = this.batchModeAction.conventionMapping.map(propertyName, value)
+        try {
+            result = retrieveActionMapping().map(propertyName, value)
         }
-        catch(InvalidUserDataException ignored){
+        catch (InvalidUserDataException ignored) {
             result = super.conventionMapping.map(propertyName, value)
         }
         result
@@ -167,10 +131,10 @@ abstract class AbstractUnityTask<T extends AbstractUnityTask> extends Convention
     @Override
     ConventionMapping.MappedProperty map(String propertyName, Callable<?> value) {
         def result
-        try{
-            result = this.batchModeAction.conventionMapping.map(propertyName, value)
+        try {
+            result = retrieveActionMapping().map(propertyName, value)
         }
-        catch(InvalidUserDataException ignored){
+        catch (InvalidUserDataException ignored) {
             result = super.conventionMapping.map(propertyName, value)
         }
         result
@@ -178,7 +142,7 @@ abstract class AbstractUnityTask<T extends AbstractUnityTask> extends Convention
 
     @Override
     <T> T getConventionValue(T actualValue, String propertyName, boolean isExplicitValue) {
-        this.batchModeAction.conventionMapping.getConventionValue(actualValue, propertyName, isExplicitValue) ?:
+        retrieveActionMapping().getConventionValue(actualValue, propertyName, isExplicitValue) ?:
                 super.conventionMapping.getConventionValue(actualValue, propertyName, isExplicitValue)
     }
 

--- a/src/main/groovy/wooga/gradle/unity/tasks/AbstractUnityTask.groovy
+++ b/src/main/groovy/wooga/gradle/unity/tasks/AbstractUnityTask.groovy
@@ -25,7 +25,6 @@ import org.gradle.api.logging.Logging
 import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.Internal
 import org.gradle.api.tasks.Optional
-import org.gradle.api.tasks.TaskAction
 import org.gradle.internal.Factory
 import org.gradle.process.ExecResult
 import org.gradle.process.internal.ExecException
@@ -45,11 +44,9 @@ abstract class AbstractUnityTask<T extends AbstractUnityTask> extends Convention
         ExecResult execute() throws ExecException
     }
 
-    @Delegate(excludeTypes = [ExecuteExclude.class], interfaces = false)
-    protected BatchModeAction batchModeAction
+    abstract BaseBatchModeSpec retrieveAction()
 
-    private ExecResult batchModeResult
-
+    
     protected Factory<BatchModeAction> retrieveBatchModeActionFactory() {
         return retrieveDefaultUnityExtension().batchModeActionFactory
     }
@@ -59,7 +56,6 @@ abstract class AbstractUnityTask<T extends AbstractUnityTask> extends Convention
     }
 
     AbstractUnityTask(Class<T> taskType) {
-        this.batchModeAction = retrieveBatchModeActionFactory().create()
         this.taskType = taskType
     }
 
@@ -67,38 +63,25 @@ abstract class AbstractUnityTask<T extends AbstractUnityTask> extends Convention
         this
     }
 
-    @TaskAction
-    protected void exec() {
-        batchModeResult = batchModeAction.execute()
-    }
-
     @Optional
     @Input
     @Override
     File getUnityPath() {
-        batchModeAction.unityPath
+        retrieveAction().unityPath
     }
 
     @Optional
     @Input
     @Override
     File getProjectPath() {
-        batchModeAction.projectPath
+        retrieveAction().projectPath
     }
 
     @Optional
     @Internal
     @Override
     File getLogFile() {
-        batchModeAction.logFile
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    @Input
-    boolean isIgnoreExitValue() {
-        return batchModeAction.isIgnoreExitValue()
+        retrieveAction().logFile
     }
 
     /**
@@ -112,7 +95,7 @@ abstract class AbstractUnityTask<T extends AbstractUnityTask> extends Convention
     }
 
     ConventionMapping retrieveActionMapping() {
-        this.batchModeAction.conventionMapping
+        this.retrieveAction().conventionMapping
     }
 
     @Override
@@ -145,6 +128,4 @@ abstract class AbstractUnityTask<T extends AbstractUnityTask> extends Convention
         retrieveActionMapping().getConventionValue(actualValue, propertyName, isExplicitValue) ?:
                 super.conventionMapping.getConventionValue(actualValue, propertyName, isExplicitValue)
     }
-
-
 }

--- a/src/main/groovy/wooga/gradle/unity/tasks/Activate.groovy
+++ b/src/main/groovy/wooga/gradle/unity/tasks/Activate.groovy
@@ -18,9 +18,7 @@
 package wooga.gradle.unity.tasks
 
 import org.gradle.api.Action
-import org.gradle.api.DefaultTask
 import org.gradle.api.internal.ConventionMapping
-import org.gradle.api.internal.IConventionAware
 import org.gradle.api.specs.Spec
 import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.Optional
@@ -33,7 +31,7 @@ import wooga.gradle.unity.UnityPluginExtension
 import wooga.gradle.unity.batchMode.ActivationAction
 import wooga.gradle.unity.batchMode.ActivationSpec
 
-class Activate extends DefaultTask implements ActivationSpec, IConventionAware {
+class Activate extends AbstractUnityTask implements ActivationSpec {
 
     @Override
     ConventionMapping getConventionMapping() {
@@ -54,6 +52,7 @@ class Activate extends DefaultTask implements ActivationSpec, IConventionAware {
     }
 
     Activate() {
+        super(Activate.class)
         this.activationAction = retrieveActivationActionFactory().create()
         onlyIf(new Spec<Activate>() {
             @Override
@@ -114,5 +113,10 @@ class Activate extends DefaultTask implements ActivationSpec, IConventionAware {
     Activate logFile(Object file) {
         activationAction.logFile(file)
         return this
+    }
+
+    @Override
+    ConventionMapping retrieveActionMapping() {
+        return this.activationAction.conventionMapping
     }
 }

--- a/src/main/groovy/wooga/gradle/unity/tasks/Activate.groovy
+++ b/src/main/groovy/wooga/gradle/unity/tasks/Activate.groovy
@@ -30,8 +30,14 @@ import wooga.gradle.unity.UnityAuthentication
 import wooga.gradle.unity.UnityPluginExtension
 import wooga.gradle.unity.batchMode.ActivationAction
 import wooga.gradle.unity.batchMode.ActivationSpec
+import wooga.gradle.unity.batchMode.BaseBatchModeSpec
 
 class Activate extends AbstractUnityTask implements ActivationSpec {
+
+    @Override
+    BaseBatchModeSpec retrieveAction() {
+        return activationAction
+    }
 
     @Override
     ConventionMapping getConventionMapping() {
@@ -97,26 +103,11 @@ class Activate extends AbstractUnityTask implements ActivationSpec {
         return this
     }
 
-    @Override
-    Activate unityPath(File path) {
-        activationAction.unityPath(path)
-        return this
-    }
-
-    @Override
-    Activate projectPath(File path) {
-        activationAction.projectPath(path)
-        return this
-    }
-
-    @Override
-    Activate logFile(Object file) {
-        activationAction.logFile(file)
-        return this
-    }
-
-    @Override
-    ConventionMapping retrieveActionMapping() {
-        return this.activationAction.conventionMapping
+    /**
+     * {@inheritDoc}
+     */
+    @Input
+    boolean isIgnoreExitValue() {
+        return activationAction.isIgnoreExitValue()
     }
 }

--- a/src/main/groovy/wooga/gradle/unity/tasks/Activate.groovy
+++ b/src/main/groovy/wooga/gradle/unity/tasks/Activate.groovy
@@ -19,7 +19,8 @@ package wooga.gradle.unity.tasks
 
 import org.gradle.api.Action
 import org.gradle.api.DefaultTask
-import org.gradle.api.internal.ConventionTask
+import org.gradle.api.internal.ConventionMapping
+import org.gradle.api.internal.IConventionAware
 import org.gradle.api.specs.Spec
 import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.Optional
@@ -32,23 +33,28 @@ import wooga.gradle.unity.UnityPluginExtension
 import wooga.gradle.unity.batchMode.ActivationAction
 import wooga.gradle.unity.batchMode.ActivationSpec
 
-class Activate extends ConventionTask implements ActivationSpec {
+class Activate extends DefaultTask implements ActivationSpec, IConventionAware {
+
+    @Override
+    ConventionMapping getConventionMapping() {
+        return activationAction.conventionMapping
+    }
 
     private interface ExecuteExclude {
         ExecResult execute() throws ExecException
     }
 
-    @Delegate(excludeTypes=[ExecuteExclude.class], interfaces = false)
+    @Delegate(excludeTypes = [ExecuteExclude.class], interfaces = false)
     ActivationAction activationAction
 
     private ExecResult batchModeResult
 
-    protected Factory<ActivationAction> getActivationActionFactory() {
+    protected Factory<ActivationAction> retrieveActivationActionFactory() {
         return project.extensions.getByType(UnityPluginExtension).activationActionFactory
     }
 
     Activate() {
-        this.activationAction = getActivationActionFactory().create()
+        this.activationAction = retrieveActivationActionFactory().create()
         onlyIf(new Spec<Activate>() {
             @Override
             boolean isSatisfiedBy(Activate task) {

--- a/src/main/groovy/wooga/gradle/unity/tasks/ReturnLicense.groovy
+++ b/src/main/groovy/wooga/gradle/unity/tasks/ReturnLicense.groovy
@@ -17,7 +17,7 @@
 
 package wooga.gradle.unity.tasks
 
-import org.gradle.api.internal.ConventionTask
+import org.gradle.api.internal.ConventionMapping
 import org.gradle.api.tasks.InputDirectory
 import org.gradle.api.tasks.SkipWhenEmpty
 import org.gradle.api.tasks.TaskAction
@@ -26,24 +26,24 @@ import org.gradle.process.ExecResult
 import org.gradle.process.internal.ExecException
 import wooga.gradle.unity.UnityPluginExtension
 import wooga.gradle.unity.batchMode.ActivationAction
-import wooga.gradle.unity.batchMode.BaseBatchModeSpec
 
-class ReturnLicense extends ConventionTask implements BaseBatchModeSpec {
+class ReturnLicense extends AbstractUnityTask {
 
     private interface ExecuteExclude {
         ExecResult execute() throws ExecException
     }
 
-    @Delegate(excludeTypes=[ExecuteExclude.class], interfaces = false)
+    @Delegate(excludeTypes = [ExecuteExclude.class], interfaces = false)
     ActivationAction activationAction
     private ExecResult batchModeResult
 
-    protected Factory<ActivationAction> getActivationActionFactory() {
+    protected Factory<ActivationAction> retrieveActivationActionFactory() {
         return project.extensions.getByType(UnityPluginExtension).activationActionFactory
     }
 
     ReturnLicense() {
-        this.activationAction = getActivationActionFactory().create()
+        super(ReturnLicense.class)
+        activationAction = retrieveActivationActionFactory().create()
     }
 
     private File dir
@@ -79,5 +79,10 @@ class ReturnLicense extends ConventionTask implements BaseBatchModeSpec {
     ReturnLicense logFile(Object file) {
         activationAction.logFile(file)
         return this
+    }
+
+    @Override
+    ConventionMapping retrieveActionMapping() {
+        return this.activationAction.conventionMapping
     }
 }

--- a/src/main/groovy/wooga/gradle/unity/tasks/ReturnLicense.groovy
+++ b/src/main/groovy/wooga/gradle/unity/tasks/ReturnLicense.groovy
@@ -18,6 +18,7 @@
 package wooga.gradle.unity.tasks
 
 import org.gradle.api.internal.ConventionMapping
+import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.InputDirectory
 import org.gradle.api.tasks.SkipWhenEmpty
 import org.gradle.api.tasks.TaskAction
@@ -26,6 +27,7 @@ import org.gradle.process.ExecResult
 import org.gradle.process.internal.ExecException
 import wooga.gradle.unity.UnityPluginExtension
 import wooga.gradle.unity.batchMode.ActivationAction
+import wooga.gradle.unity.batchMode.BaseBatchModeSpec
 
 class ReturnLicense extends AbstractUnityTask {
 
@@ -82,7 +84,15 @@ class ReturnLicense extends AbstractUnityTask {
     }
 
     @Override
-    ConventionMapping retrieveActionMapping() {
-        return this.activationAction.conventionMapping
+    BaseBatchModeSpec retrieveAction() {
+        return activationAction
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Input
+    boolean isIgnoreExitValue() {
+        return activationAction.isIgnoreExitValue()
     }
 }

--- a/src/main/groovy/wooga/gradle/unity/tasks/Test.groovy
+++ b/src/main/groovy/wooga/gradle/unity/tasks/Test.groovy
@@ -38,7 +38,7 @@ import wooga.gradle.unity.utils.ProjectSettings
 
 import javax.inject.Inject
 
-class Test extends AbstractUnityTask implements Reporting<UnityTestTaskReport> {
+class Test extends AbstractBatchModeTask implements Reporting<UnityTestTaskReport> {
 
     static Logger logger = Logging.getLogger(Test)
 

--- a/src/main/groovy/wooga/gradle/unity/tasks/Unity.groovy
+++ b/src/main/groovy/wooga/gradle/unity/tasks/Unity.groovy
@@ -17,7 +17,7 @@
 
 package wooga.gradle.unity.tasks
 
-class Unity extends AbstractUnityTask {
+class Unity extends AbstractBatchModeTask {
 
     Unity() {
         super(Unity.class)

--- a/src/main/groovy/wooga/gradle/unity/tasks/UnityPackage.groovy
+++ b/src/main/groovy/wooga/gradle/unity/tasks/UnityPackage.groovy
@@ -31,7 +31,7 @@ import wooga.gradle.unity.batchMode.BatchModeFlags
 
 import javax.inject.Inject
 
-class UnityPackage extends AbstractUnityTask {
+class UnityPackage extends AbstractBatchModeTask {
 
     private final FileResolver fileResolver
     private FileCollection inputFiles


### PR DESCRIPTION
## Description
In order to streamline our plugins structure, we want to make more use of convention mapping as described here: http://mrhaki.blogspot.de/2010/10/gradle-goodness-set-task-values-with.html 

## Changes
* ![CHANGE] set values by convention mappings 
* ![CHANGE] Refactor Actions and Tasks




[NEW]:https://atlas-resources.wooga.com/icons/icon_new.svg "New"
[ADD]:http://resources.atlas.wooga.com/icons/icon_add.svg "Add"
[IMPROVE]:http://resources.atlas.wooga.com/icons/icon_improve.svg "IMPROVE"
[CHANGE]:http://resources.atlas.wooga.com/icons/icon_change.svg "Change"
[FIX]:http://resources.atlas.wooga.com/icons/icon_fix.svg "Fix"
[UPDATE]:http://resources.atlas.wooga.com/icons/icon_update.svg "Update"

[BREAK]:http://resources.atlas.wooga.com/icons/icon_break.svg "Remove"
[REMOVE]:http://resources.atlas.wooga.com/icons/icon_remove.svg "Remove"
[IOS]:http://resources.atlas.wooga.com/icons/icon_iOS.svg "iOS"
[ANDROID]:http://resources.atlas.wooga.com/icons/icon_android.svg "Android"
[WEBGL]:http://resources.atlas.wooga.com/icons/icon_webGL.svg "Web:GL"
