### PR TITLE
Default values by convention mapping

### DIFF
--- a/src/main/groovy/wooga/gradle/unity/UnityPlugin.groovy
+++ b/src/main/groovy/wooga/gradle/unity/UnityPlugin.groovy
@@ -69,14 +69,9 @@ class UnityPlugin implements Plugin<Project> {
         project.pluginManager.apply(ReportingBasePlugin.class)
 
         final UnityPluginExtension unityExtension = project.extensions.create(EXTENSION_NAME, DefaultUnityPluginExtension, project, fileResolver, instantiator)
-        final ReportingExtension reportingExtension = (ReportingExtension) project.getExtensions().getByName(ReportingExtension.NAME)
-        final ConventionMapping unityExtensionConvention = ((IConventionAware) unityExtension).getConventionMapping()
         final BasePluginConvention basePluginConvention = new BasePluginConvention(project)
 
-        unityExtensionConvention.map("reportsDir", { return reportingExtension.file("unity") })
-        unityExtensionConvention.map("assetsDir", { return new File(unityExtension.getProjectPath().path, "Assets") })
-        unityExtensionConvention.map("pluginsDir", { return new File(unityExtension.getAssetsDir(), "Plugins") })
-
+        configureUnityExtensionConvention(unityExtension)
         configureUnityTasks(unityExtension)
         addTestTasks(unityExtension)
         addPackageTask()
@@ -91,6 +86,14 @@ class UnityPlugin implements Plugin<Project> {
                 configureAutoActivationDeactivation(p, unityExtension)
             }
         })
