### PR TITLE
Unity Task environment setter

### DIFF
--- a/src/integrationTest/groovy/wooga/gradle/unity/UnityIntegrationSpec.groovy
+++ b/src/integrationTest/groovy/wooga/gradle/unity/UnityIntegrationSpec.groovy
@@ -137,14 +137,20 @@ abstract class UnityIntegrationSpec extends IntegrationSpec {
         if (windows) {
             mockUnityFile << """
                 @echo off
-                echo ${mockUnityStartupMessage}
+                echo [ENVIRONMENT]:
+                set
+                echo [ARGUMENTS]:
                 echo %*
+                echo ${mockUnityStartupMessage}
             """.stripIndent()
         } else {
             mockUnityFile << """
                 #!/usr/bin/env bash
-                echo ${mockUnityStartupMessage}
+                echo [ENVIRONMENT]:
+                env
+                echo [ARGUMENTS]:
                 echo \$@
+                echo ${mockUnityStartupMessage}
             """.stripIndent()
         }
         addUnityPathToExtension(mockUnityFile.path)

--- a/src/main/groovy/wooga/gradle/unity/UnityTask.groovy
+++ b/src/main/groovy/wooga/gradle/unity/UnityTask.groovy
@@ -47,6 +47,7 @@ abstract class UnityTask extends DefaultTask
         // and also an additional one for our custom use
         wooga_gradle_unity_traits_ArgumentsSpec__arguments = project.provider({ getUnityCommandLineOptions() })
         wooga_gradle_unity_traits_ArgumentsSpec__additionalArguments = project.objects.listProperty(String)
+        wooga_gradle_unity_traits_ArgumentsSpec__environment =  project.objects.mapProperty(String, String)
     }
 
     @TaskAction
@@ -63,14 +64,15 @@ abstract class UnityTask extends DefaultTask
 
                 def unityPath = unityPath.get().asFile.absolutePath
                 def unityArgs = getAllArguments()
-
-                OutputStream outputStream = getOutputStream()
+                def unityEnvironment = environment.get()
+                def outputStream = getOutputStream()
 
                 exec.with {
                     executable unityPath
                     args = unityArgs
                     standardOutput = outputStream
                     ignoreExitValue = true
+                    environment = unityEnvironment
                 }
             }
         })

--- a/src/main/groovy/wooga/gradle/unity/traits/ArgumentsSpec.groovy
+++ b/src/main/groovy/wooga/gradle/unity/traits/ArgumentsSpec.groovy
@@ -17,6 +17,7 @@
 package wooga.gradle.unity.traits
 
 import org.gradle.api.provider.ListProperty
+import org.gradle.api.provider.MapProperty
 import org.gradle.api.provider.Provider
 import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.Internal
@@ -88,4 +89,12 @@ trait ArgumentsSpec {
         result
     }
 
+    private final MapProperty<String, ?> environment
+    /**
+     * @return Used for populating the system environment
+     */
+    @Internal
+    MapProperty<String, ?> getEnvironment() {
+        environment
+    }
 }


### PR DESCRIPTION
## Description
Add a property for setting the environment for an Unity Task.

## Changes
* ![UPDATE] UnityTask
* ![UPDATE] ArgumentsSpec

[NEW]:https://atlas-resources.wooga.com/icons/icon_new.svg "New"
[ADD]:http://resources.atlas.wooga.com/icons/icon_add.svg "Add"
[IMPROVE]:http://resources.atlas.wooga.com/icons/icon_improve.svg "IMPROVE"
[CHANGE]:http://resources.atlas.wooga.com/icons/icon_change.svg "Change"
[FIX]:http://resources.atlas.wooga.com/icons/icon_fix.svg "Fix"
[UPDATE]:http://resources.atlas.wooga.com/icons/icon_update.svg "Update"

[BREAK]:http://resources.atlas.wooga.com/icons/icon_break.svg "Remove"
[REMOVE]:http://resources.atlas.wooga.com/icons/icon_remove.svg "Remove"
[IOS]:http://resources.atlas.wooga.com/icons/icon_iOS.svg "iOS"
[ANDROID]:http://resources.atlas.wooga.com/icons/icon_android.svg "Android"
[WEBGL]:http://resources.atlas.wooga.com/icons/icon_webGL.svg "Web:GL"
