### PR TITLE
Fix the environment initialization in UnityTask

### DIFF
--- a/src/integrationTest/groovy/wooga/gradle/unity/UnityTaskIntegrationSpec.groovy
+++ b/src/integrationTest/groovy/wooga/gradle/unity/UnityTaskIntegrationSpec.groovy
@@ -223,7 +223,8 @@ abstract class UnityTaskIntegrationSpec<T extends UnityTask> extends UnityIntegr
         method = (useSetter) ? "setLogCategory" : "logCategory.set"
     }
 
-    def "set environment for task exec"() {
+    @Unroll
+    def "set environment variable #rawValue for task exec"() {
         given:
         appendToSubjectTask("$method($value)")
         addProviderQueryTask("custom", "${subjectUnderTestName}.environment", ".get()")
@@ -236,8 +237,14 @@ abstract class UnityTaskIntegrationSpec<T extends UnityTask> extends UnityIntegr
 
         where:
         property      | useSetter | rawValue
-        "environment" | true      | ["A": "7"]
-        "environment" | false     | ["A": "7"]
+        "environment" | true      | ["A": "foo"]
+        "environment" | false     | ["A": "bar"]
+        "environment" | true      | ["A": 7]
+        "environment" | false     | ["A": 7]
+        "environment" | true      | ["A": file("foo.bar")]
+        "environment" | false     | ["A": file("foo.bar")]
+        "environment" | true      | ["A": true]
+        "environment" | false     | ["A": false]
 
         method = (useSetter) ? "set${property.capitalize()}" : "${property}.set"
         value = wrapValueBasedOnType(rawValue, Map)

--- a/src/main/groovy/wooga/gradle/unity/UnityTask.groovy
+++ b/src/main/groovy/wooga/gradle/unity/UnityTask.groovy
@@ -47,7 +47,7 @@ abstract class UnityTask extends DefaultTask
         // and also an additional one for our custom use
         wooga_gradle_unity_traits_ArgumentsSpec__arguments = project.provider({ getUnityCommandLineOptions() })
         wooga_gradle_unity_traits_ArgumentsSpec__additionalArguments = project.objects.listProperty(String)
-        wooga_gradle_unity_traits_ArgumentsSpec__environment =  project.objects.mapProperty(String, String)
+        wooga_gradle_unity_traits_ArgumentsSpec__environment =  project.objects.mapProperty(String, Object)
     }
 
     @TaskAction


### PR DESCRIPTION
## Description

The ArgumentsSpec.environment in UnityTask was not being constructed to the correct mapProperty type.

## Changes
* ![FIX] UnityTask

[NEW]:https://atlas-resources.wooga.com/icons/icon_new.svg "New"
[ADD]:http://resources.atlas.wooga.com/icons/icon_add.svg "Add"
[IMPROVE]:http://resources.atlas.wooga.com/icons/icon_improve.svg "IMPROVE"
[CHANGE]:http://resources.atlas.wooga.com/icons/icon_change.svg "Change"
[FIX]:http://resources.atlas.wooga.com/icons/icon_fix.svg "Fix"
[UPDATE]:http://resources.atlas.wooga.com/icons/icon_update.svg "Update"

[BREAK]:http://resources.atlas.wooga.com/icons/icon_break.svg "Remove"
[REMOVE]:http://resources.atlas.wooga.com/icons/icon_remove.svg "Remove"
[IOS]:http://resources.atlas.wooga.com/icons/icon_iOS.svg "iOS"
[ANDROID]:http://resources.atlas.wooga.com/icons/icon_android.svg "Android"
[WEBGL]:http://resources.atlas.wooga.com/icons/icon_webGL.svg "Web:GL"
