### PR TITLE
Activate test task feature for unity <= 2018

### DIFF
--- a/src/main/groovy/wooga/gradle/unity/tasks/Test.groovy
+++ b/src/main/groovy/wooga/gradle/unity/tasks/Test.groovy
@@ -164,8 +164,7 @@ class Test extends AbstractUnityProjectTask implements Reporting<UnityTestTaskRe
     protected List<String> buildTestArguments(DefaultArtifactVersion unityVersion) {
         def testArgs = []
         if ((unityVersion.majorVersion == 5 && unityVersion.minorVersion == 6)
-                || unityVersion.majorVersion == 2017
-                || (unityVersion.majorVersion == 2018 && unityVersion.minorVersion == 1)) {
+                || unityVersion.majorVersion <= 2018) {
             logger.info("activate unittests with ${BatchModeFlags.RUN_TESTS} switch")
 
             //new unit test runner does not work in batchmode

--- a/src/test/groovy/wooga/gradle/unity/tasks/TestSpec.groovy
+++ b/src/test/groovy/wooga/gradle/unity/tasks/TestSpec.groovy
@@ -136,7 +136,9 @@ class TestSpec extends ProjectSpec {
         "MAC OS X" | "2017.3.0" | "-runTests"
         "MAC OS X" | "2017.4.0" | "-runTests"
         "MAC OS X" | "2018.1.0" | "-runTests"
-        "MAC OS X" | "2018.2.0" | ""
+        "MAC OS X" | "2018.2.0" | "-runTests"
+        "MAC OS X" | "2018.3.0" | "-runTests"
+        "MAC OS X" | "2019.1.0" | "-runTests"
         "WINDOWS"  | "5.4.0"    | ""
         "WINDOWS"  | "5.5.0"    | "-runEditorTests"
         "WINDOWS"  | "5.6.0"    | "-runTests"
@@ -145,7 +147,9 @@ class TestSpec extends ProjectSpec {
         "WINDOWS"  | "2017.3.0" | "-runTests"
         "WINDOWS"  | "2017.4.0" | "-runTests"
         "WINDOWS"  | "2018.1.0" | "-runTests"
-        "WINDOWS"  | "2018.2.0" | ""
+        "WINDOWS"  | "2018.2.0" | "-runTests"
+        "WINDOWS"  | "2018.3.0" | "-runTests"
+        "WINDOWS"  | "2019.2.0" | "-runTests"
 
     }
 }


### PR DESCRIPTION
This change enables the test task feature for all unity versions `5.5 < version < 2018`.

![CHANGE] `Test` task unity version restriction
![CHANGE] tests to check for changed version restrictions

[NEW]:https://atlas-resources.wooga.com/icons/icon_new.svg "New"
[ADD]:http://resources.atlas.wooga.com/icons/icon_add.svg "Add"
[IMPROVE]:http://resources.atlas.wooga.com/icons/icon_improve.svg "IMPROVE"
[CHANGE]:http://resources.atlas.wooga.com/icons/icon_change.svg "Change"
[FIX]:http://resources.atlas.wooga.com/icons/icon_fix.svg "Fix"
[UPDATE]:http://resources.atlas.wooga.com/icons/icon_update.svg "Update"

[BREAK]:http://resources.atlas.wooga.com/icons/icon_break.svg "Remove"
[REMOVE]:http://resources.atlas.wooga.com/icons/icon_remove.svg "Remove"
[IOS]:http://resources.atlas.wooga.com/icons/icon_iOS.svg "iOS"
[ANDROID]:http://resources.atlas.wooga.com/icons/icon_android.svg "Android"
[WEBGL]:http://resources.atlas.wooga.com/icons/icon_webGL.svg "Web:GL"
