### PR TITLE
Fix incorrect parse method for apiCompatibilityLevel called in enviro…

### DIFF
--- a/src/main/groovy/wooga/gradle/unity/APICompatibilityLevel.groovy
+++ b/src/main/groovy/wooga/gradle/unity/APICompatibilityLevel.groovy
@@ -91,7 +91,7 @@ enum APICompatibilityLevel {
 
     static APICompatibilityLevel valueOfInt(Integer value) {
         if (!intToValue.containsKey(value)) {
-            throw new InvalidKeyException("There is no  API compatibility level for the value ${value}")
+            throw new InvalidKeyException("There is no API compatibility level for the value ${value}")
         }
         return (APICompatibilityLevel) intToValue.get(value);
     }

--- a/src/main/groovy/wooga/gradle/unity/internal/DefaultUnityPluginExtension.groovy
+++ b/src/main/groovy/wooga/gradle/unity/internal/DefaultUnityPluginExtension.groovy
@@ -535,7 +535,7 @@ class DefaultUnityPluginExtension implements UnityPluginExtension, UnityPluginAc
     static APICompatibilityLevel getApiCompatibilityLevelFromEnv(Map<String, ?> properties, Map<String, String> env) {
         String rawValue = (properties[UnityPluginConsts.UNITY_API_COMPATIBILITY_LEVEL_OPTION] ?: env[UnityPluginConsts.UNITY_API_COMPATIBILITY_LEVEL_ENV_VAR])
         if (rawValue) {
-            return APICompatibilityLevel.valueOf(rawValue)
+            return APICompatibilityLevel.parse(rawValue)
         }
         null
     }

--- a/src/main/groovy/wooga/gradle/unity/utils/internal/UnityAssetFile.groovy
+++ b/src/main/groovy/wooga/gradle/unity/utils/internal/UnityAssetFile.groovy
@@ -25,6 +25,7 @@ import org.yaml.snakeyaml.Yaml
 
 /**
  * Manages the parsing and serialization of an Unity YAML asset file
+ * https://docs.unity3d.com/Manual/UnityYAML.html
  */
 abstract class UnityAssetFile {
 
@@ -51,8 +52,9 @@ abstract class UnityAssetFile {
             isValid = true
 
         }
-        catch (Exception ignored) {
-            logger.warn("UnityAssetFile content not parsable. Please make sure it's not set to binary.")
+        catch (Exception e) {
+            logger.warn("UnityAssetFile content not parsable (Was it set to binary?):")
+            logger.warn(e.toString())
         }
         validObject = isValid
     }


### PR DESCRIPTION
## Description

The parse call for the APICompatibilityLevel called from the environment was using the integer parameter one, rather than the one for strings.

## Changes
* ![FIX]  DefaultUnityPluginExtension

[NEW]:https://atlas-resources.wooga.com/icons/icon_new.svg "New"
[ADD]:http://resources.atlas.wooga.com/icons/icon_add.svg "Add"
[IMPROVE]:http://resources.atlas.wooga.com/icons/icon_improve.svg "IMPROVE"
[CHANGE]:http://resources.atlas.wooga.com/icons/icon_change.svg "Change"
[FIX]:http://resources.atlas.wooga.com/icons/icon_fix.svg "Fix"
[UPDATE]:http://resources.atlas.wooga.com/icons/icon_update.svg "Update"

[BREAK]:http://resources.atlas.wooga.com/icons/icon_break.svg "Remove"
[REMOVE]:http://resources.atlas.wooga.com/icons/icon_remove.svg "Remove"
[IOS]:http://resources.atlas.wooga.com/icons/icon_iOS.svg "iOS"
[ANDROID]:http://resources.atlas.wooga.com/icons/icon_android.svg "Android"
[WEBGL]:http://resources.atlas.wooga.com/icons/icon_webGL.svg "Web:GL"
