### PR TITLE
Fix remove default BuildTarget.undefined

### DIFF
--- a/src/integrationTest/groovy/wooga/gradle/unity/UnityPluginIntegrationSpec.groovy
+++ b/src/integrationTest/groovy/wooga/gradle/unity/UnityPluginIntegrationSpec.groovy
@@ -175,7 +175,7 @@ class UnityPluginIntegrationSpec extends UnityIntegrationSpec {
         "unityPath"                | "setUnityPath"  | osPath("/foo/bar/unity3") | _                                                          | "Provider<RegularFile>" | PropertyLocation.script
         "unityPath"                | "unityPath.set" | osPath("/foo/bar/unity4") | _                                                          | "Provider<RegularFile>" | PropertyLocation.script
 
-        "defaultBuildTarget"       | _               | _                         | BuildTarget.undefined                                      | BuildTarget             | PropertyLocation.none
+        "defaultBuildTarget"       | _               | _                         | null                                                          | _                       | PropertyLocation.none
         "autoActivateUnity"        | _               | _                         | true                                                       | Boolean                 | PropertyLocation.none
         "autoReturnLicense"        | _               | _                         | true                                                       | Boolean                 | PropertyLocation.none
         "logCategory"              | _               | _                         | "unity"                                                    | "Property<String>"      | PropertyLocation.none

--- a/src/main/groovy/wooga/gradle/unity/UnityPlugin.groovy
+++ b/src/main/groovy/wooga/gradle/unity/UnityPlugin.groovy
@@ -126,7 +126,6 @@ class UnityPlugin implements Plugin<Project> {
         extension.authentication.password.set(UnityPluginConventions.password.getStringValueProvider(project))
         extension.authentication.serial.set(UnityPluginConventions.serial.getStringValueProvider(project))
 
-        extension.defaultBuildTarget.convention(BuildTarget.undefined.toString())
         extension.batchModeForEditModeTest.convention(UnityPluginConventions.batchModeForEditModeTest.getBooleanValueProvider(project))
         extension.batchModeForPlayModeTest.convention(UnityPluginConventions.batchModeForPlayModeTest.getBooleanValueProvider(project))
 
@@ -143,9 +142,7 @@ class UnityPlugin implements Plugin<Project> {
             t.quit.convention(true)
             t.logToStdout.convention(t.logger.infoEnabled || t.logger.debugEnabled)
             t.toggleLogFile(true)
-            t.buildTarget.convention(project.provider {
-                extension.defaultBuildTarget.getOrElse(BuildTarget.undefined.toString())
-            })
+            t.buildTarget.convention(extension.defaultBuildTarget)
 
             // Properties used by tasks
             t.unityPath.convention(extension.unityPath)

--- a/src/main/groovy/wooga/gradle/unity/UnityPluginExtension.groovy
+++ b/src/main/groovy/wooga/gradle/unity/UnityPluginExtension.groovy
@@ -223,20 +223,18 @@ trait UnityPluginExtension implements UnitySpec,
                 return project.properties.get("unity.testBuildTargets").toString().split(",").collect({
                     it
                 })
-            } else if (defaultBuildTarget.get() == BuildTarget.undefined.toString()) {
+            } else if (!defaultBuildTarget.isPresent() ) {
                 return new HashSet<String>()
             }
         }
 
         // If test targets were assigned to the property
         Set<String> targets = new HashSet<String>()
-        for (Object t : getTestBuildTargets()) {
-            if (t != BuildTarget.undefined) {
-                targets.add(t.toString())
-            }
+        for (String t : getTestBuildTargets()) {
+            targets.add(t)
         }
 
-        if (getDefaultBuildTarget().getOrElse(BuildTarget.undefined.toString()) != BuildTarget.undefined.toString()) {
+        if (getDefaultBuildTarget().present) {
             targets.add(defaultBuildTarget.get())
         }
 

--- a/src/main/groovy/wooga/gradle/unity/models/BuildTarget.groovy
+++ b/src/main/groovy/wooga/gradle/unity/models/BuildTarget.groovy
@@ -20,7 +20,6 @@ package wooga.gradle.unity.models
  * The build target values for Unity
  */
 enum BuildTarget {
-    undefined,
     win32,
     win64,
     osx,


### PR DESCRIPTION
## Description

The old plugin version only allowed to set the BuildTarget flag with an enum. To check if a value is provided, the enum contained a value `undefined` so the task impl could check if the flag is actually provided. This is no longer needed and adds a small bug when the flag is not set. I removed the enum value and all mentions in code and adjusted the tests.

## Changes

* ![FIX] remove default `BuildTarget.undefined`


[NEW]:https://atlas-resources.wooga.com/icons/icon_new.svg "New"
[ADD]:http://resources.atlas.wooga.com/icons/icon_add.svg "Add"
[IMPROVE]:http://resources.atlas.wooga.com/icons/icon_improve.svg "IMPROVE"
[CHANGE]:http://resources.atlas.wooga.com/icons/icon_change.svg "Change"
[FIX]:http://resources.atlas.wooga.com/icons/icon_fix.svg "Fix"
[UPDATE]:http://resources.atlas.wooga.com/icons/icon_update.svg "Update"

[BREAK]:http://resources.atlas.wooga.com/icons/icon_break.svg "Remove"
[REMOVE]:http://resources.atlas.wooga.com/icons/icon_remove.svg "Remove"
[IOS]:http://resources.atlas.wooga.com/icons/icon_iOS.svg "iOS"
[ANDROID]:http://resources.atlas.wooga.com/icons/icon_android.svg "Android"
[WEBGL]:http://resources.atlas.wooga.com/icons/icon_webGL.svg "Web:GL"
