### PR TITLE
Fix license directory Linux check

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -53,7 +53,5 @@ dependencies {
 
     implementation 'org.apache.maven:maven-artifact:3.8.1'
     implementation "org.yaml:snakeyaml:1.28"
-    //implementation 'net.wooga:unity-version-manager-jni:1.+'
     implementation 'net.wooga:unity-version-manager-jni:[1,2)'
-    //implementation 'net.wooga:unity-version-manager-jni:1.3.1'
 }

--- a/src/main/groovy/wooga/gradle/unity/UnityPlugin.groovy
+++ b/src/main/groovy/wooga/gradle/unity/UnityPlugin.groovy
@@ -293,9 +293,7 @@ class UnityPlugin implements Plugin<Project> {
                 }
 
         activateTask.configure({ t ->
-            //if (extension.autoReturnLicense.get()) {
-                t.finalizedBy(returnLicenseTask)
-            //}
+            t.finalizedBy(returnLicenseTask)
         })
 
         // Assign authentication to ALL tasks of type Activate
@@ -306,21 +304,15 @@ class UnityPlugin implements Plugin<Project> {
         // Assign license to ALL tasks of type ReturnLicense
         project.tasks.withType(ReturnLicense).configureEach({ t ->
             t.licenseDirectory.convention(extension.licenseDirectory)
-            t.onlyIf {extension.autoReturnLicense.get()}
+            t.onlyIf { extension.autoReturnLicense.get() }
         })
 
-        //project.afterEvaluate {
-            project.tasks.withType(UnityTask).configureEach({ t ->
-                if (!Activate.isInstance(t) && !ReturnLicense.isInstance(t)) {
-                    //if (extension.autoActivateUnity.get()) {
-                        t.dependsOn(activateTask)
-                    //}
+        project.tasks.withType(UnityTask).configureEach({ t ->
+            if (!Activate.isInstance(t) && !ReturnLicense.isInstance(t)) {
+                t.dependsOn(activateTask)
+                t.finalizedBy(returnLicenseTask)
+            }
+        })
 
-                    //if (extension.autoReturnLicense.get()) {
-                        t.finalizedBy(returnLicenseTask)
-                    //}
-                }
-            })
-        //}
     }
 }

--- a/src/main/groovy/wooga/gradle/unity/UnityPluginConventions.groovy
+++ b/src/main/groovy/wooga/gradle/unity/UnityPluginConventions.groovy
@@ -112,12 +112,15 @@ class UnityPluginConventions implements PlatformUtilsImpl {
      * The path to the Unity license directory
      */
     static File getLicenseDirectory() {
-        File licensePath = null
+        File licensePath
 
         if (isWindows()) {
             licensePath = UnityPluginConventions.UNITY_LICENSE_DIRECTORY_WIN
-        } else if (osName().contains("mac os x")) {
+        } else if (isMac()) {
             licensePath = UnityPluginConventions.UNITY_LICENSE_DIRECTORY_MAC_OS
+        }
+        else{
+            licensePath = new File("")
         }
 
         licensePath

--- a/src/main/groovy/wooga/gradle/unity/UnityPluginConventions.groovy
+++ b/src/main/groovy/wooga/gradle/unity/UnityPluginConventions.groovy
@@ -17,6 +17,7 @@
 
 package wooga.gradle.unity
 
+import wooga.gradle.unity.utils.PlatformUtils
 import wooga.gradle.unity.utils.PlatformUtilsImpl
 import wooga.gradle.unity.utils.PropertyLookup
 
@@ -53,7 +54,13 @@ class UnityPluginConventions implements PlatformUtilsImpl {
     static File UNITY_LICENSE_DIRECTORY_MAC_OS = new File("/Library/Application Support/Unity/")
 
     /**
-     * {@code File} to Unity license directory on windows.
+     * {@code File} to Unity license directory on Linux.
+     * @value "/Library/Application Support/Unity/"
+     */
+    static File UNITY_LICENSE_DIRECTORY_LINUX = new File("${PlatformUtils.unixUserHomePath}/share/unity3d/Unity/")
+
+    /**
+     * {@code File} to Unity license directory on Windows.
      * @value "C:\ProgramData\Unity"
      */
     static File UNITY_LICENSE_DIRECTORY_WIN = new File("C:\\ProgramData\\Unity")
@@ -66,7 +73,7 @@ class UnityPluginConventions implements PlatformUtilsImpl {
     /**
      * The path to the Unity Editor executable
      */
-    static final PropertyLookup unityPath = new PropertyLookup(["UNITY_UNITY_PATH","UNITY_PATH"], "unity.unityPath", { getPlatformUnityPath().absolutePath })
+    static final PropertyLookup unityPath = new PropertyLookup(["UNITY_UNITY_PATH", "UNITY_PATH"], "unity.unityPath", { getPlatformUnityPath().absolutePath })
     /**
      * Used for authentication with Unity's servers
      */
@@ -118,9 +125,9 @@ class UnityPluginConventions implements PlatformUtilsImpl {
             licensePath = UnityPluginConventions.UNITY_LICENSE_DIRECTORY_WIN
         } else if (isMac()) {
             licensePath = UnityPluginConventions.UNITY_LICENSE_DIRECTORY_MAC_OS
-        }
-        else{
-            licensePath = new File("")
+        } else {
+            licensePath = UnityPluginConventions.UNITY_LICENSE_DIRECTORY_LINUX
+
         }
 
         licensePath

--- a/src/main/groovy/wooga/gradle/unity/utils/PlatformUtils.groovy
+++ b/src/main/groovy/wooga/gradle/unity/utils/PlatformUtils.groovy
@@ -59,6 +59,14 @@ trait PlatformUtilsImpl {
         }
         path
     }
+
+    /**
+     * Returns the pat to the usr directory in UNIX
+     * @return
+     */
+    static String getUnixUserHomePath() {
+        System.getProperty("user.home")
+    }
 }
 
 class PlatformUtils implements PlatformUtilsImpl {


### PR DESCRIPTION
## Description

The current check fails on the CI for Linux since there's no license directory (it was returning null)

## Changes
* ![UPDATE] UnityPLuginConventions

[NEW]:https://atlas-resources.wooga.com/icons/icon_new.svg "New"
[ADD]:http://resources.atlas.wooga.com/icons/icon_add.svg "Add"
[IMPROVE]:http://resources.atlas.wooga.com/icons/icon_improve.svg "IMPROVE"
[CHANGE]:http://resources.atlas.wooga.com/icons/icon_change.svg "Change"
[FIX]:http://resources.atlas.wooga.com/icons/icon_fix.svg "Fix"
[UPDATE]:http://resources.atlas.wooga.com/icons/icon_update.svg "Update"

[BREAK]:http://resources.atlas.wooga.com/icons/icon_break.svg "Remove"
[REMOVE]:http://resources.atlas.wooga.com/icons/icon_remove.svg "Remove"
[IOS]:http://resources.atlas.wooga.com/icons/icon_iOS.svg "iOS"
[ANDROID]:http://resources.atlas.wooga.com/icons/icon_android.svg "Android"
[WEBGL]:http://resources.atlas.wooga.com/icons/icon_webGL.svg "Web:GL"
