### PR TITLE
Add API compatibility level task

### DIFF
--- a/src/integrationTest/groovy/wooga/gradle/unity/IntegrationSpec.groovy
+++ b/src/integrationTest/groovy/wooga/gradle/unity/IntegrationSpec.groovy
@@ -17,13 +17,34 @@
 
 package wooga.gradle.unity
 
+import nebula.test.functional.ExecutionResult
 import org.junit.Rule
 import org.junit.contrib.java.lang.system.EnvironmentVariables
+import org.junit.contrib.java.lang.system.ProvideSystemProperty
 
 class IntegrationSpec extends nebula.test.IntegrationSpec{
 
     @Rule
-    public final EnvironmentVariables environmentVariables = new EnvironmentVariables();
+    ProvideSystemProperty properties = new ProvideSystemProperty("ignoreDeprecations", "true")
+
+    @Rule
+    public final EnvironmentVariables environmentVariables = new EnvironmentVariables()
+
+    def escapedPath(String path) {
+        String osName = System.getProperty("os.name").toLowerCase()
+        if (osName.contains("windows")) {
+            return StringEscapeUtils.escapeJava(path)
+        }
+        path
+    }
+
+    static String osPath(String path) {
+        String osName = System.getProperty("os.name").toLowerCase()
+        if (osName.contains("windows")) {
+            path = path.startsWith('/') ? "c:" + path : path
+        }
+        new File(path).path
+    }
 
     def setup() {
         def gradleVersion = System.getenv("GRADLE_VERSION")
@@ -31,7 +52,94 @@ class IntegrationSpec extends nebula.test.IntegrationSpec{
             this.gradleVersion = gradleVersion
             fork = true
         }
-
         environmentVariables.clear(UnityPluginConsts.REDIRECT_STDOUT_ENV_VAR)
+    }
+
+    enum PropertyLocation {
+        none, script, property, env
+
+        String reason() {
+            switch (this) {
+                case script:
+                    return "value is provided in script"
+                case property:
+                    return "value is provided in props"
+                case env:
+                    return "value is set in env"
+                default:
+                    return "no value was configured"
+            }
+        }
+    }
+
+    String envNameFromProperty(String extensionName, String property) {
+        "${extensionName.toUpperCase()}_${property.replaceAll(/([A-Z])/, "_\$1").toUpperCase()}"
+    }
+
+
+    Boolean outputContains(ExecutionResult result, String message) {
+        result.standardOutput.contains(message) || result.standardError.contains(message)
+    }
+
+    String wrapValueBasedOnType(Object rawValue, Class type, Closure<String> fallback = null) {
+        wrapValueBasedOnType(rawValue, type.simpleName, fallback)
+    }
+
+    String wrapValueBasedOnType(Object rawValue, String type, Closure<String> fallback = null) {
+        def value
+        def rawValueEscaped = String.isInstance(rawValue) ? "'${rawValue}'" : rawValue
+        def subtypeMatches = type =~ /(?<mainType>\w+)<(?<subType>[\w<>]+)>/
+        def subType = (subtypeMatches.matches()) ? subtypeMatches.group("subType") : null
+        type = (subtypeMatches.matches()) ? subtypeMatches.group("mainType") : type
+        switch (type) {
+            case "Closure":
+                if (subType) {
+                    value = "{${wrapValueBasedOnType(rawValue, subType, fallback)}}"
+                } else {
+                    value = "{$rawValueEscaped}"
+                }
+                break
+            case "Callable":
+                value = "new java.util.concurrent.Callable<${rawValue.class.typeName}>() {@Override ${rawValue.class.typeName} call() throws Exception { $rawValueEscaped }}"
+                break
+            case "Object":
+                value = "new Object() {@Override String toString() { ${rawValueEscaped}.toString() }}"
+                break
+            case "Provider":
+                switch (subType) {
+                    case "RegularFile":
+                        value = "project.layout.file(${wrapValueBasedOnType(rawValue, "Provider<File>", fallback)})"
+                        break
+                    case "Directory":
+                        value = "project.provider({def d = project.objects.directoryProperty();d.set(${wrapValueBasedOnType(rawValue, "File", fallback)});d.get()})"
+                        break
+                    default:
+                        value = "project.provider(${wrapValueBasedOnType(rawValue, "Closure<${subType}>", fallback)})"
+                        break
+                }
+                break
+            case "String":
+                value = "${escapedPath(rawValueEscaped.toString())}"
+                break
+            case "String[]":
+                value = "'${rawValue.collect { it }.join(",")}'.split(',')"
+                break
+            case "File":
+                value = "new File('${escapedPath(rawValue.toString())}')"
+                break
+            case "String...":
+                value = "${rawValue.collect { '"' + it + '"' }.join(", ")}"
+                break
+            case "List":
+                value = "[${rawValue.collect { '"' + it + '"' }.join(", ")}]"
+                break
+            case "Map":
+                value = "[" + rawValue.collect { k, v -> "${wrapValueBasedOnType(k, k.getClass(), fallback)} : ${wrapValueBasedOnType(v, v.getClass(), fallback)}" }.join(", ") + "]"
+                value = value == "[]" ? "[:]" : value
+                break
+            default:
+                value = (fallback) ? fallback.call(type) : rawValue
+        }
+        value
     }
 }

