### PR TITLE
Fix unity activation

### DIFF
--- a/src/integrationTest/groovy/wooga/gradle/unity/UnityActivationIntegrationSpec.groovy
+++ b/src/integrationTest/groovy/wooga/gradle/unity/UnityActivationIntegrationSpec.groovy
@@ -197,6 +197,28 @@ class UnityActivationIntegrationSpec extends UnityIntegrationSpec {
         result.standardOutput.contains("${BatchModeFlags.SERIAL} 123456789")
     }
 
+    def "activates with unity project path"() {
+        given: "a build script with fake test unity authentication"
+        buildFile << """
+            unity {
+                authentication {
+                    username = "test@test.test"
+                    password = "testtesttest"
+                    serial = "abcdefg"
+                }
+            }
+
+            task (mUnity, type: wooga.gradle.unity.tasks.Activate)
+        """.stripIndent()
+
+        when:
+        def result = runTasksSuccessfully("mUnity")
+
+        then:
+        !result.wasSkipped("mUnity")
+        result.standardOutput.contains("${BatchModeFlags.PROJECT_PATH} ${projectDir}")
+    }
+
     def "runs activation before a unity task when authentication is set once"() {
         given: "a build script with fake test unity location"
         buildFile << """

--- a/src/main/groovy/wooga/gradle/unity/UnityPlugin.groovy
+++ b/src/main/groovy/wooga/gradle/unity/UnityPlugin.groovy
@@ -41,6 +41,7 @@ import wooga.gradle.unity.tasks.ReturnLicense
 import wooga.gradle.unity.tasks.Test
 import wooga.gradle.unity.tasks.UnityPackage
 import wooga.gradle.unity.tasks.UnityPackageArtifact
+import wooga.gradle.unity.tasks.internal.AbstractUnityActivationTask
 import wooga.gradle.unity.tasks.internal.AbstractUnityProjectTask
 import wooga.gradle.unity.tasks.internal.AbstractUnityTask
 
@@ -174,14 +175,15 @@ class UnityPlugin implements Plugin<Project> {
         project.getTasks().withType(AbstractUnityProjectTask, new Action<AbstractUnityProjectTask>() {
             @Override
             void execute(AbstractUnityProjectTask task) {
+                if(!AbstractUnityActivationTask.isInstance(task)) {
+                    if (extension.autoActivateUnity) {
+                        task.dependsOn activationTask
+                    }
 
-                if (extension.autoActivateUnity) {
-                    task.dependsOn activationTask
-                }
-
-                if (extension.autoReturnLicense) {
-                    returnLicenseTask.mustRunAfter task
-                    activationTask.finalizedBy returnLicenseTask
+                    if (extension.autoReturnLicense) {
+                        returnLicenseTask.mustRunAfter task
+                        activationTask.finalizedBy returnLicenseTask
+                    }
                 }
             }
         })

--- a/src/main/groovy/wooga/gradle/unity/batchMode/internal/DefaultActivationAction.groovy
+++ b/src/main/groovy/wooga/gradle/unity/batchMode/internal/DefaultActivationAction.groovy
@@ -26,6 +26,7 @@ import org.gradle.internal.io.TextStream
 import org.gradle.process.ExecResult
 import org.gradle.process.internal.ExecException
 import org.gradle.process.internal.ExecHandle
+import wooga.gradle.unity.batchMode.BatchModeAction
 import wooga.gradle.unity.utils.internal.FileUtils
 import wooga.gradle.unity.UnityAuthentication
 import wooga.gradle.unity.batchMode.ActivationAction
@@ -103,6 +104,8 @@ class DefaultActivationAction extends DefaultBatchModeAction implements Activati
         authenticationArgs << BatchModeFlags.QUIT
         authenticationArgs << BatchModeFlags.RETURN_LICENSE
 
+        authenticationArgs << BatchModeFlags.PROJECT_PATH << getProjectPath().toString()
+
         setupLogFile(authenticationArgs)
 
         authenticationArgs
@@ -134,6 +137,8 @@ class DefaultActivationAction extends DefaultBatchModeAction implements Activati
         authenticationArgs << BatchModeFlags.USER_NAME << getAuthentication().username
         authenticationArgs << BatchModeFlags.PASSWORD << getAuthentication().password
         authenticationArgs << BatchModeFlags.SERIAL << getAuthentication().serial
+
+        authenticationArgs << BatchModeFlags.PROJECT_PATH << getProjectPath().toString()
 
         setupLogFile(authenticationArgs)
 

--- a/src/main/groovy/wooga/gradle/unity/tasks/Activate.groovy
+++ b/src/main/groovy/wooga/gradle/unity/tasks/Activate.groovy
@@ -78,8 +78,9 @@ class Activate extends AbstractUnityActivationTask implements ActivationSpec {
         onlyIf(new ActivateSpec())
     }
 
+    @Override
     @TaskAction
-    protected void activate() {
+    protected void exec() {
         batchModeResult = activationAction.activate()
     }
 

--- a/src/main/groovy/wooga/gradle/unity/tasks/ReturnLicense.groovy
+++ b/src/main/groovy/wooga/gradle/unity/tasks/ReturnLicense.groovy
@@ -71,8 +71,9 @@ class ReturnLicense extends AbstractUnityActivationTask {
         this
     }
 
+    @Override
     @TaskAction
-    void returnLicense() {
+    protected void exec() {
         activationAction.returnLicense()
     }
 }

--- a/src/main/groovy/wooga/gradle/unity/tasks/internal/AbstractUnityActivationTask.groovy
+++ b/src/main/groovy/wooga/gradle/unity/tasks/internal/AbstractUnityActivationTask.groovy
@@ -19,6 +19,7 @@ package wooga.gradle.unity.tasks.internal
 
 import org.gradle.api.internal.ConventionMapping
 import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.TaskAction
 import org.gradle.internal.Factory
 import org.gradle.process.ExecResult
 import org.gradle.process.internal.ExecException
@@ -26,7 +27,7 @@ import wooga.gradle.unity.batchMode.ActivationAction
 import wooga.gradle.unity.batchMode.BaseBatchModeSpec
 import wooga.gradle.unity.internal.UnityPluginActionExtension
 
-abstract class AbstractUnityActivationTask<T extends AbstractUnityActivationTask> extends AbstractUnityTask {
+abstract class AbstractUnityActivationTask<T extends AbstractUnityActivationTask> extends AbstractUnityProjectTask {
 
     @Override
     protected BaseBatchModeSpec retrieveAction() {
@@ -37,6 +38,10 @@ abstract class AbstractUnityActivationTask<T extends AbstractUnityActivationTask
     ConventionMapping getConventionMapping() {
         return activationAction.conventionMapping
     }
+
+    @Override
+    @TaskAction
+    abstract protected void exec()
 
     interface ExecuteExclude {
         ExecResult activate() throws ExecException


### PR DESCRIPTION
## Description

It turns out the unity activation routine will open and import a project. Since we don't provide a project path for the `activate` and `returnLicense` tasks this can lead to build errors because Unity will pick the last project opened on the system. This picked project could be incompatible and fail the activation task.

This is a very simple patch to provide the project path to `activate` and `returnLicense` tasks. The whole structure should be cleaned up in another change. The separation of  AbstractUnityProjectTask` and `AbstractUnityActivationTask` makes no real sense anymore.

## Changes

* ![FIX] ![UNITY] activation task

[NEW]:https://atlas-resources.wooga.com/icons/icon_new.svg "New"
[UNITY]:https://atlas-resources.wooga.com/icons/icon_unity.svg "Unity"
[ADD]:http://resources.atlas.wooga.com/icons/icon_add.svg "Add"
[IMPROVE]:http://resources.atlas.wooga.com/icons/icon_improve.svg "IMPROVE"
[CHANGE]:http://resources.atlas.wooga.com/icons/icon_change.svg "Change"
[FIX]:http://resources.atlas.wooga.com/icons/icon_fix.svg "Fix"
[UPDATE]:http://resources.atlas.wooga.com/icons/icon_update.svg "Update"

[BREAK]:http://resources.atlas.wooga.com/icons/icon_break.svg "Remove"
[REMOVE]:http://resources.atlas.wooga.com/icons/icon_remove.svg "Remove"
[IOS]:http://resources.atlas.wooga.com/icons/icon_iOS.svg "iOS"
[ANDROID]:http://resources.atlas.wooga.com/icons/icon_android.svg "Android"
[WEBGL]:http://resources.atlas.wooga.com/icons/icon_webGL.svg "Web:GL"

