### PR TITLE
Refactor how the values of properties in integration tests are queried

### DIFF
--- a/src/integrationTest/groovy/wooga/gradle/IntegrationSpec.groovy
+++ b/src/integrationTest/groovy/wooga/gradle/IntegrationSpec.groovy
@@ -23,9 +23,10 @@ import org.junit.Rule
 import org.junit.contrib.java.lang.system.EnvironmentVariables
 import org.junit.contrib.java.lang.system.ProvideSystemProperty
 import wooga.gradle.unity.utils.PlatformUtilsImpl
+import wooga.gradle.utils.PropertyUtilsImpl
 
 class IntegrationSpec extends nebula.test.IntegrationSpec
-        implements PropertyUtils, PlatformUtilsImpl {
+        implements PropertyUtilsImpl, PlatformUtilsImpl {
 
     @Rule
     ProvideSystemProperty properties = new ProvideSystemProperty("ignoreDeprecations", "true")

--- a/src/integrationTest/groovy/wooga/gradle/unity/UnityIntegrationSpec.groovy
+++ b/src/integrationTest/groovy/wooga/gradle/unity/UnityIntegrationSpec.groovy
@@ -20,6 +20,8 @@ package wooga.gradle.unity
 import com.wooga.spock.extensions.unity.DefaultUnityPluginTestOptions
 import com.wooga.spock.extensions.unity.UnityPathResolution
 import com.wooga.spock.extensions.unity.UnityPluginTestOptions
+import nebula.test.functional.ExecutionResult
+import org.gradle.internal.impldep.com.amazonaws.transform.MapEntry
 import wooga.gradle.IntegrationSpec
 import wooga.gradle.unity.tasks.Unity
 import wooga.gradle.unity.utils.ProjectSettingsFile
@@ -120,10 +122,9 @@ abstract class UnityIntegrationSpec extends IntegrationSpec {
     }
 
     protected File setProjectSettingsFile(String content = ProjectSettingsFile.DEFAULT_TEMPLATE_CONTENT) {
-        if (!projectSettingsFile){
+        if (!projectSettingsFile) {
             projectSettingsFile = createFile("ProjectSettings/ProjectSettings.asset")
-        }
-        else{
+        } else {
             projectSettingsFile.text = ""
         }
         projectSettingsFile << content
@@ -158,7 +159,7 @@ abstract class UnityIntegrationSpec extends IntegrationSpec {
 
     void setLicenseDirectory() {
         // Setup fake license dir so we don't delete actual licenses
-        def licenseDir = File.createTempDir("unity","testLicenseDir")
+        def licenseDir = File.createTempDir("unity", "testLicenseDir")
         createFile("testLicense", licenseDir)
         buildFile << """
         unity {
@@ -239,16 +240,5 @@ abstract class UnityIntegrationSpec extends IntegrationSpec {
             }
         """.stripIndent()
         buildFile << builder.toString()
-    }
-
-    void addProviderQueryTask(String name, String path, String invocation = ".getOrNull()") {
-        buildFile << """
-            task(${name}) {
-                doLast {
-                    def value = ${path}${invocation}
-                    println("${path}: " + value)
-                }
-            }
-        """
     }
 }

--- a/src/integrationTest/groovy/wooga/gradle/utils/PropertyQueryTaskWriter.groovy
+++ b/src/integrationTest/groovy/wooga/gradle/utils/PropertyQueryTaskWriter.groovy
@@ -1,0 +1,108 @@
+package wooga.gradle.utils
+
+import groovy.transform.InheritConstructors
+import nebula.test.Integration
+import nebula.test.functional.ExecutionResult
+
+/**
+ * Writes a task for querying the value of a property
+ * from a given path with the specified invocation.
+ */
+abstract class BasePropertyQueryTaskWriter {
+
+    String path
+    String invocation
+    String taskName
+
+    String getTaskName() {
+        taskName
+    }
+
+    /**
+     * Writes the task that will print the given query
+     */
+    abstract void write(File file);
+
+    BasePropertyQueryTaskWriter(String path, String invocation = ".getOrNull()", String taskName = null) {
+        this.path = path
+        this.invocation = invocation
+        this.taskName = taskName ?: PropertyUtils.envNameFromProperty("Query_${path}")
+    }
+}
+
+/**
+ * Writes a task for querying the value of a property
+ * from a given path with the specified invocation.
+ */
+@InheritConstructors
+class PropertyQueryTaskWriter extends BasePropertyQueryTaskWriter {
+
+    final String separator = " : "
+
+    void write(File file) {
+        file << """
+            task(${taskName}) {
+                doLast {
+                    def value = ${path}${invocation}
+                    println("${path}${separator}" + value)
+                }
+            }
+        """.stripIndent()
+    }
+
+    /**
+     * @return True if the property's toString() matches the given value
+     */
+    Boolean matches(ExecutionResult result, Object value) {
+        result.standardOutput.contains("${path}${separator}${value}")
+    }
+}
+
+/**
+ * Writes a task for querying the value of a {@code Map} type property
+ * from a given path with the specified invocation.
+ * It contains functions for testing whether the map contains certaion values.
+ */
+@InheritConstructors
+class MapPropertyQueryTaskWriter extends BasePropertyQueryTaskWriter {
+
+    final String keyword = "contains"
+
+    void write(File file) {
+        file << """
+            task(${taskName}) {
+                doLast {
+                    def value = ${path}${invocation}
+                    for(v in value) {
+                        println("${path} ${keyword} " + v)
+                    }
+                }
+            }
+        """.stripIndent()
+    }
+
+    /**
+     * @return True if the map contains the given key-value pairs
+     */
+    Boolean contains(ExecutionResult result, Map.Entry<String, ?>... entries) {
+        for (e in entries) {
+            if (!result.standardOutput.contains("${path} ${keyword} ${e}"))
+                return false
+        }
+        return true
+    }
+
+    /**
+     * @return True if the map contains the values of the given maps
+     */
+    Boolean contains(ExecutionResult result, Map<String, ?>... maps) {
+        for (m in maps) {
+            for (e in m) {
+                if (!contains(result, e))
+                    return false
+            }
+        }
+        return true
+    }
+
+}

--- a/src/integrationTest/groovy/wooga/gradle/utils/PropertyUtils.groovy
+++ b/src/integrationTest/groovy/wooga/gradle/utils/PropertyUtils.groovy
@@ -1,6 +1,6 @@
-package wooga.gradle
+package wooga.gradle.utils
 
-trait PropertyUtils {
+trait PropertyUtilsImpl {
 
     enum PropertyLocation {
         none, script, property, environment
@@ -19,11 +19,15 @@ trait PropertyUtils {
         }
     }
 
-    String envNameFromProperty(String extensionName, String property) {
+    static String envNameFromProperty(String extensionName, String property) {
         "${extensionName.toUpperCase()}_${property.replaceAll(/([A-Z])/, "_\$1").toUpperCase()}"
     }
 
-    String envNameFromProperty(String property) {
+    static String envNameFromProperty(String property) {
         property.replaceAll(/([A-Z.])/, '_$1').replaceAll(/[.]/, '').toUpperCase()
     }
 }
+
+class PropertyUtils implements PropertyUtilsImpl {
+}
+

--- a/src/main/groovy/wooga/gradle/unity/tasks/Activate.groovy
+++ b/src/main/groovy/wooga/gradle/unity/tasks/Activate.groovy
@@ -67,7 +67,6 @@ class Activate extends UnityTask implements UnityAuthenticationSpec {
     @Override
     protected void preExecute() {
         super.preExecute()
-        // @TODO: When moved to constructor, doesn't get queried properly. It could be because the authentication keeps changing?
         setCommandLineOptionConvention(UnityCommandLineOption.userName, authentication.username)
         setCommandLineOptionConvention(UnityCommandLineOption.password, authentication.password)
         setCommandLineOptionConvention(UnityCommandLineOption.serial, authentication.serial)


### PR DESCRIPTION
## Description

Rewrites how the values of properties are queried by the integration tests by using a _writer_ object which handles the writing of the query task and provides the functions for testing them.

The newer API simplifies the writing of these property tests:

```groovy
        when:
        def query = new PropertyQueryTaskWriter("${extensionName}.${property}")
        query.write(buildFile)
        def result = runTasksSuccessfully(query.taskName)

        then:
        query.matches(result, testValue)
```

## Changes
* ![UPDATE] UnityIntegrationTest
* ![IMPROVE] *IntegrationTests
* ![ADD] PropertyQueryTaskWriter

[NEW]:https://atlas-resources.wooga.com/icons/icon_new.svg "New"
[ADD]:http://resources.atlas.wooga.com/icons/icon_add.svg "Add"
[IMPROVE]:http://resources.atlas.wooga.com/icons/icon_improve.svg "IMPROVE"
[CHANGE]:http://resources.atlas.wooga.com/icons/icon_change.svg "Change"
[FIX]:http://resources.atlas.wooga.com/icons/icon_fix.svg "Fix"
[UPDATE]:http://resources.atlas.wooga.com/icons/icon_update.svg "Update"

[BREAK]:http://resources.atlas.wooga.com/icons/icon_break.svg "Remove"
[REMOVE]:http://resources.atlas.wooga.com/icons/icon_remove.svg "Remove"
[IOS]:http://resources.atlas.wooga.com/icons/icon_iOS.svg "iOS"
[ANDROID]:http://resources.atlas.wooga.com/icons/icon_android.svg "Android"
[WEBGL]:http://resources.atlas.wooga.com/icons/icon_webGL.svg "Web:GL"