--- a/src/integrationTest/groovy/wooga/gradle/unity/SetAPICompLevelIntegrationSpec.groovy
+++ b/src/integrationTest/groovy/wooga/gradle/unity/SetAPICompLevelIntegrationSpec.groovy
@@ -1,0 +1,148 @@
+package wooga.gradle.unity
+
+import spock.lang.Unroll
+import wooga.gradle.unity.tasks.SetAPICompatibilityLevel
+
+class SetAPICompLevelIntegrationSpec extends UnityIntegrationSpec {
+
+    def setup() {
+        buildFile << """
+        unity{
+             testBuildTargets = ["android"]
+        }
+        
+        """.stripIndent()
+    }
+
+    @Unroll
+    def "writes api level with type #type to project settings file correctly #expectedAPICompatibilityLevel"() {
+        given: "a valid api compatibility level to set"
+        buildFile << """
+        ${taskName}.${invocation} 
+            
+        """.stripIndent()
+
+        when:
+        def result = runTasksSuccessfully("test", "-x", "unsetAPICompatibilityLevel")
+
+        then:
+        !result.wasSkipped("test")
+        result.wasExecuted("setAPICompatibilityLevel")
+        !result.wasExecuted("unsetAPICompatibilityLevel")
+        settings.text.contains("apiCompatibilityLevel: ${expectedAPICompatibilityLevel.value}")
+        result.standardOutput.contains("Setting API compatibility level to ${expectedAPICompatibilityLevel}")
+
+        where:
+
+        property                | method                     | rawValue                                | expectedValue                | type
+        'apiCompatibilityLevel' | _                          | APICompatibilityLevel.net4_6            | _                            | "APICompatibilityLevel"
+        'apiCompatibilityLevel' | _                          | APICompatibilityLevel.net4_6            | _                            | "Closure<APICompatibilityLevel>"
+        'apiCompatibilityLevel' | _                          | APICompatibilityLevel.net4_6.toString() | APICompatibilityLevel.net4_6 | "String"
+        'apiCompatibilityLevel' | _                          | APICompatibilityLevel.net4_6.toString() | APICompatibilityLevel.net4_6 | "Closure<String>"
+        'apiCompatibilityLevel' | _                          | APICompatibilityLevel.net4_6.value      | APICompatibilityLevel.net4_6 | "Integer"
+        'apiCompatibilityLevel' | _                          | APICompatibilityLevel.net4_6.value      | APICompatibilityLevel.net4_6 | "Closure<Integer>"
+
+        'apiCompatibilityLevel' | "apiCompatibilityLevel" | APICompatibilityLevel.net4_6            | _                            | "APICompatibilityLevel"
+        'apiCompatibilityLevel' | "apiCompatibilityLevel" | APICompatibilityLevel.net4_6            | _                            | "Closure<APICompatibilityLevel>"
+        'apiCompatibilityLevel' | "apiCompatibilityLevel" | APICompatibilityLevel.net4_6.toString() | APICompatibilityLevel.net4_6 | "String"
+        'apiCompatibilityLevel' | "apiCompatibilityLevel" | APICompatibilityLevel.net4_6.toString() | APICompatibilityLevel.net4_6 | "Closure<String>"
+        'apiCompatibilityLevel' | "apiCompatibilityLevel" | APICompatibilityLevel.net4_6.value      | APICompatibilityLevel.net4_6 | "Integer"
+        'apiCompatibilityLevel' | "apiCompatibilityLevel" | APICompatibilityLevel.net4_6.value      | APICompatibilityLevel.net4_6 | "Closure<Integer>"
+
+        taskName = "setAPICompatibilityLevel"
+        value = (type != _) ? wrapValueBasedOnType(rawValue, type.toString(), { String type ->
+            switch (type) {
+                case "APICompatibilityLevel":
+                    return "wooga.gradle.unity.APICompatibilityLevel.${rawValue}"
+                    break
+                default:
+                    return rawValue.toString()
+            }
+        }) : rawValue
+        expectedAPICompatibilityLevel = (expectedValue != _) ? expectedValue : rawValue
+        defaultAPICompatibilityLevel = APICompatibilityLevel.net2_0_subset
+        testValue = (expectedValue == _) ? rawValue : expectedValue
+        escapedValue = (value instanceof String) ? escapedPath(value) : value
+        invocation = (method != _) ? "${method}(${escapedValue})" : "${property} = ${escapedValue}"
+
+    }
+
+    def "writes api level to project settings file correctly #expectedAPICompatibilityLevel"() {
+        given: "a valid api compatibility level to set"
+        buildFile << """
+            unity {
+               setApiCompatibilityLevel("${expectedAPICompatibilityLevel.toString()}") 
+            }
+            
+        """.stripIndent()
+
+        when:
+        def result = runTasksSuccessfully("test", "-x", "unsetAPICompatibilityLevel")
+
+        then:
+        !result.wasSkipped("test")
+        result.wasExecuted("setAPICompatibilityLevel")
+        !result.wasExecuted("unsetAPICompatibilityLevel")
+        settings.text.contains("apiCompatibilityLevel: ${expectedAPICompatibilityLevel.value}")
+        result.standardOutput.contains("Setting API compatibility level to ${expectedAPICompatibilityLevel}")
+
+        where:
+        defaultAPICompatibilityLevel = APICompatibilityLevel.net2_0_subset
+        expectedAPICompatibilityLevel << [APICompatibilityLevel.net4_6,
+                                          APICompatibilityLevel.net_micro,
+                                          APICompatibilityLevel.net_web]
+    }
+
+    def "sets the api level onto the project settings file, then unsets it"() {
+        given: "a valid api compatibility level to set"
+        buildFile << """
+            unity {
+               setApiCompatibilityLevel("${expectedAPICompatibilityLevel.toString()}") 
+            }
+            
+        """.stripIndent()
+
+        and: "ensure that the api compatibility level isn't the default"
+        assert settings.text.contains("apiCompatibilityLevel: ${defaultAPICompatibilityLevel.value}")
+
+        when:
+        def result = runTasksSuccessfully("test")
+
+        then:
+        !result.wasSkipped("test")
+        result.wasExecuted("setAPICompatibilityLevel")
+        result.wasExecuted("unsetAPICompatibilityLevel")
+        !settings.text.contains("apiCompatibilityLevel: ${expectedAPICompatibilityLevel.value}")
+        result.standardOutput.contains("Setting API compatibility level to ${expectedAPICompatibilityLevel}")
+        result.standardOutput.contains("Setting API compatibility level to ${defaultAPICompatibilityLevel}")
+
+        where:
+        expectedAPICompatibilityLevel = APICompatibilityLevel.net4_6
+        defaultAPICompatibilityLevel = APICompatibilityLevel.net2_0_subset
+    }
+
+    def "skips if the api level is the same as the default"() {
+        given: "a valid api compatibility level to set"
+        buildFile << """
+            unity {
+               setApiCompatibilityLevel("${expectedAPICompatibilityLevel.toString()}") 
+            }
+            
+        """.stripIndent()
+
+        when:
+        def result = runTasksSuccessfully("test")
+
+        then:
+        !result.wasSkipped("test")
+        result.wasSkipped("setAPICompatibilityLevel")
+        result.wasSkipped("unsetAPICompatibilityLevel")
+        settings.text.contains("apiCompatibilityLevel: ${defaultAPICompatibilityLevel.value}")
+        !result.standardOutput.contains("Setting API compatibility level to ${expectedAPICompatibilityLevel}")
+        !result.standardOutput.contains("Setting API compatibility level to ${defaultAPICompatibilityLevel}")
+
+        where:
+        defaultAPICompatibilityLevel = APICompatibilityLevel.net2_0_subset
+        expectedAPICompatibilityLevel = defaultAPICompatibilityLevel
+    }
+}

