### PR TITLE
Fix getBatchModeForEditModeTest and getBatchModeForPlayModeTest in extension

### DIFF
--- a/src/main/groovy/wooga/gradle/unity/internal/DefaultUnityPluginExtension.groovy
+++ b/src/main/groovy/wooga/gradle/unity/internal/DefaultUnityPluginExtension.groovy
@@ -460,7 +460,7 @@ class DefaultUnityPluginExtension implements UnityPluginExtension, UnityPluginAc
 
     @Override
     Boolean getBatchModeForPlayModeTest() {
-        if (batchModeForPlayModeTest) {
+        if (batchModeForPlayModeTest != null) {
             return batchModeForPlayModeTest
         }
 
@@ -490,7 +490,7 @@ class DefaultUnityPluginExtension implements UnityPluginExtension, UnityPluginAc
 
     @Override
     Boolean getBatchModeForEditModeTest() {
-        if (batchModeForEditModeTest) {
+        if (batchModeForEditModeTest != null) {
             return batchModeForEditModeTest
         }
 


### PR DESCRIPTION
## Description

I made a small error in the getter implemention for both `getBatchModeForEditModeTest` and `getBatchModeForPlayModeTest` in the `DefaultUnityPluginExtension` class. I used a `Boolean` class to make sure that the default value would be `null` not `false`. My problem was that the `if` check I provided also checks if the value is `false`. In this case the body was not executed and the default value was being calculated from properties/environment which falls back to `true`. I want to return the value present in the to be checked `Boolean` field if it is not `null` so I made the check more explicit.

## Changes

* ![FIX] `getBatchModeForEditModeTest` implementation
* ![FIX] `getBatchModeForPlayModeTest` implementation

[NEW]:https://atlas-resources.wooga.com/icons/icon_new.svg "New"
[ADD]:http://resources.atlas.wooga.com/icons/icon_add.svg "Add"
[IMPROVE]:http://resources.atlas.wooga.com/icons/icon_improve.svg "IMPROVE"
[CHANGE]:http://resources.atlas.wooga.com/icons/icon_change.svg "Change"
[FIX]:http://resources.atlas.wooga.com/icons/icon_fix.svg "Fix"
[UPDATE]:http://resources.atlas.wooga.com/icons/icon_update.svg "Update"

[BREAK]:http://resources.atlas.wooga.com/icons/icon_break.svg "Remove"
[REMOVE]:http://resources.atlas.wooga.com/icons/icon_remove.svg "Remove"
[IOS]:http://resources.atlas.wooga.com/icons/icon_iOS.svg "iOS"
[ANDROID]:http://resources.atlas.wooga.com/icons/icon_android.svg "Android"
[WEBGL]:http://resources.atlas.wooga.com/icons/icon_webGL.svg "Web:GL"
