### PR TITLE
Add a set of newer Unity CLI flags

### DIFF
--- a/src/integrationTest/groovy/wooga/gradle/unity/BaseBatchModeIntegrationSpec.groovy
+++ b/src/integrationTest/groovy/wooga/gradle/unity/BaseBatchModeIntegrationSpec.groovy
@@ -22,6 +22,7 @@ import spock.lang.Ignore
 import spock.lang.IgnoreIf
 import spock.lang.Unroll
 import spock.util.environment.RestoreSystemProperties
+import wooga.gradle.unity.batchMode.UnityCommandLineOption
 import wooga.gradle.unity.tasks.*
 
 class BaseBatchModeIntegrationSpec extends UnityIntegrationSpec {
@@ -77,50 +78,113 @@ class BaseBatchModeIntegrationSpec extends UnityIntegrationSpec {
         }
 
         where:
-        property      | taskType      | useSetter | value                 | expectedCommandlineSwitch | checkForFileInCommandline
-        "unityPath"   | Activate      | false     | 'file("test/file")'   | ""                        | true
-        "unityPath"   | Activate      | true      | 'file("test/file")'   | ""                        | true
-        "unityPath"   | ReturnLicense | false     | 'file("test/file")'   | ""                        | true
-        "unityPath"   | ReturnLicense | true      | 'file("test/file")'   | ""                        | true
-        "unityPath"   | Test          | false     | 'file("test/file")'   | ""                        | true
-        "unityPath"   | Test          | true      | 'file("test/file")'   | ""                        | true
-        "unityPath"   | Unity         | false     | 'file("test/file")'   | ""                        | true
-        "unityPath"   | Unity         | true      | 'file("test/file")'   | ""                        | true
-        "unityPath"   | UnityPackage  | false     | 'file("test/file")'   | ""                        | true
-        "unityPath"   | UnityPackage  | true      | 'file("test/file")'   | ""                        | true
+        property                 | taskType      | useSetter | value                 | expectedCommandlineSwitch   | checkForFileInCommandline
+        "unityPath"              | Activate      | false     | 'file("test/file")'   | ""                          | true
+        "unityPath"              | Activate      | true      | 'file("test/file")'   | ""                          | true
+        "unityPath"              | ReturnLicense | false     | 'file("test/file")'   | ""                          | true
+        "unityPath"              | ReturnLicense | true      | 'file("test/file")'   | ""                          | true
+        "unityPath"              | Test          | false     | 'file("test/file")'   | ""                          | true
+        "unityPath"              | Test          | true      | 'file("test/file")'   | ""                          | true
+        "unityPath"              | Unity         | false     | 'file("test/file")'   | ""                          | true
+        "unityPath"              | Unity         | true      | 'file("test/file")'   | ""                          | true
+        "unityPath"              | UnityPackage  | false     | 'file("test/file")'   | ""                          | true
+        "unityPath"              | UnityPackage  | true      | 'file("test/file")'   | ""                          | true
 
-        "projectPath" | Activate      | false     | 'file("test/file")'   | ""                        | false
-        "projectPath" | Activate      | true      | 'file("test/file")'   | ""                        | false
-        "projectPath" | ReturnLicense | false     | 'file("test/file")'   | ""                        | false
-        "projectPath" | ReturnLicense | true      | 'file("test/file")'   | ""                        | false
-        "projectPath" | Test          | false     | 'file("test/file")'   | "-projectPath"            | true
-        "projectPath" | Test          | true      | 'file("test/file")'   | "-projectPath"            | true
-        "projectPath" | Unity         | false     | 'file("test/file")'   | "-projectPath"            | true
-        "projectPath" | Unity         | true      | 'file("test/file")'   | "-projectPath"            | true
-        "projectPath" | UnityPackage  | false     | 'file("test/file")'   | "-projectPath"            | true
-        "projectPath" | UnityPackage  | true      | 'file("test/file")'   | "-projectPath"            | true
+        "projectPath"            | Activate      | false     | 'file("test/file")'   | ""                          | false
+        "projectPath"            | Activate      | true      | 'file("test/file")'   | ""                          | false
+        "projectPath"            | ReturnLicense | false     | 'file("test/file")'   | ""                          | false
+        "projectPath"            | ReturnLicense | true      | 'file("test/file")'   | ""                          | false
+        "projectPath"            | Test          | false     | 'file("test/file")'   | "-projectPath"              | true
+        "projectPath"            | Test          | true      | 'file("test/file")'   | "-projectPath"              | true
+        "projectPath"            | Unity         | false     | 'file("test/file")'   | "-projectPath"              | true
+        "projectPath"            | Unity         | true      | 'file("test/file")'   | "-projectPath"              | true
+        "projectPath"            | UnityPackage  | false     | 'file("test/file")'   | "-projectPath"              | true
+        "projectPath"            | UnityPackage  | true      | 'file("test/file")'   | "-projectPath"              | true
 
-        "logFile"     | Activate      | false     | 'file("test/file")'   | ""                        | false
-        "logFile"     | Activate      | false     | '{file("test/file")}' | ""                        | false
-        "logFile"     | Activate      | true      | 'file("test/file")'   | ""                        | false
-        "logFile"     | Activate      | true      | '{file("test/file")}' | ""                        | false
-        "logFile"     | ReturnLicense | false     | 'file("test/file")'   | ""                        | false
-        "logFile"     | ReturnLicense | false     | '{file("test/file")}' | ""                        | false
-        "logFile"     | ReturnLicense | true      | 'file("test/file")'   | ""                        | false
-        "logFile"     | ReturnLicense | true      | '{file("test/file")}' | ""                        | false
-        "logFile"     | Test          | false     | 'file("test/file")'   | "-logFile"                | true
-        "logFile"     | Test          | false     | '{file("test/file")}' | "-logFile"                | true
-        "logFile"     | Test          | true      | 'file("test/file")'   | "-logFile"                | true
-        "logFile"     | Test          | true      | '{file("test/file")}' | "-logFile"                | true
-        "logFile"     | Unity         | false     | 'file("test/file")'   | "-logFile"                | true
-        "logFile"     | Unity         | false     | '{file("test/file")}' | "-logFile"                | true
-        "logFile"     | Unity         | true      | 'file("test/file")'   | "-logFile"                | true
-        "logFile"     | Unity         | true      | '{file("test/file")}' | "-logFile"                | true
-        "logFile"     | UnityPackage  | false     | 'file("test/file")'   | "-logFile"                | true
-        "logFile"     | UnityPackage  | false     | '{file("test/file")}' | "-logFile"                | true
-        "logFile"     | UnityPackage  | true      | 'file("test/file")'   | "-logFile"                | true
-        "logFile"     | UnityPackage  | true      | '{file("test/file")}' | "-logFile"                | true
+        "logFile"                | Activate      | false     | 'file("test/file")'   | ""                          | false
+        "logFile"                | Activate      | false     | '{file("test/file")}' | ""                          | false
+        "logFile"                | Activate      | true      | 'file("test/file")'   | ""                          | false
+        "logFile"                | Activate      | true      | '{file("test/file")}' | ""                          | false
+        "logFile"                | ReturnLicense | false     | 'file("test/file")'   | ""                          | false
+        "logFile"                | ReturnLicense | false     | '{file("test/file")}' | ""                          | false
+        "logFile"                | ReturnLicense | true      | 'file("test/file")'   | ""                          | false
+        "logFile"                | ReturnLicense | true      | '{file("test/file")}' | ""                          | false
+        "logFile"                | Test          | false     | 'file("test/file")'   | "-logFile"                  | true
+        "logFile"                | Test          | false     | '{file("test/file")}' | "-logFile"                  | true
+        "logFile"                | Test          | true      | 'file("test/file")'   | "-logFile"                  | true
+        "logFile"                | Test          | true      | '{file("test/file")}' | "-logFile"                  | true
+        "logFile"                | Unity         | false     | 'file("test/file")'   | "-logFile"                  | true
+        "logFile"                | Unity         | false     | '{file("test/file")}' | "-logFile"                  | true
+        "logFile"                | Unity         | true      | 'file("test/file")'   | "-logFile"                  | true
+        "logFile"                | Unity         | true      | '{file("test/file")}' | "-logFile"                  | true
+        "logFile"                | UnityPackage  | false     | 'file("test/file")'   | "-logFile"                  | true
+        "logFile"                | UnityPackage  | false     | '{file("test/file")}' | "-logFile"                  | true
+        "logFile"                | UnityPackage  | true      | 'file("test/file")'   | "-logFile"                  | true
+        "logFile"                | UnityPackage  | true      | '{file("test/file")}' | "-logFile"                  | true
 
+        "disableAssemblyUpdater" | Unity         | true      | true                  | "-disable-assembly-updater" | true
+        "disableAssemblyUpdater" | Unity         | true      | false                 | ""                          | true
+        "disableAssemblyUpdater" | Unity         | false     | true                  | "-disable-assembly-updater" | true
+        "disableAssemblyUpdater" | Unity         | false     | false                 | ""                          | true
+        "disableAssemblyUpdater" | Test          | true      | true                  | "-disable-assembly-updater" | true
+        "disableAssemblyUpdater" | Test          | true      | false                 | ""                          | true
+        "disableAssemblyUpdater" | Test          | false     | true                  | "-disable-assembly-updater" | true
+        "disableAssemblyUpdater" | Test          | false     | false                 | ""                          | true
+        "disableAssemblyUpdater" | UnityPackage  | true      | true                  | "-disable-assembly-updater" | true
+        "disableAssemblyUpdater" | UnityPackage  | true      | false                 | ""                          | true
+        "disableAssemblyUpdater" | UnityPackage  | false     | true                  | "-disable-assembly-updater" | true
+        "disableAssemblyUpdater" | UnityPackage  | false     | false                 | ""                          | true
+
+        method = (useSetter) ? "set${property.capitalize()}" : property
+    }
+
+    @Unroll
+    def "can set boolean flag #property (#value) for type #taskType with #method"() {
+        given: "a custom build task"
+        buildFile << """
+            task (mUnity, type: ${taskType.name}) {
+                onlyIf = {true}
+                $method($value)
+            }
+        """.stripIndent()
+
+        and: "custom setting based on type"
+        if (taskType == UnityPackage) {
+            createFile("path/to/some/files")
+            buildFile << """
+            mUnity.inputFiles "path/to/some/files"
+            """
+        }
+
+        if (taskType == ReturnLicense) {
+            buildFile << """
+            mUnity.licenseDirectory = projectDir
+            """
+        }
+
+        and: "make sure the test file exists"
+        def testFile = createFile("test/file")
+
+        when:
+        def result = runTasks("mUnity")
+
+        then:
+        result.wasExecuted("mUnity")
+        result.standardOutput.contains("Starting process 'command '")
+        value == result.standardOutput.contains(" $expectedCommandlineSwitch ")
+
+        where:
+        [testCase, taskType, useSetter, value] <<
+                [
+                        UnityCommandLineOption.values().collect(
+                                {it -> ["${it}", it.value]}),
+                        [Unity, Test, UnityPackage],
+                        [true, false],
+                        [true, false]
+                ].combinations()
+
+        property = testCase[0]
+        expectedCommandlineSwitch = testCase[1]
         method = (useSetter) ? "set${property.capitalize()}" : property
     }
 