--- a/src/main/groovy/wooga/gradle/unity/APICompatibilityLevel.groovy
+++ b/src/main/groovy/wooga/gradle/unity/APICompatibilityLevel.groovy
@@ -1,0 +1,42 @@
+package wooga.gradle.unity
+
+import org.gradle.internal.impldep.org.apache.commons.lang.NullArgumentException
+
+import java.nio.InvalidMarkException
+import java.security.InvalidKeyException
+
+enum APICompatibilityLevel {
+    net2_0(1),
+    net2_0_subset(2),
+    net4_6(3),
+    net_web(4),
+    net_micro(5),
+    net_standard_2_0(6)
+
+    private static Map map = new HashMap<>();
+
+    static {
+        for (APICompatibilityLevel apiLevel : APICompatibilityLevel.values()) {
+            map.put(apiLevel.value, apiLevel);
+        }
+    }
+
+    APICompatibilityLevel(Integer value) {
+        this.value = value
+    }
+
+    private final Integer value
+    Integer getValue() {
+        value
+    }
+
+    static APICompatibilityLevel valueOfInt(Integer value) {
+        if (!map.containsKey(value)) {
+            throw new InvalidKeyException("There is no  API compatibility level for the value ${value}")
+        }
+        return (APICompatibilityLevel) map.get(value);
+    }
+
+    static final String unityProjectSettingsPropertyKey = "apiCompatibilityLevel"
+    static final APICompatibilityLevel defaultLevel = APICompatibilityLevel.net2_0_subset
+}

