### PR TITLE
Skip SetAPICompLevel task if the project settings file is not present

### DIFF
--- a/src/main/groovy/wooga/gradle/unity/tasks/SetAPICompatibilityLevel.groovy
+++ b/src/main/groovy/wooga/gradle/unity/tasks/SetAPICompatibilityLevel.groovy
@@ -56,6 +56,10 @@ class SetAPICompatibilityLevel extends DefaultTask implements APICompatibilityLe
             @Override
             boolean isSatisfiedBy(SetAPICompatibilityLevel t) {
                 def file = settingsFile.get().asFile
+                if (!file.exists()){
+                    logger.warn("No project settings file is present at ${file.path}")
+                    return false
+                }
                 def projectSettings = new ProjectSettingsFile(file)
 
                 Map<String, APICompatibilityLevel> currentAPICompLevel = projectSettings.getAPICompatibilityLevelPerPlatform()


### PR DESCRIPTION
## Description

If the project settings file is not set, an exception is thrown due to it trying to access it. We should instead skip when it's not found.
