### PR TITLE
Add unity hub support

### DIFF
--- a/src/integrationTest/groovy/wooga/gradle/unity/BaseBatchModeIntegrationSpec.groovy
+++ b/src/integrationTest/groovy/wooga/gradle/unity/BaseBatchModeIntegrationSpec.groovy
@@ -288,6 +288,7 @@ class BatchModeIntegrationSpec extends IntegrationSpec {
         Unity    | _
     }
 
+    @Ignore("test occasionally fails on jenkins")
     @IgnoreIf({ System.getProperty("os.name").toLowerCase().contains("windows") })
     def "redirects unity log to stdout and custom logfile if provided"() {
         given: "a custom log file location"

--- a/src/main/groovy/wooga/gradle/unity/internal/DefaultUnityPluginExtension.groovy
+++ b/src/main/groovy/wooga/gradle/unity/internal/DefaultUnityPluginExtension.groovy
@@ -32,6 +32,7 @@ import wooga.gradle.unity.UnityPluginExtension
 import wooga.gradle.unity.batchMode.*
 import wooga.gradle.unity.batchMode.internal.DefaultActivationActionFactory
 import wooga.gradle.unity.batchMode.internal.DefaultBatchModeActionFactory
+import wooga.gradle.unity.utils.internal.UnityHub
 
 import java.util.concurrent.Callable
 
@@ -98,6 +99,11 @@ class DefaultUnityPluginExtension implements UnityPluginExtension, UnityPluginAc
         }
 
         unityPath = getUnityPathFromEnv(project.properties, System.getenv())