--- a/src/main/groovy/wooga/gradle/unity/UnityPluginConsts.groovy
+++ b/src/main/groovy/wooga/gradle/unity/UnityPluginConsts.groovy
@@ -66,6 +66,7 @@ class UnityPluginConsts {
      */
     static final String UNITY_PATH_OPTION = "unity.path"
 
+
     /**
      * Environment variable name to set the default value for {@code unityPath}.
      * @value "UNITY_PATH"
@@ -170,5 +171,8 @@ class UnityPluginConsts {
      * @see UnityAuthentication#serial
      */
     static final String UNITY_SERIAL_ENV = "UNITY_SERIAL"
+
+    static final String UNITY_API_COMPATIBILITY_LEVEL_OPTION = "unity.apiCompatibilityLevel"
+    static final String UNITY_API_COMPATIBILITY_LEVEL_ENV_VAR = "UNITY_API_COMPATIBILITY_LEVEL"
 
 }

--- a/src/main/groovy/wooga/gradle/unity/UnityPluginConvention.groovy
+++ b/src/main/groovy/wooga/gradle/unity/UnityPluginConvention.groovy
@@ -157,5 +157,20 @@ interface UnityPluginConvention extends UnityActionConvention {
      */
     UnityPluginConvention batchModeForPlayModeTest(Boolean value)
 
+    /**
+     * Returns if batchmode should be enabled
+     * @return a{@code Boolean} value
+     */
     Boolean getBatchMode(TestPlatform testPlatform)
+
+    /**
+     * Returns the {@code APICompatibilityLevel} if one has been assigned
+     * @return the {@code APICompatibilityLevel} value
+     */
+    APICompatibilityLevel getApiCompatibilityLevel()
+
+    /**
+     * Sets the {@code APICompatibilityLevel}, which affects the project's compilation
+     */
+    void setApiCompatibilityLevel(APICompatibilityLevel level)
 }

--- a/src/main/groovy/wooga/gradle/unity/internal/DefaultUnityPluginExtension.groovy
+++ b/src/main/groovy/wooga/gradle/unity/internal/DefaultUnityPluginExtension.groovy
@@ -20,10 +20,12 @@ package wooga.gradle.unity.internal
 import org.gradle.api.Action
 import org.gradle.api.Project
 import org.gradle.api.internal.file.FileResolver
