### PR TITLE
Fix default environment for Unity invocation

### DIFF
--- a/src/integrationTest/groovy/wooga/gradle/unity/UnityTaskIntegrationSpec.groovy
+++ b/src/integrationTest/groovy/wooga/gradle/unity/UnityTaskIntegrationSpec.groovy
@@ -225,9 +225,21 @@ abstract class UnityTaskIntegrationSpec<T extends UnityTask> extends UnityIntegr
 
     @Unroll
     def "set environment variable #rawValue for task exec"() {
-        given:
+        given: "some clean environment variables"
+        def envNames = System.getenv().keySet().toArray()
+        environmentVariables.clear(*envNames)
+
+        and: "a test value in system env"
+        initialValue.each { key, value ->
+            environmentVariables.set(key, value)
+        }
+
+        and: "an overridden environment"
         appendToSubjectTask("$method($value)")
         addProviderQueryTask("custom", "${subjectUnderTestName}.environment", ".get()")
+
+        and: "some values in the user environment"
+        environmentVariables.set("USER_A", "foo")
 
         when:
         def result = runTasksSuccessfully(subjectUnderTestName, "custom")
@@ -246,13 +258,21 @@ abstract class UnityTaskIntegrationSpec<T extends UnityTask> extends UnityIntegr
         "environment" | true      | ["A": true]
         "environment" | false     | ["A": false]
 
+        initialValue = ["B": "5", "C" : "7"]
         method = (useSetter) ? "set${property.capitalize()}" : "${property}.set"
         value = wrapValueBasedOnType(rawValue, Map)
     }
 
     def "adds environment for task exec"() {
-        given:
-        appendToSubjectTask("environment.set(${wrapValueBasedOnType(initialValue, Map)})")
+        given: "some clean environment variables"
+        def envNames = System.getenv().keySet().toArray()
+        environmentVariables.clear(*envNames)
+
+        and: "a test value in system env"
+        initialValue.each { key, value ->
+            environmentVariables.set(key, value)
+        }
+
         appendToSubjectTask("$method(${wrapValueBasedOnType(rawValue, Map)})")
         addProviderQueryTask("custom", "${subjectUnderTestName}.environment", ".get().sort()")
 

--- a/src/main/groovy/wooga/gradle/unity/UnityPlugin.groovy
+++ b/src/main/groovy/wooga/gradle/unity/UnityPlugin.groovy
@@ -153,6 +153,7 @@ class UnityPlugin implements Plugin<Project> {
             t.unityLogFile.convention(extension.logsDir.file(project.provider {
                 t.logCategory.get().isEmpty() ? "${t.name}.log" : "${t.logCategory.get()}/${t.name}.log"
             }))
+            t.environment.putAll(project.provider({System.getenv()}))
         }
     }
 


### PR DESCRIPTION
## Description

This patch sets the default environment used to call Unity to `System.env`. It is possible to append values to this default env or reset it completely.

Unity needs the `HOME` variable by default and maybe some more.

## Changes

* ![FIX] default environment for Unity invocation

[NEW]:https://atlas-resources.wooga.com/icons/icon_new.svg "New"
[ADD]:http://resources.atlas.wooga.com/icons/icon_add.svg "Add"
[IMPROVE]:http://resources.atlas.wooga.com/icons/icon_improve.svg "IMPROVE"
[CHANGE]:http://resources.atlas.wooga.com/icons/icon_change.svg "Change"
[FIX]:http://resources.atlas.wooga.com/icons/icon_fix.svg "Fix"
[UPDATE]:http://resources.atlas.wooga.com/icons/icon_update.svg "Update"

[BREAK]:http://resources.atlas.wooga.com/icons/icon_break.svg "Remove"
[REMOVE]:http://resources.atlas.wooga.com/icons/icon_remove.svg "Remove"
[IOS]:http://resources.atlas.wooga.com/icons/icon_iOS.svg "iOS"
[ANDROID]:http://resources.atlas.wooga.com/icons/icon_android.svg "Android"
[WEBGL]:http://resources.atlas.wooga.com/icons/icon_webGL.svg "Web:GL"
