### PR TITLE
Add log error handling to Unity task when the Unity process execution…

### DIFF
--- a/src/integrationTest/groovy/wooga/gradle/unity/UnityTaskIntegrationSpec.groovy
+++ b/src/integrationTest/groovy/wooga/gradle/unity/UnityTaskIntegrationSpec.groovy
@@ -21,6 +21,7 @@ import com.wooga.spock.extensions.unity.UnityPathResolution
 import com.wooga.spock.extensions.unity.UnityPluginTestOptions
 import com.wooga.spock.extensions.uvm.UnityInstallation
 import org.gradle.api.logging.LogLevel
+import spock.lang.Ignore
 import spock.lang.IgnoreIf
 import spock.lang.Unroll
 import spock.util.environment.RestoreSystemProperties
@@ -384,6 +385,24 @@ abstract class UnityTaskIntegrationSpec<T extends UnityTask> extends UnityIntegr
         then:
         result.standardOutput.contains(mockUnityStartupMessage)
         logFile.text.contains(mockUnityStartupMessage)
+    }
+
+    @Ignore
+    // TODO: How to make the task fail/throw within the exec block?
+    def "task action does not invoke post execute if process didn't run"() {
+        given: "a task that is definitely gonna fail"
+        appendToSubjectTask("""
+                environment = null
+        """.stripIndent())
+
+        when:
+        def result = runTasks(subjectUnderTestName)
+
+        then:
+        !result.success
+        outputContains(result, "${subjectUnderTestName}.preExecute")
+        outputContains(result, "${subjectUnderTestName}.execute")
+        !outputContains(result, "${subjectUnderTestName}.postExecute")
     }
 
 }

--- a/src/main/groovy/wooga/gradle/unity/UnityTask.groovy
+++ b/src/main/groovy/wooga/gradle/unity/UnityTask.groovy
@@ -27,6 +27,7 @@ import org.gradle.internal.io.LineBufferingOutputStream
 import org.gradle.internal.io.TextStream
 import org.gradle.process.ExecResult
 import org.gradle.process.ExecSpec
+import org.gradle.api.file.RegularFile
 import sun.reflect.misc.FieldUtil
 import wooga.gradle.unity.models.UnityCommandLineOption
 import wooga.gradle.unity.traits.ArgumentsSpec
@@ -34,6 +35,7 @@ import wooga.gradle.unity.traits.UnityCommandLineSpec
 import wooga.gradle.unity.traits.UnitySpec
 import wooga.gradle.unity.utils.FileUtils
 import wooga.gradle.unity.utils.ForkTextStream
+import wooga.gradle.unity.utils.UnityLogErrorReader
 import wooga.gradle.unity.utils.UnityVersionManager
 
 abstract class UnityTask extends DefaultTask
@@ -47,21 +49,24 @@ abstract class UnityTask extends DefaultTask
         // and also an additional one for our custom use
         wooga_gradle_unity_traits_ArgumentsSpec__arguments = project.provider({ getUnityCommandLineOptions() })
         wooga_gradle_unity_traits_ArgumentsSpec__additionalArguments = project.objects.listProperty(String)
-        wooga_gradle_unity_traits_ArgumentsSpec__environment =  project.objects.mapProperty(String, Object)
+        wooga_gradle_unity_traits_ArgumentsSpec__environment = project.objects.mapProperty(String, Object)
     }
 
     @TaskAction
     void exec() {
+        // Invoked before the unity process
+        logger.info("${name}.preExecute")
+        preExecute()
+        // Execute the unity process
+        logger.info("${name}.execute")
         ExecResult execResult = project.exec(new Action<ExecSpec>() {
             @Override
             void execute(ExecSpec exec) {
 
+                // TODO: Should these be moved before preExecute?
                 if (!unityPath.present) {
                     throw new GradleException("Unity path is not set")
                 }
-
-                preExecute()
-
                 def unityPath = unityPath.get().asFile.absolutePath
                 def unityArgs = getAllArguments()
                 def unityEnvironment = environment.get()
@@ -76,8 +81,11 @@ abstract class UnityTask extends DefaultTask
                 }
             }
         })
