### PR TITLE
Fixes missing _ for several APICompatibilityLevel values

### DIFF
--- a/src/integrationTest/groovy/wooga/gradle/unity/SetAPICompLevelIntegrationSpec.groovy
+++ b/src/integrationTest/groovy/wooga/gradle/unity/SetAPICompLevelIntegrationSpec.groovy
@@ -50,20 +50,23 @@ class SetAPICompLevelIntegrationSpec extends UnityIntegrationSpec {
 
         where:
 
-        property                | method                     | rawValue                                | expectedValue                | type
-        'apiCompatibilityLevel' | _                          | APICompatibilityLevel.net4_6            | _                            | "APICompatibilityLevel"
-        'apiCompatibilityLevel' | _                          | APICompatibilityLevel.net4_6            | _                            | "Closure<APICompatibilityLevel>"
-        'apiCompatibilityLevel' | _                          | APICompatibilityLevel.net4_6.toString() | APICompatibilityLevel.net4_6 | "String"
-        'apiCompatibilityLevel' | _                          | APICompatibilityLevel.net4_6.toString() | APICompatibilityLevel.net4_6 | "Closure<String>"
-        'apiCompatibilityLevel' | _                          | APICompatibilityLevel.net4_6.value      | APICompatibilityLevel.net4_6 | "Integer"
-        'apiCompatibilityLevel' | _                          | APICompatibilityLevel.net4_6.value      | APICompatibilityLevel.net4_6 | "Closure<Integer>"
+        property                | method                  | rawValue                                 | expectedValue                        | type
+        'apiCompatibilityLevel' | _                       | APICompatibilityLevel.net_4_6            | _                                    | "APICompatibilityLevel"
+        'apiCompatibilityLevel' | _                       | APICompatibilityLevel.net_4_6            | _                                    | "Closure<APICompatibilityLevel>"
+        'apiCompatibilityLevel' | _                       | APICompatibilityLevel.net_4_6.toString() | APICompatibilityLevel.net_4_6        | "String"
+        'apiCompatibilityLevel' | _                       | "net2_0"                                 | APICompatibilityLevel.net_2_0        | "String"
+        'apiCompatibilityLevel' | _                       | "net4_6"                                 | APICompatibilityLevel.net_4_6        | "String"
+        'apiCompatibilityLevel' | _                       | "net2_0_subset"                          | APICompatibilityLevel.net_2_0_subset | "String"
+        'apiCompatibilityLevel' | _                       | APICompatibilityLevel.net_4_6.toString() | APICompatibilityLevel.net_4_6        | "Closure<String>"
+        'apiCompatibilityLevel' | _                       | APICompatibilityLevel.net_4_6.value      | APICompatibilityLevel.net_4_6        | "Integer"
+        'apiCompatibilityLevel' | _                       | APICompatibilityLevel.net_4_6.value      | APICompatibilityLevel.net_4_6        | "Closure<Integer>"
 
-        'apiCompatibilityLevel' | "apiCompatibilityLevel" | APICompatibilityLevel.net4_6            | _                            | "APICompatibilityLevel"
-        'apiCompatibilityLevel' | "apiCompatibilityLevel" | APICompatibilityLevel.net4_6            | _                            | "Closure<APICompatibilityLevel>"
-        'apiCompatibilityLevel' | "apiCompatibilityLevel" | APICompatibilityLevel.net4_6.toString() | APICompatibilityLevel.net4_6 | "String"
-        'apiCompatibilityLevel' | "apiCompatibilityLevel" | APICompatibilityLevel.net4_6.toString() | APICompatibilityLevel.net4_6 | "Closure<String>"
-        'apiCompatibilityLevel' | "apiCompatibilityLevel" | APICompatibilityLevel.net4_6.value      | APICompatibilityLevel.net4_6 | "Integer"
-        'apiCompatibilityLevel' | "apiCompatibilityLevel" | APICompatibilityLevel.net4_6.value      | APICompatibilityLevel.net4_6 | "Closure<Integer>"
+        'apiCompatibilityLevel' | "apiCompatibilityLevel" | APICompatibilityLevel.net_4_6            | _                                    | "APICompatibilityLevel"
+        'apiCompatibilityLevel' | "apiCompatibilityLevel" | APICompatibilityLevel.net_4_6            | _                                    | "Closure<APICompatibilityLevel>"
+        'apiCompatibilityLevel' | "apiCompatibilityLevel" | APICompatibilityLevel.net_4_6.toString() | APICompatibilityLevel.net_4_6        | "String"
+        'apiCompatibilityLevel' | "apiCompatibilityLevel" | APICompatibilityLevel.net_4_6.toString() | APICompatibilityLevel.net_4_6        | "Closure<String>"
+        'apiCompatibilityLevel' | "apiCompatibilityLevel" | APICompatibilityLevel.net_4_6.value      | APICompatibilityLevel.net_4_6        | "Integer"
+        'apiCompatibilityLevel' | "apiCompatibilityLevel" | APICompatibilityLevel.net_4_6.value      | APICompatibilityLevel.net_4_6        | "Closure<Integer>"
 
         taskName = "setAPICompatibilityLevel"
         value = (type != _) ? wrapValueBasedOnType(rawValue, type.toString(), { String type ->
@@ -76,7 +79,7 @@ class SetAPICompLevelIntegrationSpec extends UnityIntegrationSpec {
             }
         }) : rawValue
         expectedAPICompatibilityLevel = (expectedValue != _) ? expectedValue : rawValue
-        defaultAPICompatibilityLevel = APICompatibilityLevel.net2_0_subset
+        defaultAPICompatibilityLevel = APICompatibilityLevel.defaultLevel
         testValue = (expectedValue == _) ? rawValue : expectedValue
         escapedValue = (value instanceof String) ? escapedPath(value) : value
         invocation = (method != _) ? "${method}(${escapedValue})" : "${property} = ${escapedValue}"
@@ -113,8 +116,8 @@ class SetAPICompLevelIntegrationSpec extends UnityIntegrationSpec {
         assert previousAPICompLevelMap == currentAPICompLevelMap
 
         where:
-        expectedAPICompatibilityLevel = APICompatibilityLevel.net4_6
-        defaultAPICompatibilityLevel = APICompatibilityLevel.net2_0_subset
+        expectedAPICompatibilityLevel = APICompatibilityLevel.net_4_6
+        defaultAPICompatibilityLevel = APICompatibilityLevel.net_2_0_subset
     }
 
     def "skips if the api level is the same as the default"() {

--- a/src/main/groovy/wooga/gradle/unity/APICompatibilityLevel.groovy
+++ b/src/main/groovy/wooga/gradle/unity/APICompatibilityLevel.groovy
@@ -47,9 +47,9 @@ import java.security.InvalidKeyException
 **/
 enum APICompatibilityLevel {
 
-    net2_0(1),
-    net2_0_subset(2),
-    net4_6(3),
+    net_2_0(1),
+    net_2_0_subset(2),
+    net_4_6(3),
     net_web(4),
     net_micro(5),
     net_standard_2_0(6) // DEFAULT
@@ -67,12 +67,17 @@ enum APICompatibilityLevel {
      */
     static final APICompatibilityLevel defaultLevel = net_standard_2_0
 
-    private static Map map = new HashMap<>();
+    private static Map intToValue = new HashMap<>();
+    private static Map fallbacks = new HashMap<>()
 
     static {
         for (APICompatibilityLevel apiLevel : values()) {
-            map.put(apiLevel.value, apiLevel);
+            intToValue.put(apiLevel.value, apiLevel);
         }
+
+        fallbacks.put("net2_0", APICompatibilityLevel.net_2_0)
+        fallbacks.put("net2_0_subset", APICompatibilityLevel.net_2_0_subset)
+        fallbacks.put("net4_6", APICompatibilityLevel.net_4_6)
     }
 
     APICompatibilityLevel(Integer value) {
@@ -85,10 +90,10 @@ enum APICompatibilityLevel {
     }
 
     static APICompatibilityLevel valueOfInt(Integer value) {
-        if (!map.containsKey(value)) {
+        if (!intToValue.containsKey(value)) {
             throw new InvalidKeyException("There is no  API compatibility level for the value ${value}")
         }
-        return (APICompatibilityLevel) map.get(value);
+        return (APICompatibilityLevel) intToValue.get(value);
     }
 
     static Map<String, APICompatibilityLevel> toMap(APICompatibilityLevel level) {
@@ -97,6 +102,13 @@ enum APICompatibilityLevel {
             map.put(group.toString(), level)
         }
         return map
+    }
+
+    static APICompatibilityLevel parse(String value) {
+        if (fallbacks.containsKey(value)) {
+            return fallbacks[value]
+        }
+        return value as APICompatibilityLevel
     }
 
 }

--- a/src/main/groovy/wooga/gradle/unity/tasks/SetAPICompatibilityLevel.groovy
+++ b/src/main/groovy/wooga/gradle/unity/tasks/SetAPICompatibilityLevel.groovy
@@ -66,7 +66,7 @@ class SetAPICompatibilityLevel extends ConventionTask {
         }
         else {
             try {
-                value = value.toString() as APICompatibilityLevel
+                value = APICompatibilityLevel.parse(value.toString())
             }
             catch (Exception e) {
                 throw new Exception(parseFailureMessage)

--- a/src/test/groovy/wooga/gradle/unity/APICompatibilityLevelSpec.groovy
+++ b/src/test/groovy/wooga/gradle/unity/APICompatibilityLevelSpec.groovy
@@ -16,7 +16,7 @@
 
 package wooga.gradle.unity
 
-import org.gradle.internal.impldep.org.apache.commons.lang.NullArgumentException
+
 import spock.lang.Specification
 import spock.lang.Subject
 
@@ -34,9 +34,9 @@ class APICompatibilityLevelSpec extends Specification {
 
         where:
         value | expectedAPICompatLevel
-        "net2_0" | APICompatibilityLevel.net2_0
-        "net2_0_subset" | APICompatibilityLevel.net2_0_subset
-        "net4_6" | APICompatibilityLevel.net4_6
+        "net_2_0" | APICompatibilityLevel.net_2_0
+        "net_2_0_subset" | APICompatibilityLevel.net_2_0_subset
+        "net_4_6" | APICompatibilityLevel.net_4_6
         "net_web" | APICompatibilityLevel.net_web
         "net_micro" | APICompatibilityLevel.net_micro
         "net_standard_2_0" | APICompatibilityLevel.net_standard_2_0
@@ -51,9 +51,9 @@ class APICompatibilityLevelSpec extends Specification {
 
         where:
         value | expectedAPICompatLevel
-        1 | APICompatibilityLevel.net2_0
-        2 | APICompatibilityLevel.net2_0_subset
-        3 | APICompatibilityLevel.net4_6
+        1 | APICompatibilityLevel.net_2_0
+        2 | APICompatibilityLevel.net_2_0_subset
+        3 | APICompatibilityLevel.net_4_6
         4 | APICompatibilityLevel.net_web
         5 | APICompatibilityLevel.net_micro
         6 | APICompatibilityLevel.net_standard_2_0

--- a/src/test/groovy/wooga/gradle/unity/DefaultUnityPluginExtensionSpec.groovy
+++ b/src/test/groovy/wooga/gradle/unity/DefaultUnityPluginExtensionSpec.groovy
@@ -331,7 +331,7 @@ class DefaultUnityPluginExtensionSpec extends Specification {
 
     def "set api compatibility level with properties"() {
         given: "valid api compatibility level"
-        def testCompatibilityLevel = APICompatibilityLevel.net4_6
+        def testCompatibilityLevel = APICompatibilityLevel.net_4_6
 
         and:
         projectProperties[UnityPluginConsts.UNITY_API_COMPATIBILITY_LEVEL_OPTION] = testCompatibilityLevel.toString()
@@ -358,7 +358,7 @@ class DefaultUnityPluginExtensionSpec extends Specification {
 
     def "get api compatibility level from env returns property value over env"() {
         given: "api compatibility level set in properties"
-        def level = APICompatibilityLevel.net4_6
+        def level = APICompatibilityLevel.net_4_6
         def props = [(UnityPluginConsts.UNITY_API_COMPATIBILITY_LEVEL_OPTION): level.toString()]
 
         and: "unity path in environment"

--- a/src/test/groovy/wooga/gradle/unity/utils/internal/ProjectSettingsSpec.groovy
+++ b/src/test/groovy/wooga/gradle/unity/utils/internal/ProjectSettingsSpec.groovy
@@ -179,7 +179,7 @@ class ProjectSettingsSpec extends UnityAssetFileSpec {
 
         where:
         objectType | content | level
-        "String"   | TEMPLATE_CONTENT | APICompatibilityLevel.net4_6
+        "String"   | TEMPLATE_CONTENT | APICompatibilityLevel.net_4_6
         "String"   | TEMPLATE_CONTENT | APICompatibilityLevel.net_standard_2_0
     }
 
@@ -209,6 +209,6 @@ class ProjectSettingsSpec extends UnityAssetFileSpec {
         where:
         objectType | file | level
         "File"     | File.createTempFile("ProjectSettings", ".asset") << TEMPLATE_CONTENT | APICompatibilityLevel.net_standard_2_0
-        "File"     | File.createTempFile("ProjectSettings", ".asset") << TEMPLATE_CONTENT | APICompatibilityLevel.net4_6
+        "File"     | File.createTempFile("ProjectSettings", ".asset") << TEMPLATE_CONTENT | APICompatibilityLevel.net_4_6
     }
 }


### PR DESCRIPTION
## Description

Several of the APICompatiblityLevel values had a missing _ after _net_. This corrects it.

https://docs.unity3d.com/ScriptReference/ApiCompatibilityLevel.html

Downstream projects that use this will need to be updated accordingly, though not urgently as there's a fallback mechanism in place for the parsing to map the incorrect values to the correct ones.

## Changes
* ![FIX] APICompatibilityLevel enum values for net_2_0, net_2_0_subset, net_4_6.

[NEW]:https://atlas-resources.wooga.com/icons/icon_new.svg "New"
[ADD]:http://resources.atlas.wooga.com/icons/icon_add.svg "Add"
[IMPROVE]:http://resources.atlas.wooga.com/icons/icon_improve.svg "IMPROVE"
[CHANGE]:http://resources.atlas.wooga.com/icons/icon_change.svg "Change"
[FIX]:http://resources.atlas.wooga.com/icons/icon_fix.svg "Fix"
[UPDATE]:http://resources.atlas.wooga.com/icons/icon_update.svg "Update"

[BREAK]:http://resources.atlas.wooga.com/icons/icon_break.svg "Remove"
[REMOVE]:http://resources.atlas.wooga.com/icons/icon_remove.svg "Remove"
[IOS]:http://resources.atlas.wooga.com/icons/icon_iOS.svg "iOS"
[ANDROID]:http://resources.atlas.wooga.com/icons/icon_android.svg "Android"
[WEBGL]:http://resources.atlas.wooga.com/icons/icon_webGL.svg "Web:GL"