+import org.gradle.api.logging.LogLevel
 import org.gradle.internal.Factory
 import org.gradle.internal.reflect.Instantiator
 import org.gradle.process.ExecResult
 import org.gradle.util.GUtil
+import wooga.gradle.unity.APICompatibilityLevel
 import wooga.gradle.unity.UnityAuthentication
 import wooga.gradle.unity.UnityPlugin
 import wooga.gradle.unity.UnityPluginConsts
@@ -32,6 +34,7 @@ import wooga.gradle.unity.UnityPluginExtension
 import wooga.gradle.unity.batchMode.*
 import wooga.gradle.unity.batchMode.internal.DefaultActivationActionFactory
 import wooga.gradle.unity.batchMode.internal.DefaultBatchModeActionFactory
+import wooga.gradle.unity.tasks.SetAPICompatibilityLevel
 import wooga.gradle.unity.utils.internal.UnityHub
 
 import java.util.concurrent.Callable
@@ -517,5 +520,28 @@ class DefaultUnityPluginExtension implements UnityPluginExtension, UnityPluginAc
             default:
                 return true
         }
+    }
+
+    private APICompatibilityLevel _apiCompatibilityLevel
+
+    @Override
+    APICompatibilityLevel getApiCompatibilityLevel() {
+        if(_apiCompatibilityLevel) {
+            return _apiCompatibilityLevel
+        }
+        return getApiCompatibilityLevelFromEnv(project.properties, System.getenv())
+    }
+
+    static APICompatibilityLevel getApiCompatibilityLevelFromEnv(Map<String, ?> properties, Map<String, String> env) {
+        String rawValue = (properties[UnityPluginConsts.UNITY_API_COMPATIBILITY_LEVEL_OPTION] ?: env[UnityPluginConsts.UNITY_API_COMPATIBILITY_LEVEL_ENV_VAR])
+        if (rawValue) {
+            return APICompatibilityLevel.valueOf(rawValue)
+        }
+        null
+    }
+
+    @Override
+    void setApiCompatibilityLevel(APICompatibilityLevel level) {
+        _apiCompatibilityLevel = level
     }
 }

--- a/src/main/groovy/wooga/gradle/unity/tasks/SetAPICompatibilityLevel.groovy
+++ b/src/main/groovy/wooga/gradle/unity/tasks/SetAPICompatibilityLevel.groovy
@@ -1,0 +1,108 @@
+package wooga.gradle.unity.tasks
+
+import org.gradle.api.internal.ConventionTask
+import org.gradle.api.specs.Spec
+import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.InputFile
+import org.gradle.api.tasks.Optional
+import org.gradle.api.tasks.TaskAction
+import wooga.gradle.unity.APICompatibilityLevel
+import wooga.gradle.unity.utils.GenericUnityAsset
+
+class SetAPICompatibilityLevel extends ConventionTask {
+
+    @InputFile
+    File getSettingsFile() {
+        project.file(settingsFile)
+    }
+
+    void setSettingsFile(Object value) {
+        this.settingsFile = value
+    }
+    private Object settingsFile;
+
+    @Input
+    @Optional
+    APICompatibilityLevel getApiCompatibilityLevel() {
+        def value = apiCompatibilityLevel
+
+        if (!value) {
+            return null
+        }
+
+        if (value instanceof Closure) {
+            value = value.call()
+        }
+
+        if (!value) {
+            return null
+        }
+
+        if (value instanceof APICompatibilityLevel) {
+            value = value as APICompatibilityLevel
+        }
+        else if (value instanceof Integer) {
+            value = APICompatibilityLevel.valueOfInt((value))
+        }
+        else{
+            try {
+                value = value.toString() as APICompatibilityLevel
+            }
+            catch (Exception e){
+                throw new Exception(parseFailureMessage)
+            }
+        }
+
+        return value
+    }
+
+    void setApiCompatibilityLevel(Object value) {
+        this.apiCompatibilityLevel = value
+    }
+
+    void apiCompatibilityLevel(Object value) {
+        setApiCompatibilityLevel(value)
+    }
+
+    Object apiCompatibilityLevel
+
+    APICompatibilityLevel previousAPICompatibilityLevel
+
+    final static String parseFailureMessage = "Failed to parse API compatibility level"
+    private final static String apiCompatibilityLevelPropertyPattern = /${APICompatibilityLevel.unityProjectSettingsPropertyKey}:.*$/
+
+    SetAPICompatibilityLevel() {
+        onlyIf(new Spec<SetAPICompatibilityLevel>() {
+            @Override
+            boolean isSatisfiedBy(SetAPICompatibilityLevel t) {
+                t.settingsFile != null
+                t.apiCompatibilityLevel != null
+            }
+        })
+        onlyIf(new Spec<SetAPICompatibilityLevel>() {
+            @Override
+            boolean isSatisfiedBy(SetAPICompatibilityLevel t) {
+                def file = getSettingsFile()
+                def config = new GenericUnityAsset(file)
+                def previousAPICompatibilityLevel = APICompatibilityLevel.valueOfInt(config[APICompatibilityLevel.unityProjectSettingsPropertyKey] as Integer)
+                return previousAPICompatibilityLevel != getApiCompatibilityLevel()
+            }
+        })
+    }
+
+    @TaskAction
+    protected void onExecute() {
+
+        def file = getSettingsFile()
+        def config = new GenericUnityAsset(file)
+        previousAPICompatibilityLevel = APICompatibilityLevel.valueOfInt(config[APICompatibilityLevel.unityProjectSettingsPropertyKey] as Integer)
+
+        APICompatibilityLevel apiLevel = getApiCompatibilityLevel()
+        ant.replaceregexp(file: file.absolutePath,
+                match: apiCompatibilityLevelPropertyPattern,
+                replace: "${APICompatibilityLevel.unityProjectSettingsPropertyKey}: ${apiLevel.value}",
+                byline: true)
+        logger.info("Setting API compatibility level to ${apiLevel} (${apiLevel.value})")
+    }
+
+}