+    }
+
+    private void configureUnityExtensionConvention(UnityPluginExtension unityExtension) {
+        final ReportingExtension reportingExtension = (ReportingExtension) project.getExtensions().getByName(ReportingExtension.NAME)
+        final ConventionMapping unityExtensionConvention = ((IConventionAware) unityExtension).getConventionMapping()
+        unityExtensionConvention.map("reportsDir", { reportingExtension.file("unity") })
+        unityExtensionConvention.map("assetsDir", { new File(unityExtension.getProjectPath().path, "Assets") })
+        unityExtensionConvention.map("pluginsDir", { new File(unityExtension.getAssetsDir(), "Plugins") })
     }
 
     def configureUnityTasks(UnityPluginExtension extension) {

--- a/src/main/groovy/wooga/gradle/unity/UnityPlugin.groovy
+++ b/src/main/groovy/wooga/gradle/unity/UnityPlugin.groovy
@@ -110,6 +110,7 @@ class UnityPlugin implements Plugin<Project> {
         taskConventionMapping.map "unityPath", { extension.unityPath }
         taskConventionMapping.logCategory = { extension.logCategory }
         taskConventionMapping.map "projectPath", { extension.projectPath }
+        taskConventionMapping.map "redirectStdOut", { extension.redirectStdOut }
     }
 
     private void configureAutoActivationDeactivation(final Project project, final UnityPluginExtension extension) {

--- a/src/main/groovy/wooga/gradle/unity/UnityPlugin.groovy
+++ b/src/main/groovy/wooga/gradle/unity/UnityPlugin.groovy
@@ -43,7 +43,7 @@ import java.util.concurrent.Callable
 class UnityPlugin implements Plugin<Project> {
 
     static String TEST_TASK_NAME = "test"
-    static String TEST_EDITOMODE_TASK_NAME = "testEditMode"
+    static String TEST_EDITMODE_TASK_NAME = "testEditMode"
     static String TEST_PLAYMODE_TASK_NAME = "testPlayMode"
     static String ACTIVATE_TASK_NAME = "activateUnity"
     static String RETURN_LICENSE_TASK_NAME = "returnUnityLicense"
@@ -68,15 +68,14 @@ class UnityPlugin implements Plugin<Project> {
         project.pluginManager.apply(BasePlugin.class)
         project.pluginManager.apply(ReportingBasePlugin.class)
 
-        UnityPluginExtension unityExtension = project.extensions.create(EXTENSION_NAME, DefaultUnityPluginExtension, project, fileResolver, instantiator)
+        final UnityPluginExtension unityExtension = project.extensions.create(EXTENSION_NAME, DefaultUnityPluginExtension, project, fileResolver, instantiator)
         final ReportingExtension reportingExtension = (ReportingExtension) project.getExtensions().getByName(ReportingExtension.NAME)
-        ConventionMapping unityExtensionConvention = ((IConventionAware) unityExtension).getConventionMapping()
+        final ConventionMapping unityExtensionConvention = ((IConventionAware) unityExtension).getConventionMapping()
+        final BasePluginConvention basePluginConvention = new BasePluginConvention(project)
 
         unityExtensionConvention.map("reportsDir", { return reportingExtension.file("unity") })
         unityExtensionConvention.map("assetsDir", { return new File(unityExtension.getProjectPath().path, "Assets") })
         unityExtensionConvention.map("pluginsDir", { return new File(unityExtension.getAssetsDir(), "Plugins") })
-
-        BasePluginConvention basePluginConvention = new BasePluginConvention(project)
 
         configureUnityTasks(unityExtension)
         addTestTasks(unityExtension)
@@ -110,6 +109,7 @@ class UnityPlugin implements Plugin<Project> {
     static void applyBaseConvention(ConventionMapping taskConventionMapping, UnityPluginExtension extension) {
         taskConventionMapping.map "unityPath", { extension.unityPath }
         taskConventionMapping.logCategory = { extension.logCategory }
+        taskConventionMapping.map "projectPath", { extension.projectPath }
     }
 
     private void configureAutoActivationDeactivation(final Project project, final UnityPluginExtension extension) {
@@ -155,14 +155,14 @@ class UnityPlugin implements Plugin<Project> {
 
     private void addTestTasks(final UnityPluginExtension extension) {
         def testTask = project.tasks.create(name: TEST_TASK_NAME, group: GROUP)
-        def testEditModeTask = project.tasks.create(name: TEST_EDITOMODE_TASK_NAME, group: GROUP)
+        def testEditModeTask = project.tasks.create(name: TEST_EDITMODE_TASK_NAME, group: GROUP)
         def testPlayModeTask = project.tasks.create(name: TEST_PLAYMODE_TASK_NAME, group: GROUP)
         testTask.dependsOn testEditModeTask, testPlayModeTask
 
         project.afterEvaluate {
             extension.testBuildTargets.each { target ->
                 def suffix = target.toString().capitalize()
-                testEditModeTask.dependsOn createTestTask(TEST_EDITOMODE_TASK_NAME + suffix, TestPlatform.editmode, target)
+                testEditModeTask.dependsOn createTestTask(TEST_EDITMODE_TASK_NAME + suffix, TestPlatform.editmode, target)
                 testPlayModeTask.dependsOn createTestTask(TEST_PLAYMODE_TASK_NAME + suffix, TestPlatform.playmode, target)
             }
         }

--- a/src/main/groovy/wooga/gradle/unity/UnityPluginExtension.groovy
+++ b/src/main/groovy/wooga/gradle/unity/UnityPluginExtension.groovy
@@ -24,48 +24,35 @@ import wooga.gradle.unity.batchMode.*
 
 interface UnityPluginExtension extends UnityPluginTestExtension {
 
-    void setUnityPath(Object path)
-
     File getUnityPath()
-
+    void setUnityPath(Object path)
     UnityPluginExtension unityPath(Object path)
 
     File getUnityLicenseDirectory()
 
     File getProjectPath()
-
     void setProjectPath(File path)
+    UnityPluginExtension projectPath(File path)
 
     File getReportsDir()
-
     void setReportsDir(File reportsDir)
-
     void setReportsDir(Object reportsDir)
 
     File getPluginsDir()
-
     void setPluginsDir(File reportsDir)
-
     void setPluginsDir(Object reportsDir)
 
     File getAssetsDir()
-
     void setAssetsDir(File reportsDir)
-
     void setAssetsDir(Object reportsDir)
 
-    UnityPluginExtension projectPath(File path)
-
     ExecResult batchMode(Closure closure)
-
     ExecResult batchMode(Action<? super BatchModeSpec> action)
 
     ExecResult activate(Closure closure)
-
     ExecResult activate(Action<? super ActivationSpec> action)
 
     ExecResult returnLicense(Closure closure)
-
     ExecResult returnLicense(Action<? super BaseBatchModeSpec> action)
 
     Factory<BatchModeAction> getBatchModeActionFactory()
@@ -73,37 +60,26 @@ interface UnityPluginExtension extends UnityPluginTestExtension {
     Factory<ActivationAction> getActivationActionFactory()
 
     Boolean getAutoReturnLicense()
-
     void setAutoReturnLicense(Boolean value)
-
     UnityPluginExtension autoReturnLicense(Boolean value)
 
     Boolean getAutoActivateUnity()
-
     void setAutoActivateUnity(Boolean value)
-
     UnityPluginExtension autoActivateUnity(Boolean value)
 
     UnityAuthentication getAuthentication()
-
     void setAuthentication(UnityAuthentication authentication)
 
     UnityPluginExtension authentication(Closure closure)
-
     UnityPluginExtension authentication(Action<? super UnityAuthentication> action)
 
     BuildTarget getDefaultBuildTarget()
-
     void setDefaultBuildTarget(BuildTarget value)
-
     void setDefaultBuildTarget(Object value)
-
     UnityPluginExtension defaultBuildTarget(BuildTarget value)
 
     Boolean getRedirectStdOut()
-
     void setRedirectStdOut(Boolean redirect)
-
     UnityPluginExtension redirectStdOut(Boolean redirect)
 
     void setLogCategory(String value)

--- a/src/main/groovy/wooga/gradle/unity/batchMode/DefaultBatchModeAction.groovy
+++ b/src/main/groovy/wooga/gradle/unity/batchMode/DefaultBatchModeAction.groovy
@@ -136,7 +136,6 @@ class DefaultBatchModeAction extends DefaultExecHandleBuilder implements BatchMo
         this.fileResolver = fileResolver
         this.extension = project.getExtensions().findByName(UnityPlugin.EXTENSION_NAME) as UnityPluginExtension
         this.conventionMapping = new ConventionAwareHelper(this, project.getConvention())
-
     }
 
     ExecResult execute() {

--- a/src/main/groovy/wooga/gradle/unity/tasks/AbstractUnityTask.groovy
+++ b/src/main/groovy/wooga/gradle/unity/tasks/AbstractUnityTask.groovy
@@ -46,7 +46,6 @@ abstract class AbstractUnityTask<T extends AbstractUnityTask> extends Convention
 
     abstract BaseBatchModeSpec retrieveAction()
 
-
     protected Factory<BatchModeAction> retrieveBatchModeActionFactory() {
         return retrieveDefaultUnityExtension().batchModeActionFactory
     }

--- a/src/test/groovy/wooga/gradle/unity/UnityPluginSpec.groovy
+++ b/src/test/groovy/wooga/gradle/unity/UnityPluginSpec.groovy
@@ -61,11 +61,11 @@ class UnityPluginSpec extends ProjectSpec {
         taskType.isInstance(task)
 
         where:
-        taskName                                 | taskType
-        UnityPlugin.TEST_TASK_NAME               | DefaultTask
-        UnityPlugin.TEST_EDITOMODE_TASK_NAME     | DefaultTask
-        UnityPlugin.TEST_PLAYMODE_TASK_NAME      | DefaultTask
-        UnityPlugin.EXPORT_PACKAGE_TASK_NAME     | UnityPackage
+        taskName                             | taskType
+        UnityPlugin.TEST_TASK_NAME           | DefaultTask
+        UnityPlugin.TEST_EDITMODE_TASK_NAME  | DefaultTask
+        UnityPlugin.TEST_PLAYMODE_TASK_NAME  | DefaultTask
+        UnityPlugin.EXPORT_PACKAGE_TASK_NAME | UnityPackage
     }
 
     @Unroll
@@ -137,13 +137,13 @@ class UnityPluginSpec extends ProjectSpec {
         }
 
         where:
-        baseTestTaskName                     | testPlatform          | testBuildTarget                                                | name
-        UnityPlugin.TEST_EDITOMODE_TASK_NAME | TestPlatform.editmode | [BuildTarget.android]                                          | "single"
-        UnityPlugin.TEST_PLAYMODE_TASK_NAME  | TestPlatform.playmode | [BuildTarget.android]                                          | "single"
-        UnityPlugin.TEST_EDITOMODE_TASK_NAME | TestPlatform.editmode | [BuildTarget.android, BuildTarget.ios]                         | "two"
-        UnityPlugin.TEST_PLAYMODE_TASK_NAME  | TestPlatform.playmode | [BuildTarget.android, BuildTarget.ios]                         | "two"
-        UnityPlugin.TEST_PLAYMODE_TASK_NAME  | TestPlatform.editmode | EnumSet.range(BuildTarget.ios, BuildTarget.samsungtv).toList() | "all"
-        UnityPlugin.TEST_PLAYMODE_TASK_NAME  | TestPlatform.playmode | EnumSet.range(BuildTarget.ios, BuildTarget.samsungtv).toList() | "all"
+        baseTestTaskName                    | testPlatform          | testBuildTarget                                                | name
+        UnityPlugin.TEST_EDITMODE_TASK_NAME | TestPlatform.editmode | [BuildTarget.android]                                          | "single"
+        UnityPlugin.TEST_PLAYMODE_TASK_NAME | TestPlatform.playmode | [BuildTarget.android]                                          | "single"
+        UnityPlugin.TEST_EDITMODE_TASK_NAME | TestPlatform.editmode | [BuildTarget.android, BuildTarget.ios]                         | "two"
+        UnityPlugin.TEST_PLAYMODE_TASK_NAME | TestPlatform.playmode | [BuildTarget.android, BuildTarget.ios]                         | "two"
+        UnityPlugin.TEST_PLAYMODE_TASK_NAME | TestPlatform.editmode | EnumSet.range(BuildTarget.ios, BuildTarget.samsungtv).toList() | "all"
+        UnityPlugin.TEST_PLAYMODE_TASK_NAME | TestPlatform.playmode | EnumSet.range(BuildTarget.ios, BuildTarget.samsungtv).toList() | "all"
 
         taskNames = testBuildTarget.collect { baseTestTaskName + it.toString().capitalize() }
     }


### PR DESCRIPTION
## Description
As discussed here #26 we want to make more use of convention mapping for default values.

## Changes
* ![ADD] CM for `unityPath`
* ![ADD] CM for `projectPath `
* ![ADD] CM for `redirectStdOut `


[NEW]:https://atlas-resources.wooga.com/icons/icon_new.svg "New"
[ADD]:http://resources.atlas.wooga.com/icons/icon_add.svg "Add"
[IMPROVE]:http://resources.atlas.wooga.com/icons/icon_improve.svg "IMPROVE"
[CHANGE]:http://resources.atlas.wooga.com/icons/icon_change.svg "Change"
[FIX]:http://resources.atlas.wooga.com/icons/icon_fix.svg "Fix"
[UPDATE]:http://resources.atlas.wooga.com/icons/icon_update.svg "Update"

[BREAK]:http://resources.atlas.wooga.com/icons/icon_break.svg "Remove"
[REMOVE]:http://resources.atlas.wooga.com/icons/icon_remove.svg "Remove"
[IOS]:http://resources.atlas.wooga.com/icons/icon_iOS.svg "iOS"
[ANDROID]:http://resources.atlas.wooga.com/icons/icon_android.svg "Android"
[WEBGL]:http://resources.atlas.wooga.com/icons/icon_webGL.svg "Web:GL"
