### PR TITLE
Fix SetAPICompatibilityLevel task

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,5 +1,19 @@
 #!groovy
-
+/*
+ * Copyright 2018-2020 Wooga GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 @Library('github.com/wooga/atlas-jenkins-pipeline@1.x') _
 
 withCredentials([usernameColonPassword(credentialsId: 'artifactory_publish', variable: 'artifactory_publish'),

--- a/src/integrationTest/groovy/wooga/gradle/unity/SetAPICompLevelIntegrationSpec.groovy
+++ b/src/integrationTest/groovy/wooga/gradle/unity/SetAPICompLevelIntegrationSpec.groovy
@@ -1,7 +1,7 @@
 package wooga.gradle.unity
 
 import spock.lang.Unroll
-import wooga.gradle.unity.tasks.SetAPICompatibilityLevel
+import wooga.gradle.unity.utils.internal.ProjectSettings
 
 class SetAPICompLevelIntegrationSpec extends UnityIntegrationSpec {
 
@@ -29,8 +29,8 @@ class SetAPICompLevelIntegrationSpec extends UnityIntegrationSpec {
         !result.wasSkipped("test")
         result.wasExecuted("setAPICompatibilityLevel")
         !result.wasExecuted("unsetAPICompatibilityLevel")
-        settings.text.contains("apiCompatibilityLevel: ${expectedAPICompatibilityLevel.value}")
-        result.standardOutput.contains("Setting API compatibility level to ${expectedAPICompatibilityLevel}")
+        def expectedValueMap = APICompatibilityLevel.toMap(expectedAPICompatibilityLevel)
+        result.standardOutput.contains("Setting API compatibility level to ${expectedValueMap}")
 
         where:
 
@@ -64,33 +64,6 @@ class SetAPICompLevelIntegrationSpec extends UnityIntegrationSpec {
         testValue = (expectedValue == _) ? rawValue : expectedValue
         escapedValue = (value instanceof String) ? escapedPath(value) : value
         invocation = (method != _) ? "${method}(${escapedValue})" : "${property} = ${escapedValue}"
-
-    }
-
-    def "writes api level to project settings file correctly #expectedAPICompatibilityLevel"() {
-        given: "a valid api compatibility level to set"
-        buildFile << """
-            unity {
-               setApiCompatibilityLevel("${expectedAPICompatibilityLevel.toString()}") 
-            }
-            
-        """.stripIndent()
-
-        when:
-        def result = runTasksSuccessfully("test", "-x", "unsetAPICompatibilityLevel")
-
-        then:
-        !result.wasSkipped("test")
-        result.wasExecuted("setAPICompatibilityLevel")
-        !result.wasExecuted("unsetAPICompatibilityLevel")
-        settings.text.contains("apiCompatibilityLevel: ${expectedAPICompatibilityLevel.value}")
-        result.standardOutput.contains("Setting API compatibility level to ${expectedAPICompatibilityLevel}")
-
-        where:
-        defaultAPICompatibilityLevel = APICompatibilityLevel.net2_0_subset
-        expectedAPICompatibilityLevel << [APICompatibilityLevel.net4_6,
-                                          APICompatibilityLevel.net_micro,
-                                          APICompatibilityLevel.net_web]
     }
 
     def "sets the api level onto the project settings file, then unsets it"() {
@@ -103,7 +76,9 @@ class SetAPICompLevelIntegrationSpec extends UnityIntegrationSpec {
         """.stripIndent()
 
         and: "ensure that the api compatibility level isn't the default"
-        assert settings.text.contains("apiCompatibilityLevel: ${defaultAPICompatibilityLevel.value}")
+        def projectSettings = new ProjectSettings(settings)
+        def previousAPICompLevelMap = projectSettings.getAPICompatibilityLevelPerPlatform()
+        assert previousAPICompLevelMap != null
 
         when:
         def result = runTasksSuccessfully("test")
@@ -112,9 +87,14 @@ class SetAPICompLevelIntegrationSpec extends UnityIntegrationSpec {
         !result.wasSkipped("test")
         result.wasExecuted("setAPICompatibilityLevel")
         result.wasExecuted("unsetAPICompatibilityLevel")
-        !settings.text.contains("apiCompatibilityLevel: ${expectedAPICompatibilityLevel.value}")
-        result.standardOutput.contains("Setting API compatibility level to ${expectedAPICompatibilityLevel}")
-        result.standardOutput.contains("Setting API compatibility level to ${defaultAPICompatibilityLevel}")
+
+        def expectedValueMap = APICompatibilityLevel.toMap(expectedAPICompatibilityLevel)
+        result.standardOutput.contains("Setting API compatibility level to ${expectedValueMap}")
+        result.standardOutput.contains("Setting API compatibility level to ${previousAPICompLevelMap}")
+
+        def updatedProjectSettings = new ProjectSettings(settings)
+        def currentAPICompLevelMap = updatedProjectSettings.getAPICompatibilityLevelPerPlatform()
+        assert previousAPICompLevelMap == currentAPICompLevelMap
 
         where:
         expectedAPICompatibilityLevel = APICompatibilityLevel.net4_6
@@ -130,6 +110,14 @@ class SetAPICompLevelIntegrationSpec extends UnityIntegrationSpec {
             
         """.stripIndent()
 
+        and:
+        def projectSettings = new ProjectSettings(settings)
+        def previousAPICompLevelMap = projectSettings.getAPICompatibilityLevelPerPlatform()
+        assert previousAPICompLevelMap != null
+        def apiCompLevelMap = APICompatibilityLevel.toMap(expectedAPICompatibilityLevel)
+
+        assert previousAPICompLevelMap == apiCompLevelMap
+
         when:
         def result = runTasksSuccessfully("test")
 
@@ -137,12 +125,8 @@ class SetAPICompLevelIntegrationSpec extends UnityIntegrationSpec {
         !result.wasSkipped("test")
         result.wasSkipped("setAPICompatibilityLevel")
         result.wasSkipped("unsetAPICompatibilityLevel")
-        settings.text.contains("apiCompatibilityLevel: ${defaultAPICompatibilityLevel.value}")
-        !result.standardOutput.contains("Setting API compatibility level to ${expectedAPICompatibilityLevel}")
-        !result.standardOutput.contains("Setting API compatibility level to ${defaultAPICompatibilityLevel}")
 
         where:
-        defaultAPICompatibilityLevel = APICompatibilityLevel.net2_0_subset
-        expectedAPICompatibilityLevel = defaultAPICompatibilityLevel
+        expectedAPICompatibilityLevel = APICompatibilityLevel.defaultLevel
     }
 }

--- a/src/integrationTest/groovy/wooga/gradle/unity/SetAPICompLevelIntegrationSpec.groovy
+++ b/src/integrationTest/groovy/wooga/gradle/unity/SetAPICompLevelIntegrationSpec.groovy
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2018-2020 Wooga GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package wooga.gradle.unity
 
 import spock.lang.Unroll

--- a/src/main/groovy/wooga/gradle/unity/APICompatibilityLevel.groovy
+++ b/src/main/groovy/wooga/gradle/unity/APICompatibilityLevel.groovy
@@ -1,40 +1,50 @@
+/*
+ * Copyright 2018-2020 Wooga GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package wooga.gradle.unity
 
-import org.gradle.internal.impldep.org.apache.commons.lang.NullArgumentException
-
-import java.nio.InvalidMarkException
 import java.security.InvalidKeyException
 
 /**
-.NET profile support
-
-Unity supports a number of .NET profiles. Each profile provides a different API surface for C# code
-which interacts with the .NET class libraries.
-
-The legacy scripting runtime supports two different profiles:
-NET 2.0 Subset and .NET 2.0. Both of these are closely aligned with the .NET 2.0 profile from Microsoft.
-The .NET 2.0 Subset profile is smaller than the .NET 4.x profile, and it allows access to the class library APIs that most Unity projects use.
-It is the ideal choice for size-constrained platforms, such as mobile, and it provides a set of portable APIs for multiplatform support.
-By default, most Unity projects should use the .NET Standard 2.0 profile.
-
-The stable scripting runtime supports two different profiles: .NET Standard 2.0 and .NET 4.x.
-The name of the .NET Standard 2.0 profile can be a bit misleading because it is not related to the .NET 2.0 and .NET 2.0 Subset profile
-from the legacy scripting runtime. Instead, Unity’s support for the .NET Standard 2.0 profile matches the profile of the same name published
-by the .NET Foundation. The .NET 4.x profile in Unity matches the .NET 4 series (.NET 4.5, .NET 4.6, .NET 4.7, and so on) of profiles from the .NET Framework.
-
-Only use the .NET 4.x profile for compatibility with external libraries, or when you require functionality that is not available in .NET Standard 2.0.
-
-Unity aims to support the vast majority of the APIs in the .NET Standard 2.0 profile on all platforms.
-While not all platforms fully support the .NET Standard, libraries which aim for cross-platform compatibility should target the .NET Standard 2.0 profile.
-The .NET 4.x profile includes a much larger API surface, including parts which may work on few or no platforms.
-*/
-
-enum SupportedBuildTargetGroup {
-    Standalone,
-    Android,
-    iPhone,
-}
-
+ * .NET profile support
+ *
+ * Unity supports a number of .NET profiles. Each profile provides a different API surface for C# code
+ * which interacts with the .NET class libraries.
+ *
+ * The legacy scripting runtime supports two different profiles:
+ * NET 2.0 Subset and .NET 2.0. Both of these are closely aligned with the .NET 2.0 profile from Microsoft.
+ * The .NET 2.0 Subset profile is smaller than the .NET 4.x profile, and it allows access to the class library
+ * APIs that most Unity projects use. It is the ideal choice for size-constrained platforms, such as mobile,
+ * and it provides a set of portable APIs for multiplatform support. By default, most Unity projects should
+ * use the .NET Standard 2.0 profile.
+ *
+ * The stable scripting runtime supports two different profiles: .NET Standard 2.0 and .NET 4.x.
+ * The name of the .NET Standard 2.0 profile can be a bit misleading because it is not related to the .NET 2.0 and
+ * .NET 2.0 Subset profile from the legacy scripting runtime. Instead, Unity’s support for the .NET Standard 2.0 profile
+ * matches the profile of the same name published by the .NET Foundation. The .NET 4.x profile in Unity matches the
+ * .NET 4 series (.NET 4.5, .NET 4.6, .NET 4.7, and so on) of profiles from the .NET Framework.
+ *
+ * Only use the .NET 4.x profile for compatibility with external libraries,
+ * or when you require functionality that is not available in .NET Standard 2.0.
+ *
+ * Unity aims to support the vast majority of the APIs in the .NET Standard 2.0 profile on all platforms.
+ * While not all platforms fully support the .NET Standard, libraries which aim for cross-platform compatibility should
+ * target the .NET Standard 2.0 profile.
+ * The .NET 4.x profile includes a much larger API surface, including parts which may work on few or no platforms.
+**/
 enum APICompatibilityLevel {
 
     net2_0(1),
@@ -55,12 +65,12 @@ enum APICompatibilityLevel {
     /**
         The default API compatibility level used by Unity
      */
-    static final APICompatibilityLevel defaultLevel = APICompatibilityLevel.net_standard_2_0
+    static final APICompatibilityLevel defaultLevel = net_standard_2_0
 
     private static Map map = new HashMap<>();
 
     static {
-        for (APICompatibilityLevel apiLevel : APICompatibilityLevel.values()) {
+        for (APICompatibilityLevel apiLevel : values()) {
             map.put(apiLevel.value, apiLevel);
         }
     }
@@ -89,4 +99,10 @@ enum APICompatibilityLevel {
         return map
     }
 
+}
+
+enum SupportedBuildTargetGroup {
+    Standalone,
+    Android,
+    iPhone,
 }

--- a/src/main/groovy/wooga/gradle/unity/APICompatibilityLevel.groovy
+++ b/src/main/groovy/wooga/gradle/unity/APICompatibilityLevel.groovy
@@ -5,13 +5,57 @@ import org.gradle.internal.impldep.org.apache.commons.lang.NullArgumentException
 import java.nio.InvalidMarkException
 import java.security.InvalidKeyException
 
+/**
+.NET profile support
+
+Unity supports a number of .NET profiles. Each profile provides a different API surface for C# code
+which interacts with the .NET class libraries.
+
+The legacy scripting runtime supports two different profiles:
+NET 2.0 Subset and .NET 2.0. Both of these are closely aligned with the .NET 2.0 profile from Microsoft.
+The .NET 2.0 Subset profile is smaller than the .NET 4.x profile, and it allows access to the class library APIs that most Unity projects use.
+It is the ideal choice for size-constrained platforms, such as mobile, and it provides a set of portable APIs for multiplatform support.
+By default, most Unity projects should use the .NET Standard 2.0 profile.
+
+The stable scripting runtime supports two different profiles: .NET Standard 2.0 and .NET 4.x.
+The name of the .NET Standard 2.0 profile can be a bit misleading because it is not related to the .NET 2.0 and .NET 2.0 Subset profile
+from the legacy scripting runtime. Instead, Unity’s support for the .NET Standard 2.0 profile matches the profile of the same name published
+by the .NET Foundation. The .NET 4.x profile in Unity matches the .NET 4 series (.NET 4.5, .NET 4.6, .NET 4.7, and so on) of profiles from the .NET Framework.
+
+Only use the .NET 4.x profile for compatibility with external libraries, or when you require functionality that is not available in .NET Standard 2.0.
+
+Unity aims to support the vast majority of the APIs in the .NET Standard 2.0 profile on all platforms.
+While not all platforms fully support the .NET Standard, libraries which aim for cross-platform compatibility should target the .NET Standard 2.0 profile.
+The .NET 4.x profile includes a much larger API surface, including parts which may work on few or no platforms.
+*/
+
+enum SupportedBuildTargetGroup {
+    Standalone,
+    Android,
+    iPhone,
+}
+
 enum APICompatibilityLevel {
+
     net2_0(1),
     net2_0_subset(2),
     net4_6(3),
     net_web(4),
     net_micro(5),
-    net_standard_2_0(6)
+    net_standard_2_0(6) // DEFAULT
+
+    /**
+     * The key in the Unity project's ProjectSettings.asset file.
+     * apiCompatibilityLevelPerPlatform:
+     *   Android: 3
+     *   Standalone: 6
+     *   iPhone: 3
+     */
+    static final String unityProjectSettingsPropertyKey = "apiCompatibilityLevelPerPlatform"
+    /**
+        The default API compatibility level used by Unity
+     */
+    static final APICompatibilityLevel defaultLevel = APICompatibilityLevel.net_standard_2_0
 
     private static Map map = new HashMap<>();
 
@@ -37,6 +81,12 @@ enum APICompatibilityLevel {
         return (APICompatibilityLevel) map.get(value);
     }
 
-    static final String unityProjectSettingsPropertyKey = "apiCompatibilityLevel"
-    static final APICompatibilityLevel defaultLevel = APICompatibilityLevel.net2_0_subset
+    static Map<String, APICompatibilityLevel> toMap(APICompatibilityLevel level) {
+        Map<String, APICompatibilityLevel> map = [:]
+        for (group in SupportedBuildTargetGroup.values()) {
+            map.put(group.toString(), level)
+        }
+        return map
+    }
+
 }

--- a/src/main/groovy/wooga/gradle/unity/UnityPlugin.groovy
+++ b/src/main/groovy/wooga/gradle/unity/UnityPlugin.groovy
@@ -45,7 +45,6 @@ import wooga.gradle.unity.tasks.UnityPackageArtifact
 import wooga.gradle.unity.tasks.internal.AbstractUnityActivationTask
 import wooga.gradle.unity.tasks.internal.AbstractUnityProjectTask
 import wooga.gradle.unity.tasks.internal.AbstractUnityTask
-import wooga.gradle.unity.utils.GenericUnityAsset
 
 import javax.inject.Inject
 import java.util.concurrent.Callable

--- a/src/main/groovy/wooga/gradle/unity/tasks/SetAPICompatibilityLevel.groovy
+++ b/src/main/groovy/wooga/gradle/unity/tasks/SetAPICompatibilityLevel.groovy
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2018-2020 Wooga GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package wooga.gradle.unity.tasks
 
 import org.gradle.api.internal.ConventionTask

--- a/src/main/groovy/wooga/gradle/unity/tasks/SetAPICompatibilityLevel.groovy
+++ b/src/main/groovy/wooga/gradle/unity/tasks/SetAPICompatibilityLevel.groovy
@@ -7,7 +7,7 @@ import org.gradle.api.tasks.InputFile
 import org.gradle.api.tasks.Optional
 import org.gradle.api.tasks.TaskAction
 import wooga.gradle.unity.APICompatibilityLevel
-import wooga.gradle.unity.utils.GenericUnityAsset
+import wooga.gradle.unity.utils.internal.ProjectSettings
 
 class SetAPICompatibilityLevel extends ConventionTask {
 
@@ -23,7 +23,7 @@ class SetAPICompatibilityLevel extends ConventionTask {
 
     @Input
     @Optional
-    APICompatibilityLevel getApiCompatibilityLevel() {
+    Map<String, APICompatibilityLevel> getApiCompatibilityLevel() {
         def value = apiCompatibilityLevel
 
         if (!value) {
@@ -38,21 +38,26 @@ class SetAPICompatibilityLevel extends ConventionTask {
             return null
         }
 
+        if (value instanceof Map<String, APICompatibilityLevel>){
+            return value
+        }
+
         if (value instanceof APICompatibilityLevel) {
             value = value as APICompatibilityLevel
         }
         else if (value instanceof Integer) {
             value = APICompatibilityLevel.valueOfInt((value))
         }
-        else{
+        else {
             try {
                 value = value.toString() as APICompatibilityLevel
             }
-            catch (Exception e){
+            catch (Exception e) {
                 throw new Exception(parseFailureMessage)
             }
         }
 
+        value = APICompatibilityLevel.toMap(value)
         return value
     }
 
@@ -65,11 +70,9 @@ class SetAPICompatibilityLevel extends ConventionTask {
     }
 
     Object apiCompatibilityLevel
-
-    APICompatibilityLevel previousAPICompatibilityLevel
+    Map<String, APICompatibilityLevel> previousAPICompatibilityLevel
 
     final static String parseFailureMessage = "Failed to parse API compatibility level"
-    private final static String apiCompatibilityLevelPropertyPattern = /${APICompatibilityLevel.unityProjectSettingsPropertyKey}:.*$/
 
     SetAPICompatibilityLevel() {
         onlyIf(new Spec<SetAPICompatibilityLevel>() {
@@ -83,9 +86,12 @@ class SetAPICompatibilityLevel extends ConventionTask {
             @Override
             boolean isSatisfiedBy(SetAPICompatibilityLevel t) {
                 def file = getSettingsFile()
-                def config = new GenericUnityAsset(file)
-                def previousAPICompatibilityLevel = APICompatibilityLevel.valueOfInt(config[APICompatibilityLevel.unityProjectSettingsPropertyKey] as Integer)
-                return previousAPICompatibilityLevel != getApiCompatibilityLevel()
+                def projectSettings = new ProjectSettings(file)
+
+                def currentAPICompLevel = projectSettings.getAPICompatibilityLevelPerPlatform()
+                def newAPICompLevel = getApiCompatibilityLevel()
+
+                return currentAPICompLevel != newAPICompLevel
             }
         })
     }
@@ -94,15 +100,17 @@ class SetAPICompatibilityLevel extends ConventionTask {
     protected void onExecute() {
 
         def file = getSettingsFile()
-        def config = new GenericUnityAsset(file)
-        previousAPICompatibilityLevel = APICompatibilityLevel.valueOfInt(config[APICompatibilityLevel.unityProjectSettingsPropertyKey] as Integer)
+        def projectSettings = new ProjectSettings(file)
 
-        APICompatibilityLevel apiLevel = getApiCompatibilityLevel()
-        ant.replaceregexp(file: file.absolutePath,
-                match: apiCompatibilityLevelPropertyPattern,
-                replace: "${APICompatibilityLevel.unityProjectSettingsPropertyKey}: ${apiLevel.value}",
-                byline: true)
-        logger.info("Setting API compatibility level to ${apiLevel} (${apiLevel.value})")
+        previousAPICompatibilityLevel = projectSettings.getAPICompatibilityLevelPerPlatform()
+        if (previousAPICompatibilityLevel == null) {
+            logger.warn("No previous API compatibility level was set")
+        }
+
+        Map<String, APICompatibilityLevel> apiLevel = getApiCompatibilityLevel()
+        logger.info("Setting API compatibility level to ${apiLevel}")
+        projectSettings.setAPICompatibilityLevelForSupportedPlatforms(apiLevel)
+        projectSettings.write(file)
     }
 
 }

--- a/src/main/groovy/wooga/gradle/unity/utils/GenericUnityAsset.groovy
+++ b/src/main/groovy/wooga/gradle/unity/utils/GenericUnityAsset.groovy
@@ -18,6 +18,8 @@
 package wooga.gradle.unity.utils
 
 import groovy.transform.InheritConstructors
+import org.gradle.internal.impldep.org.hamcrest.core.IsEqual
+import sun.net.www.content.text.Generic
 import wooga.gradle.unity.utils.internal.UnityAssetFile
 
 /**

--- a/src/main/groovy/wooga/gradle/unity/utils/internal/ProjectSettings.groovy
+++ b/src/main/groovy/wooga/gradle/unity/utils/internal/ProjectSettings.groovy
@@ -19,11 +19,44 @@
 package wooga.gradle.unity.utils.internal
 
 import groovy.transform.InheritConstructors
+import wooga.gradle.unity.APICompatibilityLevel
+import wooga.gradle.unity.SupportedBuildTargetGroup
+import wooga.gradle.unity.utils.GenericUnityAsset
 
 @InheritConstructors
 class ProjectSettings extends UnityAssetFile {
 
     boolean getPlayModeTestRunnerEnabled() {
         content['playModeTestRunnerEnabled'] && content['playModeTestRunnerEnabled'] == 1
+    }
+
+    Map<String, APICompatibilityLevel> getAPICompatibilityLevelPerPlatform() {
+        Map value = getSerializedAPICompatibilityLevelPerPlatform()
+        Map<String, APICompatibilityLevel> conversion = value.collectEntries
+                { [ it.key, APICompatibilityLevel.valueOfInt(it.value) ]
+        }
+        return conversion
+    }
+
+    boolean setAPICompatibilityLevelForSupportedPlatforms(APICompatibilityLevel level) {
+        Map map = getSerializedAPICompatibilityLevelPerPlatform()
+
+        if (map == null) {
+            return false
+        }
+        for (group in SupportedBuildTargetGroup.values()) {
+            map.put(group.toString(), level.value)
+        }
+    }
+
+    private Map<String, Integer> getSerializedAPICompatibilityLevelPerPlatform() {
+        content[APICompatibilityLevel.unityProjectSettingsPropertyKey]
+    }
+
+    void setAPICompatibilityLevelForSupportedPlatforms(Map value) {
+        content[APICompatibilityLevel.unityProjectSettingsPropertyKey] = value.collectEntries
+                { [ it.key,
+                   it.value instanceof APICompatibilityLevel
+                           ? ((APICompatibilityLevel)it.value).value : it.value ]}
     }
 }

--- a/src/main/groovy/wooga/gradle/unity/utils/internal/UnityAssetFile.groovy
+++ b/src/main/groovy/wooga/gradle/unity/utils/internal/UnityAssetFile.groovy
@@ -17,59 +17,137 @@
 
 package wooga.gradle.unity.utils.internal
 
+import groovyjarjarcommonscli.MissingArgumentException
 import org.gradle.api.logging.Logger
 import org.gradle.api.logging.Logging
+import org.yaml.snakeyaml.DumperOptions
 import org.yaml.snakeyaml.Yaml
 
+/**
+ * Manages the parsing and serialization of an Unity YAML asset file
+ */
 abstract class UnityAssetFile {
+
     static Logger logger = Logging.getLogger(UnityAssetFile)
+
     private final validObject
+    private final File assetFile
+    private final UnityAssetFileText assetFileText
 
     private Map<String, Object> content = [:]
 
     UnityAssetFile(File assetFile) {
         this(assetFile.text)
+        this.assetFile = assetFile
     }
 
     UnityAssetFile(String content) {
         boolean isValid = false
         try {
             Yaml parser = new Yaml()
-            Map<String, Object> c = parser.load(stripUnityInstructions(content))
+            assetFileText = strip(content)
+            Map<String, Object> c = parser.load(assetFileText.stripped)
             this.content = c[c.keySet().first()] as Map<String, Object>
             isValid = true
 
         }
         catch (Exception ignored) {
-            logger.warn("Project Settings file not parsable. Please make sure it's not set to binary.")
+            logger.warn("UnityAssetFile content not parsable. Please make sure it's not set to binary.")
         }
         validObject = isValid
+    }
+
+    @Override
+    int hashCode() {
+        return content.hashCode()
+    }
+
+    @Override
+    boolean equals(Object obj) {
+        if (!obj) {
+            return false
+        }
+        if (obj instanceof UnityAssetFile) {
+            UnityAssetFile other = (UnityAssetFile)obj
+            return this.content == other.content
+        }
+        return false
+    }
+
+    Boolean isSerialized() {
+        assetFile != null
     }
 
     Boolean isValid() {
         validObject
     }
 
+    File getAssetFile(){
+        assetFile
+    }
+
     Map<String, Object> getContent() {
         content
     }
 
-    static String stripUnityInstructions(String content) {
-        def lines = content.readLines()
-        lines.collect {
-            if (it.matches(/%TAG !u! tag:unity3d.com,.*:/)) {
-                return ""
-            }
-
-            def m = it =~ /(--- )!u!\d+( &\d+)/
-            if (m) {
-                return "${m[0][1]}${m[0][2]}"
-            }
-
-            return it
-        }
-        .join("\n")
+    boolean write() {
+        write(null)
     }
 
+    boolean write(File assetFile, indent = 2){
 
+        if (assetFile == null){
+            if (isSerialized()){
+                assetFile = this.assetFile
+            }
+            else{
+                throw new MissingArgumentException("No asset file was either set or provided to write to")
+            }
+        }
+
+        def options = new DumperOptions()
+        options.setDefaultFlowStyle(DumperOptions.FlowStyle.BLOCK)
+        options.indent = indent
+
+        Yaml parser = new Yaml(options)
+
+        def lines = []
+
+        // Append the yaml header and unity's instructions
+        lines.addAll(assetFileText.instructions)
+
+        // Add the main map
+        def property = ["PlayerSettings" : content]
+        def contentAsYaml = parser.dump(property)
+        contentAsYaml = contentAsYaml.replaceAll(": null\n", ": \n")
+        lines.add(contentAsYaml)
+
+        // Add a newline at the end of the file
+        lines.add("\n")
+
+        def serialization = lines.join("\n")
+        assetFile.write(serialization)
+        return true
+    }
+
+    static UnityAssetFileText strip(String content) {
+        UnityAssetFileText parse = new UnityAssetFileText(content)
+        return parse
+    }
+}
+
+class UnityAssetFileText {
+    final String original
+    final String stripped
+    final List<String> instructions
+
+    UnityAssetFileText(String content) {
+        original = content
+        def lines = content.readLines()
+        lines.removeAll({ it -> it.isEmpty()})
+        instructions = lines[0,1,2]
+        lines[1] = ""
+        lines[2] = "--- "
+        stripped = lines.join("\n")
+    }
 }

--- a/src/main/groovy/wooga/gradle/unity/utils/internal/UnityVersionManager.groovy
+++ b/src/main/groovy/wooga/gradle/unity/utils/internal/UnityVersionManager.groovy
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2018-2020 Wooga GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package wooga.gradle.unity.utils.internal
 
 import org.apache.maven.artifact.versioning.ArtifactVersion

--- a/src/test/groovy/wooga/gradle/unity/APICompatibilityLevelSpec.groovy
+++ b/src/test/groovy/wooga/gradle/unity/APICompatibilityLevelSpec.groovy
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2018-2020 Wooga GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package wooga.gradle.unity
 
 import org.gradle.internal.impldep.org.apache.commons.lang.NullArgumentException

--- a/src/test/groovy/wooga/gradle/unity/utils/internal/UnityAssetFileSpec.groovy
+++ b/src/test/groovy/wooga/gradle/unity/utils/internal/UnityAssetFileSpec.groovy
@@ -86,10 +86,10 @@ abstract class UnityAssetFileSpec extends Specification {
         """.stripIndent()
 
         when:
-        def result = UnityAssetFile.stripUnityInstructions(content)
+        def result = UnityAssetFile.strip(content)
 
         then:
-        result.readLines().every { !it.matches(/%TAG !u! tag:unity3d.com,.*:/) }
-        result.readLines().every { !it.matches(/(--- )!u!\d+( &\d+)/) }
+        result.stripped.readLines().every { !it.matches(/%TAG !u! tag:unity3d.com,.*:/) }
+        result.stripped.readLines().every { !it.matches(/(--- )!u!\d+( &\d+)/) }
     }
 }


### PR DESCRIPTION
## Description

Fixes the API compatibility level set task, which was setting a deprecated property instead of the newer one (of type Map).

Tests:

**NET STANDARD 2**

![image](https://user-images.githubusercontent.com/10147802/111990467-937cc800-8b13-11eb-8bf7-29e2908f2e27.png)

**NET 4**

![image](https://user-images.githubusercontent.com/10147802/111990076-e0ac6a00-8b12-11eb-9471-5efc7017742e.png)

## Changes

* ![UPDATE] UnityAssetFile
* ![UPDATE] ProjectSettings
* ![UPDATE] SetAPICompatibilityLevel

[NEW]:https://atlas-resources.wooga.com/icons/icon_new.svg "New"
[ADD]:http://resources.atlas.wooga.com/icons/icon_add.svg "Add"
[IMPROVE]:http://resources.atlas.wooga.com/icons/icon_improve.svg "IMPROVE"
[CHANGE]:http://resources.atlas.wooga.com/icons/icon_change.svg "Change"
[FIX]:http://resources.atlas.wooga.com/icons/icon_fix.svg "Fix"
[UPDATE]:http://resources.atlas.wooga.com/icons/icon_update.svg "Update"

[BREAK]:http://resources.atlas.wooga.com/icons/icon_break.svg "Remove"
[REMOVE]:http://resources.atlas.wooga.com/icons/icon_remove.svg "Remove"
[IOS]:http://resources.atlas.wooga.com/icons/icon_iOS.svg "iOS"
[ANDROID]:http://resources.atlas.wooga.com/icons/icon_android.svg "Android"
[WEBGL]:http://resources.atlas.wooga.com/icons/icon_webGL.svg "Web:GL"