-
-        execResult.assertNormalExitValue()
+        if (execResult.exitValue != 0) {
+            handleUnityProcessError(execResult)
+        }
+        // Invoked after the unity process (even if it failed)
+        logger.info("${name}.postExecute")
         postExecute(execResult)
     }
 
@@ -95,6 +103,30 @@ abstract class UnityTask extends DefaultTask
      * @param result The result of the Unity execution
      */
     protected void postExecute(ExecResult result) {
+    }
+
+    /**
+     * Invoked whenever the Unity process executed by the task exits with an error,
+     * @param result The execution result of the Unity process
+     */
+    protected void handleUnityProcessError(ExecResult result) {
+        logger.error("Unity process failed with exit value ${result.exitValue}...")
+
+        // Look up the log
+        if (!unityLogFile.isPresent()) {
+            logger.warn("No log file was configured for the task ${this.name}")
+            return
+        }
+
+        File logFile = unityLogFile.get().asFile
+        if (!logFile.exists()) {
+            logger.warn("No log file was written for the task ${this.name}")
+            return
+        }
+
+        // TODO: Gracefully show the error here?
+        def errorParse = UnityLogErrorReader.readErrorMessageFromLog(logFile)
+        logger.error(errorParse.toString())
     }
 
     @Internal

--- a/src/main/groovy/wooga/gradle/unity/utils/UnityLogErrorReader.groovy
+++ b/src/main/groovy/wooga/gradle/unity/utils/UnityLogErrorReader.groovy
@@ -17,37 +17,162 @@
 
 package wooga.gradle.unity.utils
 
