### PR TITLE
Fix default value for batchmode for test task

### DIFF
--- a/src/integrationTest/groovy/wooga/gradle/unity/TestTaskExecutionSpec.groovy
+++ b/src/integrationTest/groovy/wooga/gradle/unity/TestTaskExecutionSpec.groovy
@@ -170,12 +170,16 @@ class TestTaskExecutionSpec extends UnityIntegrationSpec {
         """.stripIndent()
 
         and: "properties file with custom unity version"
-        createFile("gradle.properties") << """
+        def properties = createFile("gradle.properties") << """
         defaultUnityTestVersion=2018.4.0
-        unity.batchModeForPlayModeTest=${batchModeForPlayModeTest}
-        unity.batchModeForEditModeTest=${batchModeForEditModeTest}
         """.stripIndent()
 
+        if (batchModeForPlayModeTest != _) {
+            properties << "unity.batchModeForPlayModeTest=${batchModeForPlayModeTest}\n"
+        }
+        if (batchModeForEditModeTest != _) {
+            properties << "unity.batchModeForEditModeTest=${batchModeForEditModeTest}\n"
+        }
         and: "a mocked unity project with enabled playmode tests"
         settings.text = ""
         settings << ProjectSettingsSpec.TEMPLATE_CONTENT_ENABLED
@@ -189,9 +193,11 @@ class TestTaskExecutionSpec extends UnityIntegrationSpec {
         where:
         batchModeForPlayModeTest | batchModeForEditModeTest | testPlatform | containsBatchModeFlag
         true                     | true                     | '"playmode"' | true
+        _                        | true                     | '"playmode"' | true
         false                    | true                     | '"playmode"' | false
         false                    | false                    | '"playmode"' | false
         true                     | true                     | '"editmode"' | true
+        true                     | _                        | '"editmode"' | true
         true                     | false                    | '"editmode"' | false
         false                    | false                    | '"editmode"' | false
     }

--- a/src/main/groovy/wooga/gradle/unity/internal/DefaultUnityPluginExtension.groovy
+++ b/src/main/groovy/wooga/gradle/unity/internal/DefaultUnityPluginExtension.groovy
@@ -449,9 +449,13 @@ class DefaultUnityPluginExtension implements UnityPluginExtension, UnityPluginAc
     }
 
     private static Boolean getBatchModeForPlayModeTestFromEnv(Map<String, ?> properties, Map<String, String> env) {
-        String rawValue = (properties[UnityPluginConsts.BATCH_MODE_FOR_PLAY_MODE_TEST_OPTION] ?: env[UnityPluginConsts.BATCH_MODE_FOR_PLAY_MODE_TEST_ENV_VAR]).toString().toLowerCase()
-        rawValue = (rawValue == "1" || rawValue == "yes") ? "true" : rawValue
-        return Boolean.valueOf(rawValue)
+        String rawValue = (properties[UnityPluginConsts.BATCH_MODE_FOR_PLAY_MODE_TEST_OPTION] ?: env[UnityPluginConsts.BATCH_MODE_FOR_PLAY_MODE_TEST_ENV_VAR])
+        if (rawValue) {
+            rawValue = rawValue.toString().toLowerCase()
+            rawValue = (rawValue == "1" || rawValue == "yes") ? "true" : rawValue
+            return Boolean.valueOf(rawValue)
+        }
+        return true
     }
 
     @Override
@@ -475,9 +479,13 @@ class DefaultUnityPluginExtension implements UnityPluginExtension, UnityPluginAc
     }
 
     private static Boolean getBatchModeForEditModeTestFromEnv(Map<String, ?> properties, Map<String, String> env) {
-        String rawValue = (properties[UnityPluginConsts.BATCH_MODE_FOR_EDIT_MODE_TEST_OPTION] ?: env[UnityPluginConsts.BATCH_MODE_FOR_EDIT_MODE_TEST_ENV_VAR]).toString().toLowerCase()
-        rawValue = (rawValue == "1" || rawValue == "yes") ? "true" : rawValue
-        return Boolean.valueOf(rawValue)
+        String rawValue = (properties[UnityPluginConsts.BATCH_MODE_FOR_EDIT_MODE_TEST_OPTION] ?: env[UnityPluginConsts.BATCH_MODE_FOR_EDIT_MODE_TEST_ENV_VAR])
+        if (rawValue) {
+            rawValue = rawValue.toString().toLowerCase()
+            rawValue = (rawValue == "1" || rawValue == "yes") ? "true" : rawValue
+            return Boolean.valueOf(rawValue)
+        }
+        true
     }
 
     @Override


### PR DESCRIPTION
## Description

The last patch added properties to override the batchmode flag for edit/playmode tests. The default value when no values is provided was set to false which breaks for some builds. This patch sets the default value back to `true` by default.

## Changes

* ![FIX] default value for `batchmode` flag in edit/playmode test

[NEW]:https://atlas-resources.wooga.com/icons/icon_new.svg "New"
[ADD]:http://resources.atlas.wooga.com/icons/icon_add.svg "Add"
[IMPROVE]:http://resources.atlas.wooga.com/icons/icon_improve.svg "IMPROVE"
[CHANGE]:http://resources.atlas.wooga.com/icons/icon_change.svg "Change"
[FIX]:http://resources.atlas.wooga.com/icons/icon_fix.svg "Fix"
[UPDATE]:http://resources.atlas.wooga.com/icons/icon_update.svg "Update"

[BREAK]:http://resources.atlas.wooga.com/icons/icon_break.svg "Remove"
[REMOVE]:http://resources.atlas.wooga.com/icons/icon_remove.svg "Remove"
[IOS]:http://resources.atlas.wooga.com/icons/icon_iOS.svg "iOS"
[ANDROID]:http://resources.atlas.wooga.com/icons/icon_android.svg "Android"
[WEBGL]:http://resources.atlas.wooga.com/icons/icon_webGL.svg "Web:GL"