--- a/src/main/groovy/wooga/gradle/unity/batchMode/BatchModeFlags.groovy
+++ b/src/main/groovy/wooga/gradle/unity/batchMode/BatchModeFlags.groovy
@@ -18,6 +18,55 @@
 package wooga.gradle.unity.batchMode
 
 /**
+ * You can run the Unity Editor and build Unity applications with additional commands and information on startup.
+ * These are some of the command line options available.
+ */
+enum UnityCommandLineOption {
+
+    /**
+     * Specify a space-separated list of assembly names as parameters for Unity to ignore on automatic updates.
+     The space-separated list of assembly names is optional: pass the command line options without any assembly names
+     to ignore all assemblies.
+     <p>Example 1
+     unity.exe -disable-assembly-updater
+     <p>Example 2
+     unity.exe -disable-assembly-updater A1.dll subfolder/A2.dll
+     <p>(Example 2 has two assembly names, one with a pathname. Example 2 ignores A1.dll, no matter what folder it is stored
+     in, and ignores A2.dll only if it is stored under subfolder folder)
+
+     <p>If you list an assembly in the -disable-assembly-updater command line parameter (or if you don’t specify assemblies),
+     Unity logs the following message to Editor.log:
+     [Assembly Updater] warning: Ignoring assembly [assembly_path] as requested by command line parameter.”).
+
+     <p>Use this to avoid unnecessary API Updater overheads when importing assemblies.
+     It is useful for importing assemblies which access a Unity API when you know the Unity API doesn’t need updating.
+     It is also useful when importing assemblies which do not access Unity APIs at all (for example, if you have built
+     your source code, or some of it, outside of Unity, and you want to import the resulting assemblies into your Unity project).
+
+     <p>Note: If you disable the update of any assembly that does need updating, you may get errors at compile time,
+     run time, or both, that are hard to track.
+     */
+    disableAssemblyUpdater("-disable-assembly-updater"),
+    /**
+     * Enable Deep Profiling option for the CPU profiler.
+     */
+    deepProfiling("-deepprofiling"),
+    /**
+     * Enables code coverage and allows access to the Coverage API.
+     */
+    enableCodeCoverage("-enableCodeCoverage")
+
+    private final String value
+    String getValue() {
+        value
+    }
+
+    UnityCommandLineOption(String value) {
+        this.value = value
+    }
+}
+
+/**
  * Constant class with Unity commandline switches.
  */
 class BatchModeFlags {

--- a/src/main/groovy/wooga/gradle/unity/batchMode/BatchModeSpec.groovy
+++ b/src/main/groovy/wooga/gradle/unity/batchMode/BatchModeSpec.groovy
@@ -135,4 +135,16 @@ interface BatchModeSpec extends BaseBatchModeSpec ,BaseExecSpec {
      * @see wooga.gradle.unity.batchMode.BatchModeFlags#NO_GRAPHICS
      */
     BatchModeSpec noGraphics(Boolean value)
+
+    Boolean getDisableAssemblyUpdater()
+    void setDisableAssemblyUpdater(Boolean value)
+    BatchModeSpec disableAssemblyUpdater(Boolean value)
+
+    Boolean getDeepProfiling()
+    void setDeepProfiling(Boolean value)
+    BatchModeSpec deepProfiling(Boolean value)
+
+    Boolean getEnableCodeCoverage()
+    void setEnableCodeCoverage(Boolean value)
+    BatchModeSpec enableCodeCoverage(Boolean value)
 }

--- a/src/main/groovy/wooga/gradle/unity/batchMode/internal/DefaultBatchModeAction.groovy
+++ b/src/main/groovy/wooga/gradle/unity/batchMode/internal/DefaultBatchModeAction.groovy
@@ -36,7 +36,9 @@ import wooga.gradle.unity.UnityPlugin
 import wooga.gradle.unity.UnityPluginExtension
 import wooga.gradle.unity.batchMode.BatchModeAction
 import wooga.gradle.unity.batchMode.BatchModeFlags
+import wooga.gradle.unity.batchMode.BatchModeSpec
 import wooga.gradle.unity.batchMode.BuildTarget
+import wooga.gradle.unity.batchMode.UnityCommandLineOption
 import wooga.gradle.unity.utils.internal.FileUtils
 import wooga.gradle.unity.utils.internal.ForkTextStream
 import wooga.gradle.unity.utils.internal.UnityVersionManager
@@ -154,6 +156,7 @@ class DefaultBatchModeAction implements BatchModeAction, IConventionAware {
     Boolean quit = true
     Boolean batchMode = true
     Boolean noGraphics = false
+    Map<UnityCommandLineOption, Boolean> commandLineOptions
 
     DefaultBatchModeAction(Project project, FileResolver fileResolver) {
         this.project = project
@@ -162,6 +165,38 @@ class DefaultBatchModeAction implements BatchModeAction, IConventionAware {
         this.conventionMapping = new ConventionAwareHelper(this, project.getConvention())
         def execFactory = new DefaultExecActionFactory(fileResolver)
         this.execHandleBuilder = execFactory.newExec()
+        this.commandLineOptions = UnityCommandLineOption.values().collectEntries(
+                {[it, it.value] }
+        )
+    }
+
+    @Override
+    DefaultBatchModeAction args(Object... args) {
+        execHandleBuilder.args(args)
+        this
+    }
+
+    @Override
+    DefaultBatchModeAction args(Iterable<?> args) {
+        execHandleBuilder.args(args)
+        return this
+    }
+
+    @Override
+    DefaultBatchModeAction setArgs(List<String> arguments) {
+        execHandleBuilder.setArgs(arguments)
+        return this
+    }
+
+    @Override
+    DefaultBatchModeAction setArgs(Iterable<?> arguments) {
+        execHandleBuilder.setArgs(arguments)
+        return this
+    }
+
+    @Override
+    ConventionMapping getConventionMapping() {
+        return conventionMapping
     }
 
     ExecResult execute() {
@@ -192,6 +227,13 @@ class DefaultBatchModeAction implements BatchModeAction, IConventionAware {
 
         if (noGraphics) {
             batchModeArgs << BatchModeFlags.NO_GRAPHICS
+        }
+
+        // Set additional flags here
+        for(option in commandLineOptions){
+            if (option.value == true){
+                batchModeArgs << option.key.value
+            }
         }
 
         setupLogFile(batchModeArgs)
@@ -303,32 +345,62 @@ class DefaultBatchModeAction implements BatchModeAction, IConventionAware {
         this
     }
 
+    /*
+        UnityCommandLineOption.disableAssemblyUpdater
+     */
     @Override
-    DefaultBatchModeAction args(Object... args) {
-        execHandleBuilder.args(args)
+    Boolean getDisableAssemblyUpdater() {
+        commandLineOptions[UnityCommandLineOption.disableAssemblyUpdater]
+    }
+
+    @Override
+    void setDisableAssemblyUpdater(Boolean value) {
+        commandLineOptions[UnityCommandLineOption.disableAssemblyUpdater] = value
+    }
+
+    @Override
+    DefaultBatchModeAction disableAssemblyUpdater(Boolean value) {
+        this.disableAssemblyUpdater = value
         this
     }
 
+    /*
+        UnityCommandLineOption.deepProfiling
+     */
     @Override
-    DefaultBatchModeAction args(Iterable<?> args) {
-        execHandleBuilder.args(args)
-        return this
+    Boolean getDeepProfiling() {
+        commandLineOptions[UnityCommandLineOption.deepProfiling]
     }
 
     @Override
-    DefaultBatchModeAction setArgs(List<String> arguments) {
-        execHandleBuilder.setArgs(arguments)
-        return this
+    void setDeepProfiling(Boolean value) {
+        commandLineOptions[UnityCommandLineOption.deepProfiling] = value
     }
 
     @Override
-    DefaultBatchModeAction setArgs(Iterable<?> arguments) {
-        execHandleBuilder.setArgs(arguments)
-        return this
+    DefaultBatchModeAction deepProfiling(Boolean value) {
+        this.deepProfiling = value
+        this
+    }
+
+    /*
+        UnityCommandLineOption.enableCodeCoverage
+     */
+    @Override
+    Boolean getEnableCodeCoverage() {
+        commandLineOptions[UnityCommandLineOption.enableCodeCoverage]
     }
 
     @Override
-    ConventionMapping getConventionMapping() {
-        return conventionMapping
+    void setEnableCodeCoverage(Boolean value) {
+        commandLineOptions[UnityCommandLineOption.enableCodeCoverage] = value
     }
+
+    @Override
+    DefaultBatchModeAction enableCodeCoverage(Boolean value) {
+        this.enableCodeCoverage = value
+        this
+    }
+
+
 }

--- a/src/main/groovy/wooga/gradle/unity/tasks/internal/AbstractUnityProjectTask.groovy
+++ b/src/main/groovy/wooga/gradle/unity/tasks/internal/AbstractUnityProjectTask.groovy
@@ -90,6 +90,27 @@ abstract class AbstractUnityProjectTask<T extends AbstractUnityProjectTask> exte
         batchModeAction.noGraphics
     }
 
+    @Optional
+    @Input
+    @Override
+    Boolean getDisableAssemblyUpdater() {
+        batchModeAction.disableAssemblyUpdater
+    }
+
+    @Optional
+    @Input
+    @Override
+    Boolean getDeepProfiling() {
+        batchModeAction.deepProfiling
+    }
+
+    @Optional
+    @Input
+    @Override
+    Boolean getEnableCodeCoverage() {
+        batchModeAction.enableCodeCoverage
+    }
+
     /**
      * {@inheritDoc}
      */


### PR DESCRIPTION
## Description

Adds support for a newer set of CLI flags for Unity.

## Changes
* ![UPDATE] BatchModeFlags
* ![UPDATE] BatchModeSpec
* ![UPDATE] DefaultBatchModeAction
* ![UPDATE] AbtractUnityProjectTask

[NEW]:https://atlas-resources.wooga.com/icons/icon_new.svg "New"
[ADD]:http://resources.atlas.wooga.com/icons/icon_add.svg "Add"
[IMPROVE]:http://resources.atlas.wooga.com/icons/icon_improve.svg "IMPROVE"
[CHANGE]:http://resources.atlas.wooga.com/icons/icon_change.svg "Change"
[FIX]:http://resources.atlas.wooga.com/icons/icon_fix.svg "Fix"
[UPDATE]:http://resources.atlas.wooga.com/icons/icon_update.svg "Update"

[BREAK]:http://resources.atlas.wooga.com/icons/icon_break.svg "Remove"
[REMOVE]:http://resources.atlas.wooga.com/icons/icon_remove.svg "Remove"
[IOS]:http://resources.atlas.wooga.com/icons/icon_iOS.svg "iOS"
[ANDROID]:http://resources.atlas.wooga.com/icons/icon_android.svg "Android"
[WEBGL]:http://resources.atlas.wooga.com/icons/icon_webGL.svg "Web:GL"
