### PR TITLE
Allow batchmode configuration for Test task

### DIFF
--- a/src/main/groovy/wooga/gradle/unity/UnityPlugin.groovy
+++ b/src/main/groovy/wooga/gradle/unity/UnityPlugin.groovy
@@ -239,6 +239,14 @@ class UnityPlugin implements Plugin<Project> {
         project.getTasks().withType(Test.class, new Action<Test>() {
             @Override
             void execute(Test task) {
+                ConventionMapping taskConventionMapping = task.getConventionMapping()
+                Callable<Boolean> batchmode = new Callable<Boolean>() {
+                    @Override
+                    Boolean call() throws Exception {
+                        extension.getBatchMode(task.getTestPlatform())
+                    }
+                }
+                taskConventionMapping.map("batchMode", batchmode)
                 configureUnityReportDefaults(extension, task)
             }
         })

--- a/src/main/groovy/wooga/gradle/unity/UnityPluginConsts.groovy
+++ b/src/main/groovy/wooga/gradle/unity/UnityPluginConsts.groovy
@@ -102,6 +102,34 @@ class UnityPluginConsts {
     static final String REDIRECT_STDOUT_ENV_VAR = "UNITY_REDIRECT_STDOUT"
 
     /**
+     * Gradle property name to set the default value for {@code batchModeForEditModeTest}.
+     * @value "unity.batchModeForEditModeTest"
+     * @see UnityPluginConvention#batchModeForEditModeTest
+     */
+    static final String BATCH_MODE_FOR_EDIT_MODE_TEST_OPTION = "unity.batchModeForEditModeTest"
+
+    /**
+     * Environment variable name to set the default value for {@code batchModeForEditModeTest}.
+     * @value "UNITY_BATCH_MODE_FOR_EDIT_MODE_TEST"
+     * @see UnityPluginConvention#batchModeForEditModeTest
+     */
+    static final String BATCH_MODE_FOR_EDIT_MODE_TEST_ENV_VAR = "UNITY_BATCH_MODE_FOR_EDIT_MODE_TEST"
+
+    /**
+     * Gradle property name to set the default value for {@code batchModeForPlayModeTest}.
+     * @value "unity.batchModeForPlayModeTest"
+     * @see UnityPluginConvention#batchModeForPlayModeTest
+     */
+    static final String BATCH_MODE_FOR_PLAY_MODE_TEST_OPTION = "unity.batchModeForPlayModeTest"
+
+    /**
+     * Environment variable name to set the default value for {@code batchModeForPlayModeTest}.
+     * @value "UNITY_BATCH_MODE_FOR_PLAY_MODE_TEST"
+     * @see UnityPluginConvention#batchModeForPlayModeTest
+     */
+    static final String BATCH_MODE_FOR_PLAY_MODE_TEST_ENV_VAR = "UNITY_BATCH_MODE_FOR_PLAY_MODE_TEST"
+
+    /**
      * Gradle property name to set the default value for {@code authentication.username}.
      * @value "unity.username"
      * @see UnityAuthentication#username

--- a/src/main/groovy/wooga/gradle/unity/UnityPluginConvention.groovy
+++ b/src/main/groovy/wooga/gradle/unity/UnityPluginConvention.groovy
@@ -18,6 +18,7 @@
 package wooga.gradle.unity
 
 import wooga.gradle.unity.batchMode.BuildTarget
+import wooga.gradle.unity.batchMode.TestPlatform
 
 /**
  * A Unity Plugin convention object.
@@ -107,8 +108,7 @@ interface UnityPluginConvention extends UnityActionConvention {
      * The default {@code defaultBuildTarget} is applied to all tasks of type {@code AbstractUnityTask}.
      *
      * @return the default build target
-     * @see wooga.gradle.unity.batchMode.BuildTarget
-     * @see wooga.gradle.unity.tasks.internal.AbstractUnityTask
+     * @see wooga.gradle.unity.batchMode.BuildTarget* @see wooga.gradle.unity.tasks.internal.AbstractUnityTask
      */
     BuildTarget getDefaultBuildTarget()
 
@@ -124,4 +124,38 @@ interface UnityPluginConvention extends UnityActionConvention {
      * @return this
      */
     UnityPluginConvention defaultBuildTarget(BuildTarget value)
+
+    /**
+     * Returns if batchmode should be enabled for edit mode tests
+     * @return a{@code Boolean} value
+     */
+    Boolean getBatchModeForEditModeTest()
+
+    /**
+     * Sets the value if batchmode should be enabled for edit mode tests
+     */
+    void setBatchModeForEditModeTest(Boolean value)
+
+    /**
+     * Sets the value if batchmode should be enabled for edit mode tests
+     */
+    UnityPluginConvention batchModeForEditModeTest(Boolean value)
+
+    /**
+     * Returns if batchmode should be enabled for play mode tests
+     * @return a{@code Boolean} value
+     */
+    Boolean getBatchModeForPlayModeTest()
+
+    /**
+     * Sets the value if batchmode should be enabled for play mode tests
+     */
+    void setBatchModeForPlayModeTest(Boolean value)
+
+    /**
+     * Sets the value if batchmode should be enabled for play mode tests
+     */
+    UnityPluginConvention batchModeForPlayModeTest(Boolean value)
+
+    Boolean getBatchMode(TestPlatform testPlatform)
 }

--- a/src/main/groovy/wooga/gradle/unity/batchMode/internal/DefaultBatchModeAction.groovy
+++ b/src/main/groovy/wooga/gradle/unity/batchMode/internal/DefaultBatchModeAction.groovy
@@ -174,7 +174,7 @@ class DefaultBatchModeAction implements BatchModeAction, IConventionAware {
 
         batchModeArgs << getUnityPath().path
 
-        if (batchMode) {
+        if (getBatchMode()) {
             batchModeArgs << BatchModeFlags.BATCH_MODE
         }
 

--- a/src/main/groovy/wooga/gradle/unity/internal/DefaultUnityPluginExtension.groovy
+++ b/src/main/groovy/wooga/gradle/unity/internal/DefaultUnityPluginExtension.groovy
@@ -61,6 +61,8 @@ class DefaultUnityPluginExtension implements UnityPluginExtension, UnityPluginAc
 
     private Boolean autoReturnLicense
     private Boolean autoActivateUnity
+    private Boolean batchModeForPlayModeTest
+    private Boolean batchModeForEditModeTest
 
     private final Instantiator instantiator
     protected final FileResolver fileResolver
@@ -444,5 +446,68 @@ class DefaultUnityPluginExtension implements UnityPluginExtension, UnityPluginAc
         }
 
         return EnumSet.copyOf(targets)
+    }
+
+    private static Boolean getBatchModeForPlayModeTestFromEnv(Map<String, ?> properties, Map<String, String> env) {
+        String rawValue = (properties[UnityPluginConsts.BATCH_MODE_FOR_PLAY_MODE_TEST_OPTION] ?: env[UnityPluginConsts.BATCH_MODE_FOR_PLAY_MODE_TEST_ENV_VAR]).toString().toLowerCase()
+        rawValue = (rawValue == "1" || rawValue == "yes") ? "true" : rawValue
+        return Boolean.valueOf(rawValue)
+    }
+
+    @Override
+    Boolean getBatchModeForPlayModeTest() {
+        if (batchModeForPlayModeTest) {
+            return batchModeForPlayModeTest
+        }
+
+        return getBatchModeForPlayModeTestFromEnv(project.properties, System.getenv())
+    }
+
+    @Override
+    void setBatchModeForPlayModeTest(Boolean value) {
+        batchModeForPlayModeTest = value
+    }
+
+    @Override
+    UnityPluginConvention batchModeForPlayModeTest(Boolean value) {
+        setBatchModeForPlayModeTest(value)
+        return this
+    }
+
+    private static Boolean getBatchModeForEditModeTestFromEnv(Map<String, ?> properties, Map<String, String> env) {
+        String rawValue = (properties[UnityPluginConsts.BATCH_MODE_FOR_EDIT_MODE_TEST_OPTION] ?: env[UnityPluginConsts.BATCH_MODE_FOR_EDIT_MODE_TEST_ENV_VAR]).toString().toLowerCase()
+        rawValue = (rawValue == "1" || rawValue == "yes") ? "true" : rawValue
+        return Boolean.valueOf(rawValue)
+    }
+
+    @Override
+    Boolean getBatchModeForEditModeTest() {
+        if (batchModeForEditModeTest) {
+            return batchModeForEditModeTest
+        }
+
+        return getBatchModeForEditModeTestFromEnv(project.properties, System.getenv())
+    }
+
+    @Override
+    void setBatchModeForEditModeTest(Boolean value) {
+        batchModeForEditModeTest = value
+    }
+
+    @Override
+    UnityPluginConvention batchModeForEditModeTest(Boolean value) {
+        setBatchModeForEditModeTest(value)
+        return this
+    }
+
+    Boolean getBatchMode(TestPlatform testPlatform) {
+        switch (testPlatform) {
+            case TestPlatform.editmode:
+                return getBatchModeForEditModeTest()
+            case TestPlatform.playmode:
+                return getBatchModeForPlayModeTest()
+            default:
+                return true
+        }
     }
 }

--- a/src/main/groovy/wooga/gradle/unity/tasks/Test.groovy
+++ b/src/main/groovy/wooga/gradle/unity/tasks/Test.groovy
@@ -163,7 +163,10 @@ class Test extends AbstractUnityProjectTask implements Reporting<UnityTestTaskRe
                 || unityVersion.majorVersion <= 2020) {
             logger.info("activate unittests with ${BatchModeFlags.RUN_TESTS} switch")
 
-            batchMode = unityVersion.majorVersion >= 2018
+            // BatchMode for tests was broken for unity 2017 and below
+            if(unityVersion.majorVersion < 2018) {
+                batchMode = false
+            }
             quit = false
 
             testArgs << BatchModeFlags.RUN_TESTS


### PR DESCRIPTION
## Description

For years batchmode for edit and playmode tests was set to `true` due to some issues with Unity when not running them with a full Editor. We changed that to hardcode default to a `true` value when the editor version used is newer than 2018.

Some teams would like to configure the plugin to run edit/playmode tests without batchmode flag for some setups. This patch adds additional properties for the plugin extension to easily set this for a range of generated tasks.

```groove
unity {
    batchModeForEditModeTest = true
    batchModeForPlayModeTest = false
}
```

This extension variables can be set also via environment/gradle properties

`unity.batchModeForEditModeTest`
`UNITY_BATCH_MODE_FOR_EDIT_MODE_TEST=YES`
`unity.batchModeForPlayModeTest`
`UNITY_BATCH_MODE_FOR_PLAY_MODE_TEST=YES`

## Changes

* ![IMPROVE] allow batchmode configuration for `Test` task


[NEW]:https://atlas-resources.wooga.com/icons/icon_new.svg "New"
[ADD]:http://resources.atlas.wooga.com/icons/icon_add.svg "Add"
[IMPROVE]:http://resources.atlas.wooga.com/icons/icon_improve.svg "IMPROVE"
[CHANGE]:http://resources.atlas.wooga.com/icons/icon_change.svg "Change"
[FIX]:http://resources.atlas.wooga.com/icons/icon_fix.svg "Fix"
[UPDATE]:http://resources.atlas.wooga.com/icons/icon_update.svg "Update"

[BREAK]:http://resources.atlas.wooga.com/icons/icon_break.svg "Remove"
[REMOVE]:http://resources.atlas.wooga.com/icons/icon_remove.svg "Remove"
[IOS]:http://resources.atlas.wooga.com/icons/icon_iOS.svg "iOS"
[ANDROID]:http://resources.atlas.wooga.com/icons/icon_android.svg "Android"
[WEBGL]:http://resources.atlas.wooga.com/icons/icon_webGL.svg "Web:GL"
