### PR TITLE
Add test support for Unity 2020

### DIFF
--- a/src/main/groovy/wooga/gradle/unity/tasks/Test.groovy
+++ b/src/main/groovy/wooga/gradle/unity/tasks/Test.groovy
@@ -160,7 +160,7 @@ class Test extends AbstractUnityProjectTask implements Reporting<UnityTestTaskRe
     protected List<String> buildTestArguments(ArtifactVersion unityVersion) {
         def testArgs = []
         if ((unityVersion.majorVersion == 5 && unityVersion.minorVersion == 6)
-                || unityVersion.majorVersion <= 2019) {
+                || unityVersion.majorVersion <= 2020) {
             logger.info("activate unittests with ${BatchModeFlags.RUN_TESTS} switch")
 
             batchMode = unityVersion.majorVersion >= 2018


### PR DESCRIPTION
## Description
Not sure if we need this check at all. Or if we should already set it to 2021?

## Changes
* ![IMPROVE] Add test support for Unity 2020

[NEW]:https://atlas-resources.wooga.com/icons/icon_new.svg "New"
[ADD]:http://resources.atlas.wooga.com/icons/icon_add.svg "Add"
[IMPROVE]:http://resources.atlas.wooga.com/icons/icon_improve.svg "IMPROVE"
[CHANGE]:http://resources.atlas.wooga.com/icons/icon_change.svg "Change"
[FIX]:http://resources.atlas.wooga.com/icons/icon_fix.svg "Fix"
[UPDATE]:http://resources.atlas.wooga.com/icons/icon_update.svg "Update"

[BREAK]:http://resources.atlas.wooga.com/icons/icon_break.svg "Remove"
[REMOVE]:http://resources.atlas.wooga.com/icons/icon_remove.svg "Remove"
[IOS]:http://resources.atlas.wooga.com/icons/icon_iOS.svg "iOS"
[ANDROID]:http://resources.atlas.wooga.com/icons/icon_android.svg "Android"
[WEBGL]:http://resources.atlas.wooga.com/icons/icon_webGL.svg "Web:GL"