-class UnityLogErrorReader {
+import java.util.regex.Matcher
 
-    static String DEFAULT_MESSAGE = "no error"
+enum UnityLogErrorType {
+    /**
+     * No error was found
+     */
+    None,
+    /**
+     * The error could not be parsed
+     */
+    Unknown,
+    /**
+     * The Unity scripts have compiler errors
+     */
+    ScriptsCompilerError
+}
 
-    static String  readErrorMessageFromLog(File logfile) {
-        def message = DEFAULT_MESSAGE
-        if(!logfile || !logfile.exists()) {
-            return message
+class UnityLogErrorParse {
+    UnityLogErrorType type
+    String message
+    List<CSharpFileCompilationResult> compilerOutput
+
+    @Override
+    String toString() {
+        def result = "${type}:"
+        switch (type) {
+            case UnityLogErrorType.ScriptsCompilerError:
+                compilerOutput.forEach({l ->
+                    result += "\n${l.text}"
+                })
+                break
+        }
+        result
+    }
+}
+
+class CSharpFileCompilationResult {
+    String text
+    String filePath
+    Integer line
+    Integer column
+    String level
+    String code
+    String message
+
+    CSharpFileCompilationResult(String filePath, Integer line, Integer column, String level, String code, String message) {
+        this.filePath = filePath
+        this.line = line
+        this.column = column
+        this.level = level
+        this.code = code
+        this.message = message
+    }
+
+    CSharpFileCompilationResult(String text, String filePath, Integer line, Integer column, String level, String code, String message) {
+        this.text = text
+        this.filePath = filePath
+        this.line = line
+        this.column = column
+        this.level = level
+        this.code = code
+        this.message = message
+    }
+
+    CSharpFileCompilationResult() {
+    }
+
+    // e.g: "A/B.cs(9,7): warning CS0105: WRONG!"
+    static String pattern = /(?<filePath>.+)\((?<line>\d+),(?<column>\d+)\):\s(?<level>.*?)\s(?<code>.+):\s(?<message>.*)/
+
+    static CSharpFileCompilationResult Parse(String text) {
+        Matcher matcher = (text =~ pattern)
+        if (matcher.count == 0) {
+            return null
         }
 
-        boolean foundErrorMarker = false
-        String errorMarker = "Aborting batchmode due to failure:"
-        String dialogError = "Cancelling DisplayDialog:"
-        String line
-        logfile.withReader { reader ->
-            while ((line = reader.readLine())!=null) {
-                if(foundErrorMarker) {
-                    message = line
-                    break
-                }
-                if(line.startsWith(errorMarker)) {
-                    foundErrorMarker = true
-                }
+        def (all, filePath, line, column, level, code, message) = matcher[0]
+        CSharpFileCompilationResult result = new CSharpFileCompilationResult()
+        result.text = all
+        result.filePath = filePath
+        result.line = Integer.parseInt(line)
+        result.column = Integer.parseInt(column)
+        result.level = level
+        result.code = code
+        result.message = message
+        result
+    }
+}
 
-                if(line.startsWith(dialogError)) {
-                    message = line.replace(dialogError, "").trim()
-                    break
+class UnityLogErrorReader {
+
+    static String compilerOutputStartMarker = "-----CompilerOutput:"
+    static String compilerOutputEndMarker = "-----EndCompilerOutput"
+    static String compilerErrorMarker = "Scripts have compiler errors."
+    static String errorMarker = "Aborting batchmode due to failure:"
+    static String dialogError = "Cancelling DisplayDialog:"
+
+    static UnityLogErrorParse readErrorMessageFromLog(File logfile) {
+
+        UnityLogErrorParse parse = new UnityLogErrorParse()
+        parse.type = UnityLogErrorType.None
+
+        if (!logfile || !logfile.exists()) {
+            return parse
+        }
+
+        boolean foundCompilerMarker = false
+        boolean foundErrorMarker = false
+        parse.compilerOutput = []
+        String line
+        Integer lineNumber = 0
+
+        // Read through the log file
+        logfile.withReader { reader ->
+            while ((line = reader.readLine()) != null) {
+                lineNumber++
+
+                // If inside a marker, parse
+                if (foundCompilerMarker) {
+                    // Finished reading compiler output
+                    if (line.startsWith(compilerOutputEndMarker)) {
+                        foundCompilerMarker = false
+                    }
+                    // Record all warnings/errors
+                    else {
+                        CSharpFileCompilationResult fileCompilationResult = CSharpFileCompilationResult.Parse(line)
+                        if (fileCompilationResult != null) {
+                            parse.compilerOutput.add(fileCompilationResult)
+                        }
+                    }
+                } else if (foundErrorMarker) {
+                    if (line.startsWith(compilerErrorMarker)) {
+                        parse.type = UnityLogErrorType.ScriptsCompilerError
+                        break
+                    } else {
+                        parse.message = line
+                    }
+                }
+                // Look for markers
+                else {
+                    // The error marker is found near the end of the log output
+                    if (line.startsWith(errorMarker)) {
+                        parse.type = UnityLogErrorType.Unknown
+                        foundErrorMarker = true
+                    }
+                    // Started reading through C# compiler output
+                    else if (line.startsWith(compilerOutputStartMarker)) {
+                        foundCompilerMarker = true
+                    }
+//                    else if (line.startsWith(dialogError)) {
+//                        parse.message = line.replace(dialogError, "").trim()
+//                        break
+//                    }
                 }
             }
         }
-
-        message
+        parse
     }
 }

--- a/src/test/groovy/wooga/gradle/unity/utils/UnityErrorLogReaderTest.groovy
+++ b/src/test/groovy/wooga/gradle/unity/utils/UnityErrorLogReaderTest.groovy
@@ -18,12 +18,14 @@
 package wooga.gradle.unity.utils
 
 import spock.lang.Specification
+import spock.lang.Unroll
 
 class UnityErrorLogReaderTest extends Specification {
 
+
     def "reads error message from logfile"() {
         given: "logfile with error message"
-        def log = File.createTempFile("log","log")
+        def log = File.createTempFile("log", "log")
         log << """
         Reloading assemblies after script compilation.
         Validating Project structure ... 0.005520 seconds.
@@ -45,16 +47,16 @@ class UnityErrorLogReaderTest extends Specification {
         (Filename: /Users/builduser/buildslave/unity/build/Runtime/Threads/Posix/PlatformThread.cpp Line: 38)
         """.stripIndent()
 
-        when:"parsing error message"
+        when: "parsing error message"
         def message = UnityLogErrorReader.readErrorMessageFromLog(log)
 
         then:
-        message == "Scripts have compiler errors."
+        message.type == UnityLogErrorType.ScriptsCompilerError
     }
 
     def "returns default message when error marker is not included"() {
         given: "logfile with no error message"
-        def log = File.createTempFile("log","log")
+        def log = File.createTempFile("log", "log")
         log << """
         Reloading assemblies after script compilation.
         Validating Project structure ... 0.005520 seconds.
@@ -72,21 +74,194 @@ class UnityErrorLogReaderTest extends Specification {
         (Filename: /Users/builduser/buildslave/unity/build/Runtime/Threads/Posix/PlatformThread.cpp Line: 38)
         """.stripIndent()
 
-        when:"parsing error message"
+        when: "parsing error message"
         def message = UnityLogErrorReader.readErrorMessageFromLog(log)
 
         then:
-        message == UnityLogErrorReader.DEFAULT_MESSAGE
+        message.type == UnityLogErrorType.None
     }
 
     def "returns default message log file doesn't exist"() {
         given: "path to nonexisting logfile"
         def log = new File("test.log")
 
-        when:"parsing error message"
+        when: "parsing error message"
         def message = UnityLogErrorReader.readErrorMessageFromLog(log)
 
         then:
-        message == UnityLogErrorReader.DEFAULT_MESSAGE
+        message.type == UnityLogErrorType.None
     }
+
+    def "finds script compiler errors"() {
+        given: "logfile with compiler errors"
+        def log = File.createTempFile("log", "log")
+        log << """
+-----CompilerOutput:-stdout--exitcode: 1--compilationhadfailure: True--outfile: Temp/Assembly-CSharp-Editor.dll
+
+Microsoft (R) Visual C# Compiler version 2.9.1.65535 (9d34608e)
+
+Copyright (C) Microsoft Corporation. All rights reserved.
+
+Assets/Wooga/UnifiedBuildSystem/Tests/Editor/BuildEngine/BuildStepTest.cs(9,7): warning CS0105: The using directive for 'Wooga.UnifiedBuildSystem.Editor' appeared previously in this namespace
+Assets/Wooga/UnifiedBuildSystem/Tests/Editor/BuildEngine/GroupedBuildStepTest.cs(9,39): error CS0234: The type or namespace name 'Tests' does not exist in the namespace 'Wooga.UnifiedBuildSystem.Editor' (are you missing an assembly reference?)
+Assets/Wooga/UnifiedBuildSystem/Samples/Editor/BuildExamples.cs(13,45): warning CS0618: 'BuildStep.RunAfter' is obsolete: 'This ordering is planned to be deprecated. '
+Assets/Wooga/UnifiedBuildSystem/Samples/Editor/BuildExamples.cs(16,45): warning CS0618: 'BuildStep.RunBefore' is obsolete: 'This ordering is planned to be deprecated. '
+Assets/Wooga/UnifiedBuildSystem/Editor/AppConfig/AppConfig.ISerializationCallbackReceiver.cs(7,21): warning CS0114: 'AppConfig.OnBeforeSerialize()' hides inherited member 'BuildConfigScriptable.OnBeforeSerialize()'. To make the current member override that implementation, add the override keyword. Otherwise add the new keyword.
+Assets/Wooga/UnifiedBuildSystem/Editor/AppConfig/AppConfig.ISerializationCallbackReceiver.cs(23,21): warning CS0114: 'AppConfig.OnAfterDeserialize()' hides inherited member 'BuildConfigScriptable.OnAfterDeserialize()'. To make the current member override that implementation, add the override keyword. Otherwise add the new keyword.
+Assets/Wooga/UnifiedBuildSystem/Editor/Build/Build.ExportProject.cs(9,41): warning CS0618: 'BuildStep.RunBefore' is obsolete: 'This ordering is planned to be deprecated. '
+Assets/Wooga/UnifiedBuildSystem/Editor/Build/Build.PostBuildAndroid.cs(8,46): warning CS0618: 'BuildStep.RunAfter' is obsolete: 'This ordering is planned to be deprecated. '
+Assets/Wooga/UnifiedBuildSystem/Editor/Build/Build.PostBuildAndroid.cs(8,83): warning CS0618: 'BuildStep.RunBefore' is obsolete: 'This ordering is planned to be deprecated. '
+
+-----CompilerOutput:-stderr----------
+
+-----EndCompilerOutput---------------
+
+- Finished script compilation in 7.715436 seconds
+
+Assets/Wooga/UnifiedBuildSystem/Tests/Editor/BuildEngine/BuildStepTest.cs(9,7): warning CS0105: The using directive for 'Wooga.UnifiedBuildSystem.Editor' appeared previously in this namespace
+Assets/Wooga/UnifiedBuildSystem/Tests/Editor/BuildEngine/GroupedBuildStepTest.cs(9,39): error CS0234: The type or namespace name 'Tests' does not exist in the namespace 'Wooga.UnifiedBuildSystem.Editor' (are you missing an assembly reference?)
+Assets/Wooga/UnifiedBuildSystem/Samples/Editor/BuildExamples.cs(13,45): warning CS0618: 'BuildStep.RunAfter' is obsolete: 'This ordering is planned to be deprecated. '
+Assets/Wooga/UnifiedBuildSystem/Samples/Editor/BuildExamples.cs(16,45): warning CS0618: 'BuildStep.RunBefore' is obsolete: 'This ordering is planned to be deprecated. '
+Assets/Wooga/UnifiedBuildSystem/Editor/AppConfig/AppConfig.ISerializationCallbackReceiver.cs(7,21): warning CS0114: 'AppConfig.OnBeforeSerialize()' hides inherited member 'BuildConfigScriptable.OnBeforeSerialize()'. To make the current member override that implementation, add the override keyword. Otherwise add the new keyword.
+Assets/Wooga/UnifiedBuildSystem/Editor/AppConfig/AppConfig.ISerializationCallbackReceiver.cs(23,21): warning CS0114: 'AppConfig.OnAfterDeserialize()' hides inherited member 'BuildConfigScriptable.OnAfterDeserialize()'. To make the current member override that implementation, add the override keyword. Otherwise add the new keyword.
+Assets/Wooga/UnifiedBuildSystem/Editor/Build/Build.ExportProject.cs(9,41): warning CS0618: 'BuildStep.RunBefore' is obsolete: 'This ordering is planned to be deprecated. '
+Assets/Wooga/UnifiedBuildSystem/Editor/Build/Build.PostBuildAndroid.cs(8,46): warning CS0618: 'BuildStep.RunAfter' is obsolete: 'This ordering is planned to be deprecated. '
+Assets/Wooga/UnifiedBuildSystem/Editor/Build/Build.PostBuildAndroid.cs(8,83): warning CS0618: 'BuildStep.RunBefore' is obsolete: 'This ordering is planned to be deprecated. '
+
+Unloading 1218 Unused Serialized files (Serialized files now loaded: 0)
+System memory in use before: 321.0 MB.
+System memory in use after: 321.2 MB.
+
+...
+
+Unloading 1798 Unused Serialized files (Serialized files now loaded: 0)
+System memory in use before: 348.5 MB.
+System memory in use after: 347.6 MB.
+
+Unloading 1814 unused Assets to reduce memory usage. Loaded Objects now: 1668.
+Total: 7.968787 ms (FindLiveObjects: 0.574456 ms CreateObjectMapping: 0.243863 ms MarkObjects: 4.823242 ms  DeleteObjects: 2.326409 ms)
+
+Disconnect from CacheServer
+Refreshing native plugins compatible for Editor in 4.99 ms, found 0 plugins.
+Preloading 0 native plugins for Editor in 0.00 ms.
+Warming cache for 1797 main assets: 0.003021 seconds elapsed
+
+Initializing Unity extensions:
+
+ '/Users/jenkins_agent/Applications/Unity/Hub/Editor/2019.4.19f1/Unity.app/Contents/UnityExtensions/Unity/UnityVR/Editor/UnityEditor.VR.dll'  GUID: 4ba2329b63d54f0187bcaa12486b1b0f
+
+Unloading 53 Unused Serialized files (Serialized files now loaded: 0)
+
+System memory in use before: 309.1 MB.
+System memory in use after: 309.1 MB.
+Unloading 56 unused Assets to reduce memory usage. Loaded Objects now: 1678.
+Total: 5.620424 ms (FindLiveObjects: 0.363267 ms CreateObjectMapping: 0.103867 ms MarkObjects: 5.024895 ms  DeleteObjects: 0.127224 ms)
+
+
+Scripts have compiler errors. 
+(Filename: ./Runtime/Utilities/Argv.cpp Line: 376)
+
+Aborting batchmode due to failure:
+Scripts have compiler errors.
+
+[Package Manager] Server::Kill -- Server was shutdown
+
+(lldb) command source -s 0 '/tmp/mono-gdb-commands.Fr24P1'
+
+
+> Task :Wooga.UnifiedBuildSystem:exportUnityPackage FAILED
+> Task :Wooga.UnifiedBuildSystem:returnUnityLicense SKIPPED
+> Task :Wooga.UnifiedBuildSystem:unsetAPICompatibilityLevel SKIPPED
+
+FAILURE: Build failed with an exception.
+
+* What went wrong:
+Execution failed for task ':Wooga.UnifiedBuildSystem:exportUnityPackage'.
+
+> Unity batchmode finished with non-zero exit value 1 and error 'Scripts have compiler errors.'
+
+* Try:
+
+Run with --stacktrace option to get the stack trace. Run with --info or --debug option to get more log output. Run with --scan to get full insights.
+
+* Get more help at https://help.gradle.org
+
+Deprecated Gradle features were used in this build, making it incompatible with Gradle 5.0.
+Use '--warning-mode all' to show the individual deprecation warnings.
+See https://docs.gradle.org/4.10.2/userguide/command_line_interface.html#sec:command_line_warnings
+
+BUILD FAILED in 2m 24s
+10 actionable tasks: 9 executed, 1 up-to-date
+
+"""
+        when: "parsing error message"
+        def message = UnityLogErrorReader.readErrorMessageFromLog(log)
+
+        then:
+        message.type == UnityLogErrorType.ScriptsCompilerError
+        message.compilerOutput.size() == 9
+        message.compilerOutput[0].properties == new CSharpFileCompilationResult(
+                "Assets/Wooga/UnifiedBuildSystem/Tests/Editor/BuildEngine/BuildStepTest.cs(9,7): warning CS0105: The using directive for 'Wooga.UnifiedBuildSystem.Editor' appeared previously in this namespace",
+                "Assets/Wooga/UnifiedBuildSystem/Tests/Editor/BuildEngine/BuildStepTest.cs",
+                9,
+                7,
+                "warning",
+                "CS0105",
+                "The using directive for 'Wooga.UnifiedBuildSystem.Editor' appeared previously in this namespace"
+        ).properties
+
+    }
+
+    @Unroll("parses #testCase[0]")
+    def "parses csharp file compilation result"() {
+        given:
+        def input = testCase[0]
+        def expected = testCase[1]
+
+        when:
+        def result = CSharpFileCompilationResult.Parse(input)
+
+        then:
+        result != null
+        result.properties == expected.properties
+
+        where:
+        testCase << [
+                [
+                        "A/B.cs(9,7): warning CS0105: WRONG!",
+                        new CSharpFileCompilationResult(
+                                "A/B.cs(9,7): warning CS0105: WRONG!",
+                                "A/B.cs",
+                                9,
+                                7,
+                                "warning",
+                                "CS0105",
+                                "WRONG!")
+                ],
+                [
+                        "Assets/Wooga/UnifiedBuildSystem/Tests/Editor/BuildEngine/BuildStepTest.cs(9,7): warning CS0105: The using directive for 'Wooga.UnifiedBuildSystem.Editor' appeared previously in this namespace",
+                        new CSharpFileCompilationResult(
+                                "Assets/Wooga/UnifiedBuildSystem/Tests/Editor/BuildEngine/BuildStepTest.cs(9,7): warning CS0105: The using directive for 'Wooga.UnifiedBuildSystem.Editor' appeared previously in this namespace",
+                                "Assets/Wooga/UnifiedBuildSystem/Tests/Editor/BuildEngine/BuildStepTest.cs",
+                                9,
+                                7,
+                                "warning",
+                                "CS0105",
+                                "The using directive for 'Wooga.UnifiedBuildSystem.Editor' appeared previously in this namespace")
+                ],
+                [
+                        "Assets/Wooga/UnifiedBuildSystem/Tests/Editor/BuildEngine/GroupedBuildStepTest.cs(9,39): error CS0234: The type or namespace name 'Tests' does not exist in the namespace 'Wooga.UnifiedBuildSystem.Editor' (are you missing an assembly reference?)",
+                        new CSharpFileCompilationResult(
+                                "Assets/Wooga/UnifiedBuildSystem/Tests/Editor/BuildEngine/GroupedBuildStepTest.cs(9,39): error CS0234: The type or namespace name 'Tests' does not exist in the namespace 'Wooga.UnifiedBuildSystem.Editor' (are you missing an assembly reference?)",
+                                "Assets/Wooga/UnifiedBuildSystem/Tests/Editor/BuildEngine/GroupedBuildStepTest.cs",
+                                9,
+                                39,
+                                "error",
+                                "CS0234",
+                                "The type or namespace name 'Tests' does not exist in the namespace 'Wooga.UnifiedBuildSystem.Editor' (are you missing an assembly reference?)")
+                ],
+        ]
+
+    }
+
 }


### PR DESCRIPTION
… fails

## Description

Whenever the unity task process execution returns a non-zero exit code, parse the resulting log to identify the error and log it to the user.

## Changes
* ![UPDATE] UnityLogErrorParser
* ![UPDATE] UnityTask

[NEW]:https://atlas-resources.wooga.com/icons/icon_new.svg "New"
[ADD]:http://resources.atlas.wooga.com/icons/icon_add.svg "Add"
[IMPROVE]:http://resources.atlas.wooga.com/icons/icon_improve.svg "IMPROVE"
[CHANGE]:http://resources.atlas.wooga.com/icons/icon_change.svg "Change"
[FIX]:http://resources.atlas.wooga.com/icons/icon_fix.svg "Fix"
[UPDATE]:http://resources.atlas.wooga.com/icons/icon_update.svg "Update"

[BREAK]:http://resources.atlas.wooga.com/icons/icon_break.svg "Remove"
[REMOVE]:http://resources.atlas.wooga.com/icons/icon_remove.svg "Remove"
[IOS]:http://resources.atlas.wooga.com/icons/icon_iOS.svg "iOS"
[ANDROID]:http://resources.atlas.wooga.com/icons/icon_android.svg "Android"
[WEBGL]:http://resources.atlas.wooga.com/icons/icon_webGL.svg "Web:GL"