+
+        if (unityPath == null) {
+            //read unity-hub version if available
+            unityPath = UnityHub.defaultEditor
+        }
 
         if (unityPath == null) {
             unityPath = defaultUnityLocation()

--- a/src/main/groovy/wooga/gradle/unity/utils/internal/UnityHub.groovy
+++ b/src/main/groovy/wooga/gradle/unity/utils/internal/UnityHub.groovy
@@ -1,0 +1,158 @@
+/*
+ * Copyright 2018 Wooga GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package wooga.gradle.unity.utils.internal
+
+import groovy.json.JsonSlurper
+
+class UnityHub {
+
+    static HUB_INSTALL_LOCATION = "secondaryInstallPath.json"
+    static HUB_MANUAL_EDITORS = "editors.json"
+    static HUB_DEFAULT_EDITOR = "defaultEditor.json"
+
+    static File DEFAULT_UNITY_HUB_INSTALL_LOCATION_MAC_OS() {
+        new File("/Applications/Unity/Hub/Editor")
+    }
+
+    static File DEFAULT_UNITY_HUB_INSTALL_LOCATION_WINDOWS() {
+        new File("${System.env.get('ProgramFiles')}\\Unity\\Hub\\Editor")
+    }
+
+    private static File UNITY_HUB_CONFIG_PATH_MAC_OS() {
+        new File("${System.env.get('HOME')}/Library/Application Support/UnityHub")
+    }
+
+    private static File UNITY_HUB_CONFIG_PATH_WINDOWS() {
+        new File("${System.env.get('HOMEPATH')}\\AppData\\Roaming\\UnityHub")
+    }
+
+    static File getConfigLocation() {
+        File unityHubConfigPath = null
+        String osName = System.getProperty("os.name").toLowerCase()
+        if (osName.contains("windows")) {
+            unityHubConfigPath = UNITY_HUB_CONFIG_PATH_WINDOWS()
+        } else if (osName.contains("mac os x")) {
+            unityHubConfigPath = UNITY_HUB_CONFIG_PATH_MAC_OS()
+        }
+        unityHubConfigPath
+    }
+
+    static File getDefaultInstallLocation() {
+        File unityHubDefaultInstallLocation = null
+        String osName = System.getProperty("os.name").toLowerCase()
+        if (osName.contains("windows")) {
+            unityHubDefaultInstallLocation = DEFAULT_UNITY_HUB_INSTALL_LOCATION_WINDOWS()
+        } else if (osName.contains("mac os x")) {
+            unityHubDefaultInstallLocation = DEFAULT_UNITY_HUB_INSTALL_LOCATION_MAC_OS()
+        }
+        unityHubDefaultInstallLocation
+    }
+
+    static File unitySytemBinaryPath(File basePath) {
+        File unityBinary = null
+        String osName = System.getProperty("os.name").toLowerCase()
+        if (osName.contains("windows")) {
+            unityBinary = basePath
+        } else if (osName.contains("mac os x")) {
+            unityBinary = new File(basePath, "Contents/MacOS/Unity")
+        }
+        unityBinary
+    }
+
+    static String getUnitySytemAppName() {
+        String appName = "Unity"
+        String osName = System.getProperty("os.name").toLowerCase()
+        if (osName.contains("windows")) {
+            appName = "${appName}.exe"
+        } else if (osName.contains("mac os x")) {
+            appName = "${appName}.app"
+        }
+        appName
+    }
+
+
+    static boolean getIsAvailable() {
+        return configLocation && configLocation.exists()
+    }
+
+    static File getHubInstallPath() {
+        File installPath = null
+        if (isAvailable) {
+            def installHubPath = new File(configLocation, HUB_INSTALL_LOCATION)
+            def path = new JsonSlurper().parseText(installHubPath.text) as String
+            installPath = (path == "") ? defaultInstallLocation : new File(path)
+
+        }
+        installPath
+    }
+
+    static Map<String, File> getInstalledEditors() {
+        getManualInstalledEditors() + getHubInstalledEditors()
+    }
+
+    static Map<String, File> getManualInstalledEditors() {
+        def editors = new HashMap<String, File>()
+        if (isAvailable) {
+            def editorsConfigPath = new File(configLocation, HUB_MANUAL_EDITORS)
+            if(editorsConfigPath.exists()) {
+                def rawEditors = new JsonSlurper().parseText(editorsConfigPath.text) as Map<String, Object>
+                editors = rawEditors.collectEntries(editors) { k, v ->
+                    [k, unitySytemBinaryPath(new File(v['location'][0] as String))]
+                }
+            }
+        }
+        editors
+    }
+
+    static Map<String, File> getHubInstalledEditors() {
+        def editors = new HashMap<String, File>()
+        if (isAvailable) {
+            if (hubInstallPath && hubInstallPath.exists()) {
+                hubInstallPath.eachDir { File dir ->
+                    def unityPath = new File(dir, unitySytemAppName)
+                    if (unityPath.exists()) {
+                        def version = dir.name
+                        editors[version] = unitySytemBinaryPath(unityPath)
+                    }
+                }
+            }
+        }
+        editors
+    }
+
+    static String getDefaultEditorVersion() {
+        def defaultEditor = null
+        if (isAvailable) {
+            def defaultEditorPath = new File(configLocation, HUB_DEFAULT_EDITOR)
+            if(defaultEditorPath.exists()) {
+                defaultEditorPath = new File(configLocation, HUB_DEFAULT_EDITOR)
+                defaultEditor = new JsonSlurper().parse(defaultEditorPath) as String
+            }
+        }
+
+        defaultEditor
+    }
+
+    static File getDefaultEditor() {
+        def defaultEditorVersion = defaultEditorVersion
+        if (defaultEditorVersion) {
+            return installedEditors[defaultEditorVersion]
+        }
+        null
+    }
+}

--- a/src/test/groovy/wooga/gradle/unity/DefaultUnityPluginExtensionSpec.groovy
+++ b/src/test/groovy/wooga/gradle/unity/DefaultUnityPluginExtensionSpec.groovy
@@ -99,6 +99,8 @@ class DefaultUnityPluginExtensionSpec extends Specification {
     def "get default #property with #osName #osArch"() {
         given:
         environmentVariables.set("UNITY_PATH", null)
+        environmentVariables.set("HOME", File.createTempDir().path)
+        environmentVariables.set("HOMEPATH", File.createTempDir().path)
         System.setProperty("os.name", osName)
         System.setProperty("os.arch", osArch)
 

--- a/src/test/groovy/wooga/gradle/unity/utils/internal/UnityHubSpec.groovy
+++ b/src/test/groovy/wooga/gradle/unity/utils/internal/UnityHubSpec.groovy
@@ -17,6 +17,7 @@
 
 package wooga.gradle.unity.utils.internal
 
+import groovy.json.JsonBuilder
 import org.junit.Rule
 import org.junit.contrib.java.lang.system.EnvironmentVariables
 import spock.lang.Shared
@@ -67,9 +68,9 @@ class UnityHubSpec extends Specification {
         secondaryInstallPathConfig = new File(hubBasePath, UnityHub.HUB_INSTALL_LOCATION)
         secondaryInstallPathConfig.createNewFile()
 
-        editorsConfig.text = "{}"
-        defaultEditorConfig.text = ""
-        secondaryInstallPathConfig.text = "\"${secondaryInstallPath.path}\""
+        editorsConfig.text = new JsonBuilder([:]).toPrettyString()
+        defaultEditorConfig.text = new JsonBuilder("").toPrettyString()
+        secondaryInstallPathConfig.text = new JsonBuilder(secondaryInstallPath.path).toPrettyString()
     }
 
     File mockUnityInstallation(File basePath, String version) {
@@ -81,6 +82,16 @@ class UnityHubSpec extends Specification {
         }
 
         versionPath
+    }
+
+    Map mockEditorsConfig(File location, String version) {
+        def config = [:]
+        config.put(version, [
+                "version" : version,
+                "location": location.path,
+                "manual"  : true
+        ])
+        config
     }
 
     @Unroll("isAvailable returns #expectedResult if unity hub path #message")
@@ -132,16 +143,7 @@ class UnityHubSpec extends Specification {
         if (unityHubExists && hasInstallation) {
 
             def location = mockUnityInstallation(manualInstallPath, version)
-
-            editorsConfig.text = """
-            {
-                "${version}": {
-                    "version":"${version}",
-                    "location": ["${location.path}"],
-                    "manual":true
-                }
-            }
-            """.stripIndent().trim()
+            editorsConfig.text = new JsonBuilder( mockEditorsConfig(location, version) ).toPrettyString()
         }
 
         expect:
@@ -200,16 +202,7 @@ class UnityHubSpec extends Specification {
         def manualVersion = "2017.1.0f3"
         if (unityHubExists && hasManualInstallation) {
             def location = mockUnityInstallation(manualInstallPath, manualVersion)
-
-            editorsConfig.text = """
-            {
-                "${manualVersion}": {
-                    "version":"${manualVersion}",
-                    "location": ["${location.path}"],
-                    "manual":true
-                }
-            }
-            """.stripIndent().trim()
+            editorsConfig.text = new JsonBuilder( mockEditorsConfig(location, manualVersion) ).toPrettyString()
         }
 
         and: "hub unity editor versions"
@@ -277,16 +270,7 @@ class UnityHubSpec extends Specification {
         and: "manual unity editor versions"
         if (unityHubExists && hasManualInstallation) {
             def location = mockUnityInstallation(manualInstallPath, hasManualInstallation)
-
-            editorsConfig.text = """
-            {
-                "${hasManualInstallation}": {
-                    "version":"${hasManualInstallation}",
-                    "location": ["${location.path}"],
-                    "manual":true
-                }
-            }
-            """.stripIndent().trim()
+            editorsConfig.text = new JsonBuilder( mockEditorsConfig(location, hasManualInstallation) ).toPrettyString()
         }
 
         and: "hub unity editor versions"

--- a/src/test/groovy/wooga/gradle/unity/utils/internal/UnityHubSpec.groovy
+++ b/src/test/groovy/wooga/gradle/unity/utils/internal/UnityHubSpec.groovy
@@ -1,0 +1,320 @@
+/*
+ * Copyright 2018 Wooga GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package wooga.gradle.unity.utils.internal
+
+import org.junit.Rule
+import org.junit.contrib.java.lang.system.EnvironmentVariables
+import spock.lang.Shared
+import spock.lang.Specification
+import spock.lang.Unroll
+
+
+class UnityHubSpec extends Specification {
+
+    @Rule
+    public final EnvironmentVariables environmentVariables = new EnvironmentVariables()
+
+    @Shared
+    File hubBasePath
+
+    @Shared
+    File secondaryInstallPath
+
+    @Shared
+    File manualInstallPath
+
+    @Shared
+    File defaultEditorConfig
+
+    @Shared
+    File editorsConfig
+
+    @Shared
+    File secondaryInstallPathConfig
+
+    def setup() {
+        environmentVariables.set("HOME", File.createTempDir().path)
+        environmentVariables.set("HOMEPATH", File.createTempDir().path)
+        secondaryInstallPath = File.createTempDir()
+        manualInstallPath = File.createTempDir()
+
+        hubBasePath = UnityHub.getConfigLocation()
+    }
+
+    def setupUnityHubConfiguration() {
+        hubBasePath.mkdirs()
+        editorsConfig = new File(hubBasePath, UnityHub.HUB_MANUAL_EDITORS)
+        editorsConfig.createNewFile()
+
+        defaultEditorConfig = new File(hubBasePath, UnityHub.HUB_DEFAULT_EDITOR)
+        defaultEditorConfig.createNewFile()
+
+        secondaryInstallPathConfig = new File(hubBasePath, UnityHub.HUB_INSTALL_LOCATION)
+        secondaryInstallPathConfig.createNewFile()
+
+        editorsConfig.text = "{}"
+        defaultEditorConfig.text = ""
+        secondaryInstallPathConfig.text = "\"${secondaryInstallPath.path}\""
+    }
+
+    File mockUnityInstallation(File basePath, String version) {
+        def versionPath = new File(basePath, "${version}/${UnityHub.unitySytemAppName}")
+
+        if (!versionPath.exists()) {
+            versionPath.mkdirs()
+            versionPath.createNewFile()
+        }
+
+        versionPath
+    }
+
+    @Unroll("isAvailable returns #expectedResult if unity hub path #message")
+    def "getIsAvailable"() {
+        given: "unity hub configuration"
+        if (unityHubExists) {
+            setupUnityHubConfiguration()
+        }
+
+        expect:
+        UnityHub.isAvailable == expectedResult
+
+        where:
+        unityHubExists | expectedResult
+        true           | true
+        false          | false
+        message = (unityHubExists) ? "exists" : "does not exist"
+    }
+
+    @Unroll("hubInstallPath returns #locationMessage when unity hub path #message")
+    def "getHubInstallPath"() {
+        given: "unity hub configuration"
+        if (unityHubExists) {
+            setupUnityHubConfiguration()
+            secondaryInstallPathConfig.text = "\"${configuredPath}\""
+        }
+
+        expect:
+        UnityHub.hubInstallPath == expectedResult
+
+        where:
+        unityHubExists | configuredPath | expectedResult                  | locationMessage
+        true           | "/custom/path" | new File("/custom/path")        | "path to configured install location"
+        true           | ''             | UnityHub.defaultInstallLocation | "path to default install location"
+        false          | ''             | null                            | "null"
+        message = (unityHubExists) ? "exists" : "does not exist"
+
+    }
+
+    @Unroll("manualInstalledEditors returns #mapMessage when #whenMessage")
+    def "getManualInstalledEditors"() {
+        given: "unity hub configuration"
+        if (unityHubExists) {
+            setupUnityHubConfiguration()
+        }
+
+        and: "some configured unity editor versions"
+        def version = "2017.1.0f3"
+        if (unityHubExists && hasInstallation) {
+
+            def location = mockUnityInstallation(manualInstallPath, version)
+
+            editorsConfig.text = """
+            {
+                "${version}": {
+                    "version":"${version}",
+                    "location": ["${location.path}"],
+                    "manual":true
+                }
+            }
+            """.stripIndent().trim()
+        }
+
+        expect:
+        def editors = UnityHub.manualInstalledEditors
+        editors.size() == expectedSize
+        if (hasInstallation) {
+            editors[version] == UnityHub.unitySytemBinaryPath(mockUnityInstallation(manualInstallPath, version))
+        } else {
+            editors[version] == null
+        }
+
+        where:
+        unityHubExists | expectedSize | hasInstallation | mapMessage                                               | whenMessage
+        true           | 1            | true            | "Map with manual configured unity installation location" | "unity hub exists and unity editor is installed"
+        true           | 0            | false           | "empty Map"                                              | "unity hub exists and no unity editor is installed"
+        false          | 0            | false           | "empty Map"                                              | "unity hub doesn't exist"
+    }
+
+    @Unroll("hubInstalledEditors returns #mapMessage when #whenMessage")
+    def "getHubInstalledEditors"() {
+        given: "unity hub configuration"
+        if (unityHubExists) {
+            setupUnityHubConfiguration()
+        }
+
+        and: "some configured unity editor versions"
+        def version = "2017.1.0f3"
+        if (unityHubExists && hasInstallation) {
+            mockUnityInstallation(secondaryInstallPath, version)
+        }
+
+        expect:
+        def editors = UnityHub.hubInstalledEditors
+        editors.size() == expectedSize
+        if (hasInstallation) {
+            editors[version] == UnityHub.unitySytemBinaryPath(mockUnityInstallation(secondaryInstallPath, version))
+        } else {
+            editors[version] == null
+        }
+
+        where:
+        unityHubExists | expectedSize | hasInstallation | mapMessage                                           | whenMessage
+        true           | 1            | true            | "Map with hub installed unity installation location" | "unity hub exists and unity editor is installed"
+        true           | 0            | false           | "empty Map"                                          | "unity hub exists and no unity editor is installed"
+        false          | 0            | false           | "empty Map"                                          | "unity hub doesn't exist"
+    }
+
+    @Unroll("installedEditors returns #mapMessage when #whenMessage")
+    def "getInstalledEditors"() {
+        given: "unity hub configuration"
+        if (unityHubExists) {
+            setupUnityHubConfiguration()
+        }
+
+        and: "manual unity editor versions"
+        def manualVersion = "2017.1.0f3"
+        if (unityHubExists && hasManualInstallation) {
+            def location = mockUnityInstallation(manualInstallPath, manualVersion)
+
+            editorsConfig.text = """
+            {
+                "${manualVersion}": {
+                    "version":"${manualVersion}",
+                    "location": ["${location.path}"],
+                    "manual":true
+                }
+            }
+            """.stripIndent().trim()
+        }
+
+        and: "hub unity editor versions"
+        def hubVersion = "2018.1.0f3"
+        if (unityHubExists && hasHubInstallation) {
+            mockUnityInstallation(secondaryInstallPath, hubVersion)
+        }
+
+        expect:
+        def editors = UnityHub.installedEditors
+        editors.size() == expectedSize
+        if (hasHubInstallation) {
+            editors[hubVersion] == UnityHub.unitySytemBinaryPath(mockUnityInstallation(secondaryInstallPath, hubVersion))
+        } else {
+            editors[hubVersion] == null
+        }
+
+        if (hasManualInstallation) {
+            editors[manualVersion] == UnityHub.unitySytemBinaryPath(mockUnityInstallation(manualInstallPath, manualVersion))
+        } else {
+            editors[manualVersion] == null
+        }
+
+        where:
+        unityHubExists | expectedSize | hasManualInstallation | hasHubInstallation | mapMessage                                                      | whenMessage
+        true           | 2            | true                  | true               | "Map with hub and manual installed unity installation location" | "unity hub exists and unity editor is installed"
+        true           | 1            | false                 | true               | "Map with hub installed unity installation location"            | "unity hub exists and unity editor is installed"
+        true           | 1            | true                  | false              | "Map with manual configured unity installation location"        | "unity hub exists and unity editor is installed"
+        true           | 0            | false                 | false              | "empty Map"                                                     | "unity hub exists and no unity editor is installed"
+        false          | 0            | false                 | false              | "empty Map"                                                     | "unity hub doesn't exist"
+    }
+
+    @Unroll("defaultEditorVersion returns #resultMessage when #whenMessage")
+    def "getDefaultEditorVersion"() {
+        given: "unity hub configuration"
+        if (unityHubExists) {
+            setupUnityHubConfiguration()
+        }
+
+        and: "a active unity version"
+        if (hasDefaultVersion) {
+            defaultEditorConfig.text = "\"2018.1.0f3\""
+        } else {
+            defaultEditorConfig.delete()
+        }
+
+        expect:
+        UnityHub.defaultEditorVersion == expectedResult
+
+        where:
+        unityHubExists | expectedResult | hasDefaultVersion | resultMessage    | whenMessage
+        true           | "2018.1.0f3"   | true              | "active version" | "unity hub exists and default version is set"
+        true           | null           | false             | "null"           | "unity hub exists and no default version is set"
+        false          | null           | false             | "null"           | "unity hub doesn't exist"
+
+    }
+
+    @Unroll("defaultEditor returns #resultMessage when #whenMessage")
+    def "getDefaultEditor"() {
+        given: "unity hub configuration"
+        if (unityHubExists) {
+            setupUnityHubConfiguration()
+        }
+
+        and: "manual unity editor versions"
+        if (unityHubExists && hasManualInstallation) {
+            def location = mockUnityInstallation(manualInstallPath, hasManualInstallation)
+
+            editorsConfig.text = """
+            {
+                "${hasManualInstallation}": {
+                    "version":"${hasManualInstallation}",
+                    "location": ["${location.path}"],
+                    "manual":true
+                }
+            }
+            """.stripIndent().trim()
+        }
+
+        and: "hub unity editor versions"
+        if (unityHubExists && hasHubInstallation) {
+            mockUnityInstallation(secondaryInstallPath, hasHubInstallation)
+        }
+
+        and: "a active unity version"
+        if (hasDefaultVersion) {
+            defaultEditorConfig.text = "\"${hasDefaultVersion}\""
+        } else {
+            defaultEditorConfig.delete()
+        }
+
+        expect:
+        def result = UnityHub.defaultEditor
+        if (expectedVersion) {
+            result.path.contains(expectedVersion)
+        } else {
+            result == null
+        }
+
+        where:
+        unityHubExists | expectedVersion | hasDefaultVersion | hasManualInstallation | hasHubInstallation | resultMessage                             | whenMessage
+        true           | "2018.1.0f3"    | "2018.1.0f3"      | "2018.1.0f3"          | "2017.1.0f3"       | "path to active manual installed version" | "unity hub exists and default version is set to manual installation"
+        true           | "2017.2.0f3"    | "2017.2.0f3"      | "2018.2.0f3"          | "2017.2.0f3"       | "path to active hub installed version"    | "unity hub exists and default version is set to hub installation"
+        true           | null            | null              | "2018.2.0f3"          | "2017.2.0f3"       | "null"                                    | "unity hub exists and no default version is set"
+        true           | null            | "2017.4.0f3"      | "2018.2.0f3"          | "2017.3.0f3"       | "null"                                    | "unity hub exists and default version is set to unknown version"
+        false          | null            | null              | null                  | null               | "null"                                    | "unity hub doesn't exist"
+    }
+}


### PR DESCRIPTION
## Description

This patch adds support to fetch the __default__ unity editor installation through [Unity Hub]. The order for fetching the __default__ location is as follows:

1. configured `path` in `build.gradle`
2. configured `path` in `gradle.properties`
3. configured `path` in `env`
4. prefered version configured in [Unity Hub] (if available)
5. default system installation location

All logic for [Unity Hub] is contained on a single utility class `UnityHub`. This patch and the posibility to lookup editor version installations through [Unity Hub] is the basis for a future feature to fetch the matching unity version based on the project editor version.

## Changes

![IMPROVE] fetch default unity logic with unity hub
![ADD] new utility class `UnityHub`

[Unity Hub]:	https://docs.unity3d.com/Manual/GettingStartedUnityHub.html

[NEW]:https://atlas-resources.wooga.com/icons/icon_new.svg "New"
[ADD]:http://resources.atlas.wooga.com/icons/icon_add.svg "Add"
[IMPROVE]:http://resources.atlas.wooga.com/icons/icon_improve.svg "IMPROVE"
[CHANGE]:http://resources.atlas.wooga.com/icons/icon_change.svg "Change"
[FIX]:http://resources.atlas.wooga.com/icons/icon_fix.svg "Fix"
[UPDATE]:http://resources.atlas.wooga.com/icons/icon_update.svg "Update"

[BREAK]:http://resources.atlas.wooga.com/icons/icon_break.svg "Remove"
[REMOVE]:http://resources.atlas.wooga.com/icons/icon_remove.svg "Remove"
[IOS]:http://resources.atlas.wooga.com/icons/icon_iOS.svg "iOS"
[ANDROID]:http://resources.atlas.wooga.com/icons/icon_android.svg "Android"
[WEBGL]:http://resources.atlas.wooga.com/icons/icon_webGL.svg "Web:GL"
