### PR TITLE
Fix logCategory default value

### DIFF
--- a/src/integrationTest/groovy/wooga/gradle/unity/BaseBatchModeIntegrationSpec.groovy
+++ b/src/integrationTest/groovy/wooga/gradle/unity/BaseBatchModeIntegrationSpec.groovy
@@ -180,11 +180,14 @@ class BaseBatchModeIntegrationSpec extends UnityIntegrationSpec {
     def "set log category with #method to #value"() {
         given:
         buildFile << """
-        
-        task (mUnity, type: ${Unity.name}) {
-            $method("${value}") 
-        }
+        task (mUnity, type: ${Unity.name})
         """.stripIndent()
+
+        if (value) {
+            buildFile << """
+            mUnity.$method("${value}")
+            """.stripIndent()
+        }
 
         when:
         def result = runTasksSuccessfully("mUnity")
@@ -200,6 +203,8 @@ class BaseBatchModeIntegrationSpec extends UnityIntegrationSpec {
         "helloworld" | false     | "helloworld/mUnity.log"
         ""           | true      | "mUnity.log"
         ""           | false     | "mUnity.log"
+        null         | true      | "mUnity.log"
+        null         | false     | "mUnity.log"
 
         method = (useSetter) ? "setLogCategory" : "logCategory"
 

--- a/src/main/groovy/wooga/gradle/unity/UnityPlugin.groovy
+++ b/src/main/groovy/wooga/gradle/unity/UnityPlugin.groovy
@@ -161,7 +161,7 @@ class UnityPlugin implements Plugin<Project> {
 
     static void applyBaseConvention(ConventionMapping taskConventionMapping, UnityPluginExtension extension) {
         taskConventionMapping.map "unityPath", { extension.unityPath }
-        taskConventionMapping.logCategory = { extension.logCategory }
+        taskConventionMapping.map "logCategory", { extension.logCategory }
         taskConventionMapping.map "projectPath", { extension.projectPath }
         taskConventionMapping.map "redirectStdOut", { extension.redirectStdOut }
     }


### PR DESCRIPTION
## Description

With the last changes we somehow brought in a regression for the
`logCategory` value. It seems we no longer evaluate clojure values at
one point. Since we try to limit API's with clojures that is Ok. I run
the tests and the one testing the `logCategory` also failed (strange).
So I changed the default mapping to the old `conventionMapping` style
and it works.

resolved #39 

## Changes

![FIX] `logCategory` default convention mapping

[NEW]:https://atlas-resources.wooga.com/icons/icon_new.svg "New"
[ADD]:http://resources.atlas.wooga.com/icons/icon_add.svg "Add"
[IMPROVE]:http://resources.atlas.wooga.com/icons/icon_improve.svg "IMPROVE"
[CHANGE]:http://resources.atlas.wooga.com/icons/icon_change.svg "Change"
[FIX]:http://resources.atlas.wooga.com/icons/icon_fix.svg "Fix"
[UPDATE]:http://resources.atlas.wooga.com/icons/icon_update.svg "Update"

[BREAK]:http://resources.atlas.wooga.com/icons/icon_break.svg "Remove"
[REMOVE]:http://resources.atlas.wooga.com/icons/icon_remove.svg "Remove"
[IOS]:http://resources.atlas.wooga.com/icons/icon_iOS.svg "iOS"
[ANDROID]:http://resources.atlas.wooga.com/icons/icon_android.svg "Android"
[WEBGL]:http://resources.atlas.wooga.com/icons/icon_webGL.svg "Web:GL"
