### PR TITLE
Add property logCategory

### DIFF
--- a/src/integrationTest/groovy/wooga/gradle/unity/BaseBatchModeIntegrationSpec.groovy
+++ b/src/integrationTest/groovy/wooga/gradle/unity/BaseBatchModeIntegrationSpec.groovy
@@ -201,7 +201,7 @@ class BaseBatchModeIntegrationSpec extends UnityIntegrationSpec {
 
         then:
         result.wasExecuted("mUnity")
-        def resultPath = escapedPath(new File(projectDir, "/build/logs/${path}").getPath())
+        def resultPath = new File(projectDir, "/build/logs/${path}").getPath()
         result.standardOutput.contains("-logFile ${resultPath}")
 
         where:

--- a/src/integrationTest/groovy/wooga/gradle/unity/BaseBatchModeIntegrationSpec.groovy
+++ b/src/integrationTest/groovy/wooga/gradle/unity/BaseBatchModeIntegrationSpec.groovy
@@ -177,7 +177,7 @@ class BaseBatchModeIntegrationSpec extends UnityIntegrationSpec {
     }
 
     @Unroll
-    def "set logCategory by task to #value with getter #useGetter to #path"() {
+    def "set logCategory by task to #value with getter #useGetter"() {
         given: ""
         buildFile << """
             task (mUnity, type: ${Unity.name}) {

--- a/src/integrationTest/groovy/wooga/gradle/unity/BaseBatchModeIntegrationSpec.groovy
+++ b/src/integrationTest/groovy/wooga/gradle/unity/BaseBatchModeIntegrationSpec.groovy
@@ -235,7 +235,7 @@ class BatchModeIntegrationSpec extends IntegrationSpec {
     }
 
     @Unroll
-    @Ignore
+    @Ignore("test occasionally fails on jenkins")
     //test occasionally fails on jenkins
     //@IgnoreIf({ System.getProperty("os.name").toLowerCase().contains("windows") })
     def "redirects unity log to stdout when redirectStdOut is set to true for #taskType"() {

--- a/src/integrationTest/groovy/wooga/gradle/unity/BaseBatchModeIntegrationSpec.groovy
+++ b/src/integrationTest/groovy/wooga/gradle/unity/BaseBatchModeIntegrationSpec.groovy
@@ -201,7 +201,7 @@ class BaseBatchModeIntegrationSpec extends UnityIntegrationSpec {
 
         then:
         result.wasExecuted("mUnity")
-        def resultPath = escapedPath("${projectDir}/build/logs/${path}")
+        def resultPath = escapedPath(new File(projectDir, "/build/logs/${path}").getPath())
         result.standardOutput.contains("-logFile ${resultPath}")
 
         where:

--- a/src/integrationTest/groovy/wooga/gradle/unity/BaseBatchModeIntegrationSpec.groovy
+++ b/src/integrationTest/groovy/wooga/gradle/unity/BaseBatchModeIntegrationSpec.groovy
@@ -2,6 +2,7 @@ package wooga.gradle.unity
 
 import nebula.test.IntegrationSpec
 import org.apache.commons.lang.StringEscapeUtils
+import spock.lang.Ignore
 import spock.lang.IgnoreIf
 import spock.lang.Unroll
 import wooga.gradle.unity.tasks.*
@@ -241,7 +242,8 @@ class BatchModeIntegrationSpec extends IntegrationSpec {
     }
 
     @Unroll
-    @IgnoreIf({ System.getProperty("os.name").toLowerCase().contains("windows") })
+    @Ignore //test occasionally fails on jenkins
+    //@IgnoreIf({ System.getProperty("os.name").toLowerCase().contains("windows") })
     def "redirects unity log to stdout when redirectStdOut is set to true for #taskType"() {
         given: "a custom build task"
         buildFile << """

--- a/src/integrationTest/groovy/wooga/gradle/unity/BaseBatchModeIntegrationSpec.groovy
+++ b/src/integrationTest/groovy/wooga/gradle/unity/BaseBatchModeIntegrationSpec.groovy
@@ -178,24 +178,14 @@ class BaseBatchModeIntegrationSpec extends UnityIntegrationSpec {
     }
 
     @Unroll
-    def "set logCategory by task to #value with getter #useGetter"() {
-        given: ""
+    def "set log category with #method to #value"() {
+        given:
         buildFile << """
-            task (mUnity, type: ${Unity.name}) {
-
-            }
-        """.stripIndent()
-
-        and:
-        if (useGetter) {
-            buildFile << """
-            mUnity.setLogCategory("${value}")
-        """.stripIndent()
-        } else {
-            buildFile << """
-            mUnity.logCategory = "${value}"
-        """.stripIndent()
+        
+        task (mUnity, type: ${Unity.name}) {
+            $method("${value}") 
         }
+        """.stripIndent()
 
         when:
         def result = runTasksSuccessfully("mUnity")
@@ -206,11 +196,14 @@ class BaseBatchModeIntegrationSpec extends UnityIntegrationSpec {
         result.standardOutput.contains("-logFile ${resultPath}")
 
         where:
-        value    | useGetter | path
-        "hello1" | true      | "hello1/mUnity.log"
-        "hello1" | false     | "hello1/mUnity.log"
-        ""       | true      | "mUnity.log"
-        ""       | false     | "mUnity.log"
+        value        | useSetter | path
+        "helloworld" | true      | "helloworld/mUnity.log"
+        "helloworld" | false     | "helloworld/mUnity.log"
+        ""           | true      | "mUnity.log"
+        ""           | false     | "mUnity.log"
+
+        method = (useSetter) ? "setLogCategory" : "logCategory"
+
     }
 
 }
@@ -242,7 +235,8 @@ class BatchModeIntegrationSpec extends IntegrationSpec {
     }
 
     @Unroll
-    @Ignore //test occasionally fails on jenkins
+    @Ignore
+    //test occasionally fails on jenkins
     //@IgnoreIf({ System.getProperty("os.name").toLowerCase().contains("windows") })
     def "redirects unity log to stdout when redirectStdOut is set to true for #taskType"() {
         given: "a custom build task"

--- a/src/integrationTest/groovy/wooga/gradle/unity/PluginConfigurationSpec.groovy
+++ b/src/integrationTest/groovy/wooga/gradle/unity/PluginConfigurationSpec.groovy
@@ -17,9 +17,7 @@
 
 package wooga.gradle.unity
 
-import spock.lang.Shared
 import spock.lang.Unroll
-import spock.util.environment.RestoreSystemProperties
 
 /**
  * Spec test for basic configuration of the plugin
@@ -77,8 +75,8 @@ class PluginConfigurationSpec extends UnityIntegrationSpec {
         result.standardOutput.contains("$property: ${path.path}")
 
         where:
-        property    | expectedPath
-        'assetsDir' | "Assets"
+        property     | expectedPath
+        'assetsDir'  | "Assets"
         'pluginsDir' | "Assets/Plugins"
     }
 }

--- a/src/main/groovy/wooga/gradle/unity/DefaultUnityPluginExtension.groovy
+++ b/src/main/groovy/wooga/gradle/unity/DefaultUnityPluginExtension.groovy
@@ -42,6 +42,8 @@ class DefaultUnityPluginExtension implements UnityPluginExtension {
 
     static final String UNITY_PATH_OPTION = "unity.path"
     static final String UNITY_PATH_ENV_VAR = "UNITY_PATH"
+    static final String UNITY_LOG_CATEGORY_OPTION = "unity.logCategory"
+    static final String UNITY_LOG_CATEGORY_ENV_VAR = "UNITY_LOG_CATEGORY"
 
     static final String REDIRECT_STDOUT_OPTION = "unity.redirectStdout"
     static final String REDIRECT_STDOUT_ENV_VAR = "UNITY_REDIRECT_STDOUT"
@@ -84,6 +86,7 @@ class DefaultUnityPluginExtension implements UnityPluginExtension {
     private Object defaultBuildTarget
     private final List<Object> testBuildTargets = new ArrayList<Object>()
     private Boolean redirectStdOut = false
+    private String logCategory
 
     static File getUnityPathFromEnv(Map<String, ?> properties, Map<String, String> env) {
         String unityPath = properties[UNITY_PATH_OPTION] ?: env[UNITY_PATH_ENV_VAR]
@@ -93,6 +96,11 @@ class DefaultUnityPluginExtension implements UnityPluginExtension {
             return null
         }
     }
+
+    static String getUnityLogCategory(Map<String, ?> properties, Map<String, String> env) {
+        properties[UNITY_LOG_CATEGORY_OPTION] ?: env[UNITY_LOG_CATEGORY_ENV_VAR]
+    }
+
 
     File getUnityPath() {
         File unityPath
@@ -287,6 +295,22 @@ class DefaultUnityPluginExtension implements UnityPluginExtension {
     }
 
     @Override
+    void setLogCategory(String value) {
+        logCategory = value
+    }
+
+    @Override
+    String getLogCategory() {
+        return (logCategory ?: getUnityLogCategory(project.properties, System.getenv())) ?: ""
+    }
+
+    @Override
+    UnityPluginExtension logCategory(String value) {
+        this.setLogCategory(value)
+        return this
+    }
+
+    @Override
     BuildTarget getDefaultBuildTarget() {
         if (!defaultBuildTarget) {
             return BuildTarget.undefined
@@ -398,5 +422,4 @@ class DefaultUnityPluginExtension implements UnityPluginExtension {
 
         return EnumSet.copyOf(targets)
     }
-
 }

--- a/src/main/groovy/wooga/gradle/unity/DefaultUnityPluginExtension.groovy
+++ b/src/main/groovy/wooga/gradle/unity/DefaultUnityPluginExtension.groovy
@@ -359,6 +359,7 @@ class DefaultUnityPluginExtension implements UnityPluginExtension {
     @Override
     ExecResult activate(Action<? super ActivationSpec> action) {
         ActivationAction activationAction = activationActionFactory.create()
+        //TODO: configure action
         action.execute(activationAction)
         return activationAction.activate()
     }

--- a/src/main/groovy/wooga/gradle/unity/DefaultUnityPluginExtension.groovy
+++ b/src/main/groovy/wooga/gradle/unity/DefaultUnityPluginExtension.groovy
@@ -358,7 +358,6 @@ class DefaultUnityPluginExtension implements UnityPluginExtension {
     @Override
     ExecResult activate(Action<? super ActivationSpec> action) {
         ActivationAction activationAction = activationActionFactory.create()
-        //TODO: configure action
         action.execute(activationAction)
         return activationAction.activate()
     }

--- a/src/main/groovy/wooga/gradle/unity/DefaultUnityPluginExtension.groovy
+++ b/src/main/groovy/wooga/gradle/unity/DefaultUnityPluginExtension.groovy
@@ -101,7 +101,6 @@ class DefaultUnityPluginExtension implements UnityPluginExtension {
         properties[UNITY_LOG_CATEGORY_OPTION] ?: env[UNITY_LOG_CATEGORY_ENV_VAR]
     }
 
-
     File getUnityPath() {
         File unityPath
         if (customUnityPath) {
@@ -217,7 +216,7 @@ class DefaultUnityPluginExtension implements UnityPluginExtension {
 
     @Override
     DefaultUnityPluginExtension unityPath(Object path) {
-        customUnityPath = fileResolver.resolveLater(path)
+        this.setUnityPath(path)
         this
     }
 

--- a/src/main/groovy/wooga/gradle/unity/UnityPlugin.groovy
+++ b/src/main/groovy/wooga/gradle/unity/UnityPlugin.groovy
@@ -118,7 +118,7 @@ class UnityPlugin implements Plugin<Project> {
                 ConventionMapping taskConventionMapping = task.conventionMapping
                 applyBaseConvention(taskConventionMapping, extension)
                 taskConventionMapping.logFile = {
-                    project.file("${project.buildDir}/logs${task.getLogCategory()}/${task.name}.log")
+                    project.file("${project.buildDir}/logs/${task.getLogCategory()}/${task.name}.log")
                 }
             }
         })

--- a/src/main/groovy/wooga/gradle/unity/UnityPlugin.groovy
+++ b/src/main/groovy/wooga/gradle/unity/UnityPlugin.groovy
@@ -132,10 +132,9 @@ class UnityPlugin implements Plugin<Project> {
         Task activationTask = project.tasks[ACTIVATE_TASK_NAME]
         Task returnLicenseTask = project.tasks[RETURN_LICENSE_TASK_NAME]
 
-        project.getTasks().withType(AbstractBatchModeTask, new Action<AbstractBatchModeTask>() {
+        project.getTasks().withType(AbstractUnityTask, new Action<AbstractUnityTask>() {
             @Override
-            void execute(AbstractBatchModeTask task) {
-
+            void execute(AbstractUnityTask task) {
                 if (extension.autoActivateUnity) {
                     task.dependsOn activationTask
                 }

--- a/src/main/groovy/wooga/gradle/unity/UnityPlugin.groovy
+++ b/src/main/groovy/wooga/gradle/unity/UnityPlugin.groovy
@@ -118,7 +118,7 @@ class UnityPlugin implements Plugin<Project> {
                 ConventionMapping taskConventionMapping = task.conventionMapping
                 applyBaseConvention(taskConventionMapping, extension)
                 taskConventionMapping.logFile = {
-                    project.file("${project.buildDir}/logs/${task.name}.log")
+                    project.file("${project.buildDir}/logs${task.getLogCategory()}/${task.name}.log")
                 }
             }
         })
@@ -126,6 +126,7 @@ class UnityPlugin implements Plugin<Project> {
 
     static void applyBaseConvention(ConventionMapping taskConventionMapping, UnityPluginExtension extension) {
         taskConventionMapping.map "unityPath", { extension.unityPath }
+        taskConventionMapping.logCategory = { extension.logCategory }
     }
 
     private void configureAutoActivationDeactivation(final Project project, final UnityPluginExtension extension) {

--- a/src/main/groovy/wooga/gradle/unity/UnityPlugin.groovy
+++ b/src/main/groovy/wooga/gradle/unity/UnityPlugin.groovy
@@ -133,9 +133,10 @@ class UnityPlugin implements Plugin<Project> {
         Task activationTask = project.tasks[ACTIVATE_TASK_NAME]
         Task returnLicenseTask = project.tasks[RETURN_LICENSE_TASK_NAME]
 
-        project.getTasks().withType(AbstractUnityTask, new Action<AbstractUnityTask>() {
+        project.getTasks().withType(AbstractBatchModeTask, new Action<AbstractBatchModeTask>() {
             @Override
-            void execute(AbstractUnityTask task) {
+            void execute(AbstractBatchModeTask task) {
+
                 if (extension.autoActivateUnity) {
                     task.dependsOn activationTask
                 }

--- a/src/main/groovy/wooga/gradle/unity/UnityPluginExtension.groovy
+++ b/src/main/groovy/wooga/gradle/unity/UnityPluginExtension.groovy
@@ -24,13 +24,13 @@ import wooga.gradle.unity.batchMode.*
 
 interface UnityPluginExtension extends UnityPluginTestExtension {
 
-    File getUnityPath()
-
     void setUnityPath(Object path)
 
-    File getUnityLicenseDirectory()
+    File getUnityPath()
 
     UnityPluginExtension unityPath(Object path)
+
+    File getUnityLicenseDirectory()
 
     File getProjectPath()
 

--- a/src/main/groovy/wooga/gradle/unity/UnityPluginExtension.groovy
+++ b/src/main/groovy/wooga/gradle/unity/UnityPluginExtension.groovy
@@ -105,4 +105,11 @@ interface UnityPluginExtension extends UnityPluginTestExtension {
     void setRedirectStdOut(Boolean redirect)
 
     UnityPluginExtension redirectStdOut(Boolean redirect)
+
+    void setLogCategory(String value)
+
+    String getLogCategory()
+
+    UnityPluginExtension logCategory(String value)
+
 }

--- a/src/main/groovy/wooga/gradle/unity/batchMode/BaseBatchModeSpec.groovy
+++ b/src/main/groovy/wooga/gradle/unity/batchMode/BaseBatchModeSpec.groovy
@@ -17,9 +17,7 @@
 
 package wooga.gradle.unity.batchMode
 
-import org.gradle.api.internal.IConventionAware
-
-interface BaseBatchModeSpec extends IConventionAware {
+interface BaseBatchModeSpec {
     File getUnityPath()
 
     BaseBatchModeSpec unityPath(File path)
@@ -39,4 +37,9 @@ interface BaseBatchModeSpec extends IConventionAware {
 
     BaseBatchModeSpec redirectStdOut(Boolean redirect)
     void setRedirectStdOut(Boolean redirect)
+
+    String getLogCategory()
+
+    BaseBatchModeSpec logCategory(String category)
+    void setLogCategory(String category)
 }

--- a/src/main/groovy/wooga/gradle/unity/batchMode/BaseBatchModeSpec.groovy
+++ b/src/main/groovy/wooga/gradle/unity/batchMode/BaseBatchModeSpec.groovy
@@ -17,29 +17,36 @@
 
 package wooga.gradle.unity.batchMode
 
-interface BaseBatchModeSpec {
+import org.gradle.api.internal.IConventionAware
+
+interface BaseBatchModeSpec extends IConventionAware {
     File getUnityPath()
 
     BaseBatchModeSpec unityPath(File path)
+
     void setUnityPath(File path)
 
     File getProjectPath()
 
     BaseBatchModeSpec projectPath(File path)
+
     void setProjectPath(File path)
 
     File getLogFile()
 
     BaseBatchModeSpec logFile(Object file)
+
     void setLogFile(Object file)
 
     Boolean getRedirectStdOut()
 
     BaseBatchModeSpec redirectStdOut(Boolean redirect)
+
     void setRedirectStdOut(Boolean redirect)
 
     String getLogCategory()
 
     BaseBatchModeSpec logCategory(String category)
+
     void setLogCategory(String category)
 }

--- a/src/main/groovy/wooga/gradle/unity/batchMode/DefaultBatchModeAction.groovy
+++ b/src/main/groovy/wooga/gradle/unity/batchMode/DefaultBatchModeAction.groovy
@@ -40,11 +40,15 @@ class DefaultBatchModeAction extends DefaultExecHandleBuilder implements BatchMo
     private final PathToFileResolver fileResolver
     private final ConventionMapping conventionMapping
 
-    private File customUnityPath
+    private File unityPath
     private File customProjectPath
     private BuildTarget customBuildTarget
     private String logCategory
 
+
+    //todo: use convention mapping, not extension -> logCategory
+
+    /*
     File getUnityPath() {
         if (customUnityPath) {
             return customUnityPath
@@ -56,6 +60,24 @@ class DefaultBatchModeAction extends DefaultExecHandleBuilder implements BatchMo
     void setUnityPath(File path) {
         customUnityPath = path
     }
+    */
+
+    @Override
+    File getUnityPath() {
+        this.unityPath
+    }
+
+    @Override
+    BaseBatchModeSpec unityPath(File value) {
+        this.setUnityPath(value)
+        return this
+    }
+
+    @Override
+    void setUnityPath(File value) {
+        this.unityPath = value
+    }
+
 
     File getProjectPath() {
         if (customProjectPath) {
@@ -218,11 +240,13 @@ class DefaultBatchModeAction extends DefaultExecHandleBuilder implements BatchMo
         return this
     }
 
+    /*
     @Override
     DefaultBatchModeAction unityPath(File path) {
         unityPath = path
         this
     }
+    */
 
     @Override
     DefaultBatchModeAction projectPath(File path) {

--- a/src/main/groovy/wooga/gradle/unity/batchMode/DefaultBatchModeAction.groovy
+++ b/src/main/groovy/wooga/gradle/unity/batchMode/DefaultBatchModeAction.groovy
@@ -40,7 +40,7 @@ class DefaultBatchModeAction extends DefaultExecHandleBuilder implements BatchMo
     private final PathToFileResolver fileResolver
     private final ConventionMapping conventionMapping
 
-    private File unityPath
+    private File customUnityPath
     private File customProjectPath
     private BuildTarget customBuildTarget
     private String logCategory
@@ -48,7 +48,7 @@ class DefaultBatchModeAction extends DefaultExecHandleBuilder implements BatchMo
 
     //todo: use convention mapping, not extension -> logCategory
 
-    /*
+
     File getUnityPath() {
         if (customUnityPath) {
             return customUnityPath
@@ -60,24 +60,24 @@ class DefaultBatchModeAction extends DefaultExecHandleBuilder implements BatchMo
     void setUnityPath(File path) {
         customUnityPath = path
     }
-    */
 
-    @Override
-    File getUnityPath() {
-        this.unityPath
-    }
+    /*
+   @Override
+   File getUnityPath() {
+       this.unityPath
+   }
 
-    @Override
-    BaseBatchModeSpec unityPath(File value) {
-        this.setUnityPath(value)
-        return this
-    }
+   @Override
+   BaseBatchModeSpec unityPath(File value) {
+       this.setUnityPath(value)
+       return this
+   }
 
-    @Override
-    void setUnityPath(File value) {
-        this.unityPath = value
-    }
-
+   @Override
+   void setUnityPath(File value) {
+       this.unityPath = value
+   }
+       */
 
     File getProjectPath() {
         if (customProjectPath) {
@@ -240,13 +240,11 @@ class DefaultBatchModeAction extends DefaultExecHandleBuilder implements BatchMo
         return this
     }
 
-    /*
     @Override
     DefaultBatchModeAction unityPath(File path) {
         unityPath = path
         this
     }
-    */
 
     @Override
     DefaultBatchModeAction projectPath(File path) {

--- a/src/main/groovy/wooga/gradle/unity/batchMode/DefaultBatchModeAction.groovy
+++ b/src/main/groovy/wooga/gradle/unity/batchMode/DefaultBatchModeAction.groovy
@@ -45,46 +45,24 @@ class DefaultBatchModeAction extends DefaultExecHandleBuilder implements BatchMo
     private BuildTarget customBuildTarget
     private String logCategory
 
-
-    //todo: use convention mapping, not extension -> logCategory
-
-
     File getUnityPath() {
         if (customUnityPath) {
             return customUnityPath
         }
 
-        return extension.unityPath
+        extension.unityPath
     }
 
     void setUnityPath(File path) {
         customUnityPath = path
     }
 
-    /*
-   @Override
-   File getUnityPath() {
-       this.unityPath
-   }
-
-   @Override
-   BaseBatchModeSpec unityPath(File value) {
-       this.setUnityPath(value)
-       return this
-   }
-
-   @Override
-   void setUnityPath(File value) {
-       this.unityPath = value
-   }
-       */
-
     File getProjectPath() {
         if (customProjectPath) {
             return customProjectPath
         }
 
-        return extension.projectPath
+        extension.projectPath
     }
 
     void setProjectPath(File path) {
@@ -111,11 +89,10 @@ class DefaultBatchModeAction extends DefaultExecHandleBuilder implements BatchMo
 
     @Override
     Boolean getRedirectStdOut() {
-        if(redirectStdOut) {
+        if (redirectStdOut) {
             return redirectStdOut
         }
-
-        return extension.redirectStdOut
+        extension.redirectStdOut
     }
 
     @Override
@@ -125,7 +102,10 @@ class DefaultBatchModeAction extends DefaultExecHandleBuilder implements BatchMo
 
     @Override
     String getLogCategory() {
-        this.logCategory
+        if (this.logCategory) {
+            return logCategory
+        }
+        extension.logCategory
     }
 
     @Override

--- a/src/main/groovy/wooga/gradle/unity/batchMode/DefaultBatchModeAction.groovy
+++ b/src/main/groovy/wooga/gradle/unity/batchMode/DefaultBatchModeAction.groovy
@@ -43,6 +43,7 @@ class DefaultBatchModeAction extends DefaultExecHandleBuilder implements BatchMo
     private File customUnityPath
     private File customProjectPath
     private BuildTarget customBuildTarget
+    private String logCategory
 
     File getUnityPath() {
         if (customUnityPath) {
@@ -98,6 +99,22 @@ class DefaultBatchModeAction extends DefaultExecHandleBuilder implements BatchMo
     @Override
     void setRedirectStdOut(Boolean redirect) {
         this.redirectStdOut = redirect
+    }
+
+    @Override
+    String getLogCategory() {
+        this.logCategory
+    }
+
+    @Override
+    BaseBatchModeSpec logCategory(String value) {
+        this.setLogCategory(value)
+        return this
+    }
+
+    @Override
+    void setLogCategory(String value) {
+        this.logCategory = value
     }
 
     BuildTarget getBuildTarget() {

--- a/src/main/groovy/wooga/gradle/unity/tasks/AbstractUnityTask.groovy
+++ b/src/main/groovy/wooga/gradle/unity/tasks/AbstractUnityTask.groovy
@@ -17,17 +17,14 @@
 
 package wooga.gradle.unity.tasks
 
-import org.gradle.api.DefaultTask
 import org.gradle.api.InvalidUserDataException
 import org.gradle.api.internal.ConventionMapping
 import org.gradle.api.internal.ConventionTask
-import org.gradle.api.internal.IConventionAware
 import org.gradle.api.logging.Logger
 import org.gradle.api.logging.Logging
 import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.Internal
 import org.gradle.api.tasks.Optional
-import org.gradle.api.tasks.TaskAction
 import org.gradle.internal.Factory
 import org.gradle.process.ExecResult
 import org.gradle.process.internal.ExecException
@@ -62,13 +59,6 @@ abstract class AbstractUnityTask<T extends AbstractUnityTask> extends Convention
         this.taskType = taskType
     }
 
-    private def getLogCategory() {
-        if (retrieveDefaultUnityExtension().logCategory != null || retrieveDefaultUnityExtension().logCategory != "") {
-            return "/${retrieveDefaultUnityExtension().logCategory}"
-        } else {
-            return ""
-        }
-    }
 
     ConventionMapping getConventionMapping() {
         this
@@ -95,6 +85,12 @@ abstract class AbstractUnityTask<T extends AbstractUnityTask> extends Convention
         retrieveAction().logFile
     }
 
+    @Optional
+    @Input
+    String getLogCategory() {
+        return retrieveAction().logCategory
+    }
+
     /**
      * Returns the result for the command run by this task. Returns {@code null} if this task has not been executed yet.
      *
@@ -109,11 +105,17 @@ abstract class AbstractUnityTask<T extends AbstractUnityTask> extends Convention
         this.retrieveAction().conventionMapping
     }
 
-    @Optional
-    @Input
-    String getLogCategory() {
-        return batchModeAction.logCategory
+
+
+    /*
+    private def getLogCategory() {
+        if (retrieveDefaultUnityExtension().logCategory != null || retrieveDefaultUnityExtension().logCategory != "") {
+            return "/${retrieveDefaultUnityExtension().logCategory}"
+        } else {
+            return ""
+        }
     }
+    */
 
     @Optional
     @Input

--- a/src/main/groovy/wooga/gradle/unity/tasks/AbstractUnityTask.groovy
+++ b/src/main/groovy/wooga/gradle/unity/tasks/AbstractUnityTask.groovy
@@ -104,8 +104,6 @@ abstract class AbstractUnityTask<T extends AbstractUnityTask> extends Convention
         this.retrieveAction().conventionMapping
     }
 
-    @Optional
-    @Input
     @Override
     ConventionMapping.MappedProperty map(String propertyName, Closure<?> value) {
 

--- a/src/main/groovy/wooga/gradle/unity/tasks/AbstractUnityTask.groovy
+++ b/src/main/groovy/wooga/gradle/unity/tasks/AbstractUnityTask.groovy
@@ -59,7 +59,6 @@ abstract class AbstractUnityTask<T extends AbstractUnityTask> extends Convention
         this.taskType = taskType
     }
 
-
     ConventionMapping getConventionMapping() {
         this
     }
@@ -104,18 +103,6 @@ abstract class AbstractUnityTask<T extends AbstractUnityTask> extends Convention
     ConventionMapping retrieveActionMapping() {
         this.retrieveAction().conventionMapping
     }
-
-
-
-    /*
-    private def getLogCategory() {
-        if (retrieveDefaultUnityExtension().logCategory != null || retrieveDefaultUnityExtension().logCategory != "") {
-            return "/${retrieveDefaultUnityExtension().logCategory}"
-        } else {
-            return ""
-        }
-    }
-    */
 
     @Optional
     @Input

--- a/src/main/groovy/wooga/gradle/unity/tasks/AbstractUnityTask.groovy
+++ b/src/main/groovy/wooga/gradle/unity/tasks/AbstractUnityTask.groovy
@@ -17,14 +17,17 @@
 
 package wooga.gradle.unity.tasks
 
+import org.gradle.api.DefaultTask
 import org.gradle.api.InvalidUserDataException
 import org.gradle.api.internal.ConventionMapping
 import org.gradle.api.internal.ConventionTask
+import org.gradle.api.internal.IConventionAware
 import org.gradle.api.logging.Logger
 import org.gradle.api.logging.Logging
 import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.Internal
 import org.gradle.api.tasks.Optional
+import org.gradle.api.tasks.TaskAction
 import org.gradle.internal.Factory
 import org.gradle.process.ExecResult
 import org.gradle.process.internal.ExecException
@@ -106,6 +109,14 @@ abstract class AbstractUnityTask<T extends AbstractUnityTask> extends Convention
         this.retrieveAction().conventionMapping
     }
 
+    @Optional
+    @Input
+    String getLogCategory() {
+        return batchModeAction.logCategory
+    }
+
+    @Optional
+    @Input
     @Override
     ConventionMapping.MappedProperty map(String propertyName, Closure<?> value) {
 

--- a/src/main/groovy/wooga/gradle/unity/tasks/AbstractUnityTask.groovy
+++ b/src/main/groovy/wooga/gradle/unity/tasks/AbstractUnityTask.groovy
@@ -46,7 +46,7 @@ abstract class AbstractUnityTask<T extends AbstractUnityTask> extends Convention
 
     abstract BaseBatchModeSpec retrieveAction()
 
-    
+
     protected Factory<BatchModeAction> retrieveBatchModeActionFactory() {
         return retrieveDefaultUnityExtension().batchModeActionFactory
     }
@@ -57,6 +57,14 @@ abstract class AbstractUnityTask<T extends AbstractUnityTask> extends Convention
 
     AbstractUnityTask(Class<T> taskType) {
         this.taskType = taskType
+    }
+
+    private def getLogCategory() {
+        if (retrieveDefaultUnityExtension().logCategory != null || retrieveDefaultUnityExtension().logCategory != "") {
+            return "/${retrieveDefaultUnityExtension().logCategory}"
+        } else {
+            return ""
+        }
     }
 
     ConventionMapping getConventionMapping() {

--- a/src/main/groovy/wooga/gradle/unity/tasks/Activate.groovy
+++ b/src/main/groovy/wooga/gradle/unity/tasks/Activate.groovy
@@ -18,9 +18,7 @@
 package wooga.gradle.unity.tasks
 
 import org.gradle.api.Action
-import org.gradle.api.DefaultTask
 import org.gradle.api.internal.ConventionMapping
-import org.gradle.api.internal.IConventionAware
 import org.gradle.api.specs.Spec
 import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.Optional

--- a/src/main/groovy/wooga/gradle/unity/tasks/Activate.groovy
+++ b/src/main/groovy/wooga/gradle/unity/tasks/Activate.groovy
@@ -18,7 +18,9 @@
 package wooga.gradle.unity.tasks
 
 import org.gradle.api.Action
+import org.gradle.api.DefaultTask
 import org.gradle.api.internal.ConventionMapping
+import org.gradle.api.internal.IConventionAware
 import org.gradle.api.specs.Spec
 import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.Optional

--- a/src/main/groovy/wooga/gradle/unity/tasks/UnityPackage.groovy
+++ b/src/main/groovy/wooga/gradle/unity/tasks/UnityPackage.groovy
@@ -18,8 +18,6 @@
 package wooga.gradle.unity.tasks
 
 import org.gradle.api.file.FileCollection
-import org.gradle.api.internal.ConventionAwareHelper
-import org.gradle.api.internal.ConventionMapping
 import org.gradle.api.internal.file.FileResolver
 import org.gradle.api.tasks.*
 import org.gradle.util.GUtil
@@ -30,14 +28,12 @@ import javax.inject.Inject
 
 class UnityPackage extends AbstractBatchModeTask {
 
-    private final ConventionMapping conventionMapping
     private final FileResolver fileResolver
     private FileCollection inputFiles
     private String baseName
     private String appendix
     private String version
     private String extension
-
 
     public static final String UNITY_PACKAGE_EXTENSION = "unitypackage"
 
@@ -141,19 +137,12 @@ class UnityPackage extends AbstractBatchModeTask {
         inputFiles(project.files([source]))
     }
 
-    @Override
-    ConventionMapping getConventionMapping() {
-        return this
-    }
-
     @Inject
     UnityPackage(FileResolver fileResolver) {
         super(UnityPackage.class)
-        this.conventionMapping = new ConventionAwareHelper(this, project.getConvention())
         this.fileResolver = fileResolver
         this.extension = UNITY_PACKAGE_EXTENSION
         outputs.upToDateWhen { false }
-
     }
 
     @TaskAction

--- a/src/main/groovy/wooga/gradle/unity/tasks/UnityPackage.groovy
+++ b/src/main/groovy/wooga/gradle/unity/tasks/UnityPackage.groovy
@@ -18,13 +18,10 @@
 package wooga.gradle.unity.tasks
 
 import org.gradle.api.file.FileCollection
+import org.gradle.api.internal.ConventionAwareHelper
+import org.gradle.api.internal.ConventionMapping
 import org.gradle.api.internal.file.FileResolver
-import org.gradle.api.tasks.InputFiles
-import org.gradle.api.tasks.Internal
-import org.gradle.api.tasks.OutputFile
-import org.gradle.api.tasks.SkipWhenEmpty
-import org.gradle.api.tasks.TaskAction
-import org.gradle.internal.Factory
+import org.gradle.api.tasks.*
 import org.gradle.util.GUtil
 import wooga.gradle.FileUtils
 import wooga.gradle.unity.batchMode.BatchModeFlags
@@ -33,12 +30,14 @@ import javax.inject.Inject
 
 class UnityPackage extends AbstractBatchModeTask {
 
+    private final ConventionMapping conventionMapping
     private final FileResolver fileResolver
     private FileCollection inputFiles
     private String baseName
     private String appendix
     private String version
     private String extension
+
 
     public static final String UNITY_PACKAGE_EXTENSION = "unitypackage"
 
@@ -142,12 +141,19 @@ class UnityPackage extends AbstractBatchModeTask {
         inputFiles(project.files([source]))
     }
 
+    @Override
+    ConventionMapping getConventionMapping() {
+        return this
+    }
+
     @Inject
     UnityPackage(FileResolver fileResolver) {
         super(UnityPackage.class)
+        this.conventionMapping = new ConventionAwareHelper(this, project.getConvention())
         this.fileResolver = fileResolver
         this.extension = UNITY_PACKAGE_EXTENSION
-        outputs.upToDateWhen {false}
+        outputs.upToDateWhen { false }
+
     }
 
     @TaskAction
@@ -157,7 +163,7 @@ class UnityPackage extends AbstractBatchModeTask {
         exportArgs << BatchModeFlags.EXPORT_PACKAGE
         Set exportFiles = []
         getInputFiles().each { File f ->
-            if(f.file) {
+            if (f.file) {
                 f = f.parentFile
             }
 

--- a/src/test/groovy/wooga/gradle/unity/DefaultUnityPluginExtensionSpec.groovy
+++ b/src/test/groovy/wooga/gradle/unity/DefaultUnityPluginExtensionSpec.groovy
@@ -315,6 +315,33 @@ class DefaultUnityPluginExtensionSpec extends Specification {
         expectedSize = source.size()
     }
 
+    def "set logCategory with properties"(){
+        given: "mock property in project"
+        def testCategory = "helloworld"
+
+        and:
+        projectProperties[DefaultUnityPluginExtension.UNITY_LOG_CATEGORY_OPTION] = testCategory
+
+        expect:
+        subject.logCategory == testCategory
+    }
+
+    def "get logCategory from env returns property value over env"() {
+        given: "logCategory set in properties"
+        def category = "highPriority"
+        def props = ['unity.logCategory': category]
+
+        and: "unity path in environment"
+        def newCategory = "lowPriority"
+        def env = ['UNITY_LOG_CATEGORY': newCategory]
+
+        when: "calling getUnityLogCategory"
+        def result = subject.getUnityLogCategory(props, env)
+
+        then: "file path points to props path"
+        result == category
+    }
+
     class BuildTargetTestObject {
 
         private def testValue


### PR DESCRIPTION
## Description
The logs for each tasks are based on the taskname. It would be nice to add another level so you can invoke gradle multiple times with different parameters without overriding the logs and reports. This is mainly for a jenkins workflow.

The default should be `""`. There should be the 3 typical ways to set/override it.
* property in task
* property in extension
* gradle parameter `-P...=`

resolves #15 

## Changes
* ![ADD] logCategory 




[NEW]:https://atlas-resources.wooga.com/icons/icon_new.svg "New"
[ADD]:http://resources.atlas.wooga.com/icons/icon_add.svg "Add"
[IMPROVE]:http://resources.atlas.wooga.com/icons/icon_improve.svg "IMPROVE"
[CHANGE]:http://resources.atlas.wooga.com/icons/icon_change.svg "Change"
[FIX]:http://resources.atlas.wooga.com/icons/icon_fix.svg "Fix"
[UPDATE]:http://resources.atlas.wooga.com/icons/icon_update.svg "Update"

[BREAK]:http://resources.atlas.wooga.com/icons/icon_break.svg "Remove"
[REMOVE]:http://resources.atlas.wooga.com/icons/icon_remove.svg "Remove"
[IOS]:http://resources.atlas.wooga.com/icons/icon_iOS.svg "iOS"
[ANDROID]:http://resources.atlas.wooga.com/icons/icon_android.svg "Android"
[WEBGL]:http://resources.atlas.wooga.com/icons/icon_webGL.svg "Web:GL"