--- a/src/test/groovy/wooga/gradle/unity/APICompatibilityLevelSpec.groovy
+++ b/src/test/groovy/wooga/gradle/unity/APICompatibilityLevelSpec.groovy
@@ -1,0 +1,56 @@
+package wooga.gradle.unity
+
+import org.gradle.internal.impldep.org.apache.commons.lang.NullArgumentException
+import spock.lang.Specification
+import spock.lang.Subject
+
+import java.security.InvalidKeyException
+
+@Subject(APICompatibilityLevel)
+class APICompatibilityLevelSpec extends Specification {
+
+    def "parses api compatibility level string"() {
+        given:
+        def apiCompatLevel = value as APICompatibilityLevel
+
+        expect:
+        expectedAPICompatLevel == apiCompatLevel
+
+        where:
+        value | expectedAPICompatLevel
+        "net2_0" | APICompatibilityLevel.net2_0
+        "net2_0_subset" | APICompatibilityLevel.net2_0_subset
+        "net4_6" | APICompatibilityLevel.net4_6
+        "net_web" | APICompatibilityLevel.net_web
+        "net_micro" | APICompatibilityLevel.net_micro
+        "net_standard_2_0" | APICompatibilityLevel.net_standard_2_0
+    }
+
+    def "parses api compatibility level from int"() {
+        given:
+        def apiCompatLevel = APICompatibilityLevel.valueOfInt(value)
+
+        expect:
+        expectedAPICompatLevel == apiCompatLevel
+
+        where:
+        value | expectedAPICompatLevel
+        1 | APICompatibilityLevel.net2_0
+        2 | APICompatibilityLevel.net2_0_subset
+        3 | APICompatibilityLevel.net4_6
+        4 | APICompatibilityLevel.net_web
+        5 | APICompatibilityLevel.net_micro
+        6 | APICompatibilityLevel.net_standard_2_0
+    }
+
+    def "handles invalid values for api compatibility level from int"() {
+        when:
+        APICompatibilityLevel.valueOfInt(value)
+
+        then:
+        thrown(InvalidKeyException)
+
+        where:
+        value << [-1, 10]
+    }
+}

--- a/src/test/groovy/wooga/gradle/unity/DefaultUnityPluginExtensionSpec.groovy
+++ b/src/test/groovy/wooga/gradle/unity/DefaultUnityPluginExtensionSpec.groovy
@@ -329,20 +329,47 @@ class DefaultUnityPluginExtensionSpec extends Specification {
         subject.logCategory == testCategory
     }
 
