### PR TITLE
Enable batchmode for tests in Unity >= 2018

### DIFF
--- a/src/main/groovy/wooga/gradle/unity/tasks/Test.groovy
+++ b/src/main/groovy/wooga/gradle/unity/tasks/Test.groovy
@@ -163,8 +163,7 @@ class Test extends AbstractUnityProjectTask implements Reporting<UnityTestTaskRe
                 || unityVersion.majorVersion <= 2019) {
             logger.info("activate unittests with ${BatchModeFlags.RUN_TESTS} switch")
 
-            //new unit test runner does not work in batchmode
-            batchMode = false
+            batchMode = unityVersion.majorVersion >= 2018
             quit = false
 
             testArgs << BatchModeFlags.RUN_TESTS


### PR DESCRIPTION
## Description

Unity `5.6` added a complete new test runner compared to the one used in `5.5`. The main problem was a bug in unity. When the tests where executed in _batchmode_ unity actually never executed anything. This was true also in `2017` versions of unity. We tested this with `2018` and it looks like the issue was fixed. I enable _batchmode_ for all versions >= 2018.

## Changes

* ![IMPROVE] enable _batchmode_ for tests in unity >= 2018

[NEW]:https://atlas-resources.wooga.com/icons/icon_new.svg "New"
[ADD]:http://resources.atlas.wooga.com/icons/icon_add.svg "Add"
[IMPROVE]:http://resources.atlas.wooga.com/icons/icon_improve.svg "IMPROVE"
[CHANGE]:http://resources.atlas.wooga.com/icons/icon_change.svg "Change"
[FIX]:http://resources.atlas.wooga.com/icons/icon_fix.svg "Fix"
[UPDATE]:http://resources.atlas.wooga.com/icons/icon_update.svg "Update"

[BREAK]:http://resources.atlas.wooga.com/icons/icon_break.svg "Remove"
[REMOVE]:http://resources.atlas.wooga.com/icons/icon_remove.svg "Remove"
[IOS]:http://resources.atlas.wooga.com/icons/icon_iOS.svg "iOS"
[ANDROID]:http://resources.atlas.wooga.com/icons/icon_android.svg "Android"
[WEBGL]:http://resources.atlas.wooga.com/icons/icon_webGL.svg "Web:GL"
