### PR TITLE
Use new buildGradlePlugin step instead of custom script


### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,5 +1,6 @@
 #!groovy
-@Library('github.com/wooga/atlas-jenkins-pipeline@fix/lazy_env') _
+
+@Library('github.com/wooga/atlas-jenkins-pipeline@1.x') _
 
 withCredentials([usernameColonPassword(credentialsId: 'artifactory_publish', variable: 'artifactory_publish'),
                  usernameColonPassword(credentialsId: 'artifactory_deploy', variable: 'artifactory_deploy'),

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,5 +1,5 @@
 #!groovy
-@Library('github.com/wooga/atlas-jenkins-pipeline@fix/lazy_env') _
+@Library('atlas-jenkins-pipeline@fix/lazy_env') _
 
 withCredentials([usernameColonPassword(credentialsId: 'artifactory_publish', variable: 'artifactory_publish'),
                  usernameColonPassword(credentialsId: 'artifactory_deploy', variable: 'artifactory_deploy'),
@@ -8,7 +8,7 @@ withCredentials([usernameColonPassword(credentialsId: 'artifactory_publish', var
     def testEnvironment = [
                             "artifactoryCredentials=${artifactory_publish}",
                             "nugetkey=${artifactory_deploy}",
-                            {"UNITY_PATH=${APPLICATIONS_HOME}/Unity-2017.1.0p5/${UNITY_EXEC_PACKAGE_PATH}"}
+                            {pathToUnity("2017.1.0p5")}
                           ]
 
     buildGradlePlugin plaforms: ['osx','windows'],

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,5 +1,5 @@
 #!groovy
-@Library('atlas-jenkins-pipeline@fix/lazy_env') _
+@Library('github.com/wooga/atlas-jenkins-pipeline@fix/lazy_env') _
 
 withCredentials([usernameColonPassword(credentialsId: 'artifactory_publish', variable: 'artifactory_publish'),
                  usernameColonPassword(credentialsId: 'artifactory_deploy', variable: 'artifactory_deploy'),

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,5 +1,5 @@
 #!groovy
-@Library('github.com/wooga/atlas-jenkins-pipeline@1.x') _
+@Library('github.com/wooga/atlas-jenkins-pipeline@fix/lazy_env') _
 
 withCredentials([usernameColonPassword(credentialsId: 'artifactory_publish', variable: 'artifactory_publish'),
                  usernameColonPassword(credentialsId: 'artifactory_deploy', variable: 'artifactory_deploy'),
@@ -8,8 +8,11 @@ withCredentials([usernameColonPassword(credentialsId: 'artifactory_publish', var
     def testEnvironment = [
                             "artifactoryCredentials=${artifactory_publish}",
                             "nugetkey=${artifactory_deploy}",
-                            "UNITY_PATH=${env.UNITY_2017_1_0_P_5_PATH}"
+                            {"UNITY_PATH=${APPLICATIONS_HOME}/Unity-2017.1.0p5/${UNITY_EXEC_PACKAGE_PATH}"}
                           ]
 
-    buildGradlePlugin plaforms: ['unity&&osx&&unity_2017.1.0p5e','unity&&windows&&unity_2017.1.0p5e'], coverallsToken: coveralls_token, testEnvironment: testEnvironment
+    buildGradlePlugin plaforms: ['osx','windows'],
+                      coverallsToken: coveralls_token,
+                      testEnvironment: testEnvironment,
+                      labels: 'unity&&unity_2017.1.0p5e'
 }


### PR DESCRIPTION
## Description

To unify the atlas plugin build steps I added a new custom step to https://github.com/wooga/atlas-jenkins-pipeline

This steps tests and publishes gradle plugins. At the moment, the custom test configuration has to be set from the outside.

```groovy
def coveralls_token = "coveralls token" //can be null

def testEnvironment = [
                        "test_var_1=value1",
                        "test_var_2=value2"
                       ]

buildGradlePlugin plaforms: ['osx'], coverallsToken: coveralls_token, testEnvironment: testEnvironment
```

resolves wooga/rfcs#4

## Changes

![IMPROVE] Jenkinsfile by using custom build step

[NEW]:https://atlas-resources.wooga.com/icons/icon_new.svg "New"
[ADD]:http://resources.atlas.wooga.com/icons/icon_add.svg "Add"
[IMPROVE]:http://resources.atlas.wooga.com/icons/icon_improve.svg "IMPROVE"
[CHANGE]:http://resources.atlas.wooga.com/icons/icon_change.svg "Change"
[FIX]:http://resources.atlas.wooga.com/icons/icon_fix.svg "Fix"
[UPDATE]:http://resources.atlas.wooga.com/icons/icon_update.svg "Update"

[BREAK]:http://resources.atlas.wooga.com/icons/icon_break.svg "Remove"
[REMOVE]:http://resources.atlas.wooga.com/icons/icon_remove.svg "Remove"
[IOS]:http://resources.atlas.wooga.com/icons/icon_iOS.svg "iOS"
[ANDROID]:http://resources.atlas.wooga.com/icons/icon_android.svg "Android"
[WEBGL]:http://resources.atlas.wooga.com/icons/icon_webGL.svg "Web:GL"