+    def "set api compatibility level with properties"() {
+        given: "valid api compatibility level"
+        def testCompatibilityLevel = APICompatibilityLevel.net4_6
+
+        and:
+        projectProperties[UnityPluginConsts.UNITY_API_COMPATIBILITY_LEVEL_OPTION] = testCompatibilityLevel.toString()
+
+        expect:
+        subject.getApiCompatibilityLevel() == testCompatibilityLevel
+    }
+
     def "get logCategory from env returns property value over env"() {
         given: "logCategory set in properties"
         def category = "highPriority"
-        def props = ['unity.logCategory': category]
+        def props = [(UnityPluginConsts.UNITY_LOG_CATEGORY_OPTION): category]
 
         and: "unity path in environment"
         def newCategory = "lowPriority"
-        def env = ['UNITY_LOG_CATEGORY': newCategory]
+        def env = [(UnityPluginConsts.UNITY_LOG_CATEGORY_ENV_VAR): newCategory]
 
         when: "calling getUnityLogCategory"
         def result = subject.getUnityLogCategory(props, env)
 
         then: "file path points to props path"
         result == category
+    }
+
+    def "get api compatibility level from env returns property value over env"() {
+        given: "api compatibility level set in properties"
+        def level = APICompatibilityLevel.net4_6
+        def props = [(UnityPluginConsts.UNITY_API_COMPATIBILITY_LEVEL_OPTION): level.toString()]
+
+        and: "unity path in environment"
+        def newLevel = APICompatibilityLevel.net_micro
+        def env = [(UnityPluginConsts.UNITY_API_COMPATIBILITY_LEVEL_ENV_VAR): newLevel.toString()]
+
+        when: "calling getAPICompatibilityLevel"
+        def result = subject.getApiCompatibilityLevelFromEnv(props, env)
+
+        then: "file path points to props path"
+        result == level
     }
 
     class BuildTargetTestObject {

--- a/src/test/groovy/wooga/gradle/unity/utils/internal/ProjectSettingsSpec.groovy
+++ b/src/test/groovy/wooga/gradle/unity/utils/internal/ProjectSettingsSpec.groovy
@@ -18,6 +18,7 @@
 package wooga.gradle.unity.utils.internal
 
 import spock.lang.Unroll
+import wooga.gradle.unity.APICompatibilityLevel
 
 class ProjectSettingsSpec extends UnityAssetFileSpec {
 
@@ -34,6 +35,7 @@ class ProjectSettingsSpec extends UnityAssetFileSpec {
         wiiUDrcBufferDisabled: 0
         wiiUProfilerLibPath: 
         playModeTestRunnerEnabled: 0
+        apiCompatibilityLevel: ${APICompatibilityLevel.net2_0_subset.value}
         actionOnDotNetUnhandledException: 1
     
     """.stripIndent()


### PR DESCRIPTION
## Description

Adds a new task to set the API compatibility level on the ProjectSettings.asset, which will be used to test Unity versions against different NET runtimes (2, 4.6)

## Changes
* ![ADD] SetAPICompatibilityLevel
* ![ADD] APICompatibilityLevel
* ![UPDATE] DefaultUnityPluginExtension, UnityPlugin
* ![UPDATE] UnityPluginConsts, UnityPluginConvention

[NEW]:https://atlas-resources.wooga.com/icons/icon_new.svg "New"
[ADD]:http://resources.atlas.wooga.com/icons/icon_add.svg "Add"
[IMPROVE]:http://resources.atlas.wooga.com/icons/icon_improve.svg "IMPROVE"
[CHANGE]:http://resources.atlas.wooga.com/icons/icon_change.svg "Change"
[FIX]:http://resources.atlas.wooga.com/icons/icon_fix.svg "Fix"
[UPDATE]:http://resources.atlas.wooga.com/icons/icon_update.svg "Update"

[BREAK]:http://resources.atlas.wooga.com/icons/icon_break.svg "Remove"
[REMOVE]:http://resources.atlas.wooga.com/icons/icon_remove.svg "Remove"
[IOS]:http://resources.atlas.wooga.com/icons/icon_iOS.svg "iOS"
[ANDROID]:http://resources.atlas.wooga.com/icons/icon_android.svg "Android"
[WEBGL]:http://resources.atlas.wooga.com/icons/icon_webGL.svg "Web:GL"
