### PR TITLE
Bootstrap preinstalled Unity version in tests

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -8,12 +8,11 @@ withCredentials([usernameColonPassword(credentialsId: 'artifactory_publish', var
 
     def testEnvironment = [
                             "artifactoryCredentials=${artifactory_publish}",
-                            "nugetkey=${artifactory_deploy}",
-                            {pathToUnity("2017.1.0p5")}
+                            "nugetkey=${artifactory_deploy}"
                           ]
 
-    buildGradlePlugin plaforms: ['osx','windows', 'linux'],
+    buildGradlePlugin plaforms: ['osx','windows','linux'],
                       coverallsToken: coveralls_token,
                       testEnvironment: testEnvironment,
-                      labels: 'unity&&unity_2017.1.0p5e'
+                      labels: 'primary'
 }

--- a/build.gradle
+++ b/build.gradle
@@ -45,6 +45,10 @@ dependencies {
         exclude module: 'logback-classic'
     }
 
+    testCompile("com.wooga.spock.extensions:spock-unity-version-manager-extension:0.1.0") {
+        exclude module: 'groovy-all'
+    }
+
     compile 'org.apache.maven:maven-artifact:3.6.3'
     compile "org.yaml:snakeyaml:1.26"
     compile 'net.wooga:unity-version-manager-jni:1.+'

--- a/build.gradle
+++ b/build.gradle
@@ -49,6 +49,8 @@ dependencies {
         exclude module: 'groovy-all'
     }
 
+    testCompile 'com.github.stefanbirkner:system-rules:1.18.0'
+
     compile 'org.apache.maven:maven-artifact:3.6.3'
     compile "org.yaml:snakeyaml:1.26"
     compile 'net.wooga:unity-version-manager-jni:1.+'

--- a/src/integrationTest/groovy/wooga/gradle/unity/IntegrationSpec.groovy
+++ b/src/integrationTest/groovy/wooga/gradle/unity/IntegrationSpec.groovy
@@ -17,7 +17,13 @@
 
 package wooga.gradle.unity
 
+import org.junit.Rule
+import org.junit.contrib.java.lang.system.EnvironmentVariables
+
 class IntegrationSpec extends nebula.test.IntegrationSpec{
+
+    @Rule
+    public final EnvironmentVariables environmentVariables = new EnvironmentVariables();
 
     def setup() {
         def gradleVersion = System.getenv("GRADLE_VERSION")
@@ -25,5 +31,7 @@ class IntegrationSpec extends nebula.test.IntegrationSpec{
             this.gradleVersion = gradleVersion
             fork = true
         }
+
+        environmentVariables.clear(UnityPluginConsts.REDIRECT_STDOUT_ENV_VAR)
     }
 }

--- a/src/integrationTest/groovy/wooga/gradle/unity/UnityIntegrationRealSpec.groovy
+++ b/src/integrationTest/groovy/wooga/gradle/unity/UnityIntegrationRealSpec.groovy
@@ -21,11 +21,10 @@ import com.wooga.spock.extensions.uvm.UnityInstallation
 import net.wooga.uvm.Installation
 import org.apache.commons.lang.StringEscapeUtils
 import org.junit.contrib.java.lang.system.EnvironmentVariables
-import spock.lang.Ignore
-import spock.lang.IgnoreIf
+import spock.lang.Requires
 import spock.lang.Shared
 
-@IgnoreIf({ os.windows })
+@Requires({ os.macOs })
 class UnityIntegrationRealSpec extends IntegrationSpec {
 
     def escapedPath(String path) {

--- a/src/integrationTest/groovy/wooga/gradle/unity/UnityIntegrationRealSpec.groovy
+++ b/src/integrationTest/groovy/wooga/gradle/unity/UnityIntegrationRealSpec.groovy
@@ -17,10 +17,15 @@
 
 package wooga.gradle.unity
 
+import com.wooga.spock.extensions.uvm.UnityInstallation
+import net.wooga.uvm.Installation
 import org.apache.commons.lang.StringEscapeUtils
+import org.junit.contrib.java.lang.system.EnvironmentVariables
 import spock.lang.Ignore
+import spock.lang.IgnoreIf
+import spock.lang.Shared
 
-@Ignore
+@IgnoreIf({ os.windows })
 class UnityIntegrationRealSpec extends IntegrationSpec {
 
     def escapedPath(String path) {
@@ -31,9 +36,18 @@ class UnityIntegrationRealSpec extends IntegrationSpec {
         path
     }
 
+    EnvironmentVariables environmentVariables = new EnvironmentVariables()
+
+    @Shared
+    @UnityInstallation(version="2018.4.18f1", basePath = "build/unity", cleanup = true)
+    Installation preInstalledUnity2018_4_18f1
+
     def "runs batchmode action"() {
         given: "path to future project"
-        def project_path = new File( projectDir,"build/test")
+        def project_path = "build/test_project"
+
+        and: "a pre installed unity editor"
+        environmentVariables.set("UNITY_PATH", unityPath)
 
         and: "a build script"
         buildFile << """
@@ -43,7 +57,7 @@ class UnityIntegrationRealSpec extends IntegrationSpec {
             task mUnity {
                 doLast {
                     unity.batchMode {
-                        args "-createProject", "test"
+                        args "-createProject", "${project_path}"
                     }
                 }
             }
@@ -53,13 +67,19 @@ class UnityIntegrationRealSpec extends IntegrationSpec {
         def result = runTasksSuccessfully("mUnity")
 
         then:
-        result.standardOutput.contains("Unity.exe")
-        fileExists("build/test")
+        result.standardOutput.contains("Starting process 'command '${unityPath}'")
+        fileExists(project_path)
+
+        where:
+        unityPath = preInstalledUnity2018_4_18f1.executable.path
     }
 
     def "runs batchmode task"() {
         given: "path to future project"
-        def project_path = new File( projectDir,"build/test")
+        def project_path = "build/test_project"
+
+        and: "a pre installed unity editor"
+        environmentVariables.set("UNITY_PATH", unityPath)
 
         and: "a build script"
         buildFile << """
@@ -67,7 +87,7 @@ class UnityIntegrationRealSpec extends IntegrationSpec {
             ${applyPlugin(UnityPlugin)}
          
             task (mUnity, type: wooga.gradle.unity.tasks.Unity) {
-                args "-createProject", "${escapedPath(project_path.path)}"
+                args "-createProject", "${project_path}"
             }
         """.stripIndent()
 
@@ -75,7 +95,10 @@ class UnityIntegrationRealSpec extends IntegrationSpec {
         def result = runTasksSuccessfully("mUnity")
 
         then:
-        result.standardOutput.contains("Unity.exe")
-        fileExists("build/test")
+        result.standardOutput.contains("Starting process 'command '${unityPath}'")
+        fileExists(project_path)
+
+        where:
+        unityPath = preInstalledUnity2018_4_18f1.executable.path
     }
 }

--- a/src/main/groovy/wooga/gradle/unity/batchMode/internal/UnityLogErrorReader.groovy
+++ b/src/main/groovy/wooga/gradle/unity/batchMode/internal/UnityLogErrorReader.groovy
@@ -23,7 +23,7 @@ class UnityLogErrorReader {
 
     static String  readErrorMessageFromLog(File logfile) {
         def message = DEFAULT_MESSAGE
-        if(!logfile.exists()) {
+        if(!logfile || !logfile.exists()) {
             return message
         }
 


### PR DESCRIPTION
## Description

Instead of using a unityversion being installed on the test system this patch ensures a unity installation at test runtime. It uses a spock extension library [spock-unity-version-manager-extension]. Tests some tests for windows are disabled because there is an issue with
installing unity without admin rights.

## Changes

* ![IMPROVE] bootstrap preinstalled Unity versions in tests

[spock-unity-version-manager-extension]: https://github.com/wooga/spock-unity-version-manager-extension

[NEW]:https://atlas-resources.wooga.com/icons/icon_new.svg "New"
[ADD]:http://resources.atlas.wooga.com/icons/icon_add.svg "Add"
[IMPROVE]:http://resources.atlas.wooga.com/icons/icon_improve.svg "IMPROVE"
[CHANGE]:http://resources.atlas.wooga.com/icons/icon_change.svg "Change"
[FIX]:http://resources.atlas.wooga.com/icons/icon_fix.svg "Fix"
[UPDATE]:http://resources.atlas.wooga.com/icons/icon_update.svg "Update"

[BREAK]:http://resources.atlas.wooga.com/icons/icon_break.svg "Remove"
[REMOVE]:http://resources.atlas.wooga.com/icons/icon_remove.svg "Remove"
[IOS]:http://resources.atlas.wooga.com/icons/icon_iOS.svg "iOS"
[ANDROID]:http://resources.atlas.wooga.com/icons/icon_android.svg "Android"
[WEBGL]:http://resources.atlas.wooga.com/icons/icon_webGL.svg "Web:GL"
