### PR TITLE
Added unity root, unity dotnet and unity mono framework properties

### DIFF
--- a/src/integrationTest/groovy/wooga/gradle/IntegrationSpec.groovy
+++ b/src/integrationTest/groovy/wooga/gradle/IntegrationSpec.groovy
@@ -25,6 +25,8 @@ import org.junit.contrib.java.lang.system.ProvideSystemProperty
 import wooga.gradle.unity.utils.PlatformUtilsImpl
 import wooga.gradle.utils.PropertyUtilsImpl
 
+import static java.lang.System.lineSeparator
+
 class IntegrationSpec extends nebula.test.IntegrationSpec
         implements PropertyUtilsImpl, PlatformUtilsImpl {
 
@@ -84,13 +86,11 @@ class IntegrationSpec extends nebula.test.IntegrationSpec
                         value = "project.layout.file(${wrapValueBasedOnType(rawValue, "Provider<File>", fallback)})"
                         break
                     case "Directory":
-                        value = """
-                                project.provider({
-                                    def d = project.layout.directoryProperty()
-                                    d.set(${wrapValueBasedOnType(rawValue, "File", fallback)})
-                                    d.get()
-                                })
-                        """.trim().stripIndent()
+                        value = "project.provider{ "+
+                                "def d = project.objects.directoryProperty();"+
+                                "d.set(${wrapValueBasedOnType(rawValue, "File", fallback)});"+
+                                "d.get();"+
+                                "}".trim().stripIndent()
                         break
                     default:
                         value = "project.provider(${wrapValueBasedOnType(rawValue, "Closure<${subType}>", fallback)})"

--- a/src/integrationTest/groovy/wooga/gradle/unity/UnityPluginIntegrationSpec.groovy
+++ b/src/integrationTest/groovy/wooga/gradle/unity/UnityPluginIntegrationSpec.groovy
@@ -20,12 +20,14 @@ package wooga.gradle.unity
 import com.wooga.spock.extensions.unity.UnityPathResolution
 import com.wooga.spock.extensions.unity.UnityPluginTestOptions
 import spock.lang.Unroll
-import wooga.gradle.unity.models.BuildTarget
 import wooga.gradle.unity.models.UnityCommandLineOption
 import wooga.gradle.unity.tasks.Test
 import wooga.gradle.unity.utils.ProjectSettingsFile
 import wooga.gradle.utils.PropertyLocation
 import wooga.gradle.utils.PropertyQueryTaskWriter
+
+import static wooga.gradle.unity.UnityPluginConventions.getUnityFileTree
+import static wooga.gradle.unity.UnityPluginConventions.getPlatformUnityPath
 
 /**
  * Tests the {@link UnityPluginExtension} when applied on the {@link UnityPlugin}
@@ -132,7 +134,7 @@ class UnityPluginIntegrationSpec extends UnityIntegrationSpec {
 
     @UnityPluginTestOptions(unityPath = UnityPathResolution.None, addPluginTestDefaults = false,
             disableAutoActivateAndLicense = false)
-    @Unroll()
+    @Unroll
     def "extension property :#property returns '#testValue' if #reason"() {
         given: "an applied plugin"
         setupUnityPlugin()
@@ -168,27 +170,29 @@ class UnityPluginIntegrationSpec extends UnityIntegrationSpec {
         query.matches(result, testValue)
 
         where:
-        property                   | method                       | rawValue                  | expectedValue                                              | type                    | location
-        "unityPath"                | _                            | _                         | UnityPluginConventions.getPlatformUnityPath().absolutePath | "Provider<RegularFile>" | PropertyLocation.none
-        "unityPath"                | _                            | osPath("/foo/bar/unity1") | _                                                          | _                       | PropertyLocation.environment
-        "unityPath"                | _                            | osPath("/foo/bar/unity2") | _                                                          | _                       | PropertyLocation.property
-        "unityPath"                | "setUnityPath"               | osPath("/foo/bar/unity3") | _                                                          | "Provider<RegularFile>" | PropertyLocation.script
-        "unityPath"                | "unityPath.set"              | osPath("/foo/bar/unity4") | _                                                          | "Provider<RegularFile>" | PropertyLocation.script
+        property                   | method                       | rawValue                  | expectedValue                                                   | type                    | location
+        "unityPath"                | _                            | _                         | getPlatformUnityPath().absolutePath                             | "Provider<RegularFile>" | PropertyLocation.none
+        "unityPath"                | _                            | osPath("/foo/bar/unity1") | _                                                               | _                       | PropertyLocation.environment
+        "unityPath"                | _                            | osPath("/foo/bar/unity2") | _                                                               | _                       | PropertyLocation.property
+        "unityPath"                | "setUnityPath"               | osPath("/foo/bar/unity3") | _                                                               | "Provider<RegularFile>" | PropertyLocation.script
+        "unityPath"                | "unityPath.set"              | osPath("/foo/bar/unity4") | _                                                               | "Provider<RegularFile>" | PropertyLocation.script
 
-        "defaultBuildTarget"       | _                            | _                         | null                                                       | _                       | PropertyLocation.none
-        "autoActivateUnity"        | _                            | _                         | true                                                       | Boolean                 | PropertyLocation.none
-        "autoReturnLicense"        | _                            | _                         | true                                                       | Boolean                 | PropertyLocation.none
-        "logCategory"              | _                            | _                         | "unity"                                                    | "Property<String>"      | PropertyLocation.none
-        "batchModeForEditModeTest" | _                            | _                         | true                                                       | Boolean                 | PropertyLocation.none
-        "batchModeForPlayModeTest" | _                            | _                         | true                                                       | Boolean                 | PropertyLocation.none
+        "unityRootDir"             | _                            | _                         | getUnityFileTree(getPlatformUnityPath()).unityRoot.absolutePath | "Provider<Directory>"   | PropertyLocation.none
 
-        "assetsDir"                | _                            | _                         | osPath("#projectDir#/Assets")                              | "Provider<Directory>"   | PropertyLocation.none
-        "logsDir"                  | _                            | _                         | osPath("#projectDir#/build/logs")                          | "Provider<Directory>"   | PropertyLocation.none
-        "reportsDir"               | _                            | _                         | osPath("#projectDir#/build/reports")                       | "Provider<Directory>"   | PropertyLocation.none
-        "enableTestCodeCoverage"   | _                            | _                         | false                                                      | Boolean                 | PropertyLocation.none
-        "enableTestCodeCoverage"   | "enableTestCodeCoverage.set" | true                      | _                                                          | "Provider<Boolean>"     | PropertyLocation.script
-        "enableTestCodeCoverage"   | "setEnableTestCodeCoverage"  | true                      | _                                                          | Boolean                 | PropertyLocation.script
-        "enableTestCodeCoverage"   | "setEnableTestCodeCoverage"  | true                      | _                                                          | "Provider<Boolean>"     | PropertyLocation.script
+        "defaultBuildTarget"       | _                            | _                         | null                                                            | _                       | PropertyLocation.none
+        "autoActivateUnity"        | _                            | _                         | true                                                            | Boolean                 | PropertyLocation.none
+        "autoReturnLicense"        | _                            | _                         | true                                                            | Boolean                 | PropertyLocation.none
+        "logCategory"              | _                            | _                         | "unity"                                                         | "Property<String>"      | PropertyLocation.none
+        "batchModeForEditModeTest" | _                            | _                         | true                                                            | Boolean                 | PropertyLocation.none
+        "batchModeForPlayModeTest" | _                            | _                         | true                                                            | Boolean                 | PropertyLocation.none
+
+        "assetsDir"                | _                            | _                         | osPath("#projectDir#/Assets")                                   | "Provider<Directory>"   | PropertyLocation.none
+        "logsDir"                  | _                            | _                         | osPath("#projectDir#/build/logs")                               | "Provider<Directory>"   | PropertyLocation.none
+        "reportsDir"               | _                            | _                         | osPath("#projectDir#/build/reports")                            | "Provider<Directory>"   | PropertyLocation.none
+        "enableTestCodeCoverage"   | _                            | _                         | false                                                           | Boolean                 | PropertyLocation.none
+        "enableTestCodeCoverage"   | "enableTestCodeCoverage.set" | true                      | _                                                               | "Provider<Boolean>"     | PropertyLocation.script
+        "enableTestCodeCoverage"   | "setEnableTestCodeCoverage"  | true                      | _                                                               | Boolean                 | PropertyLocation.script
+        "enableTestCodeCoverage"   | "setEnableTestCodeCoverage"  | true                      | _                                                               | "Provider<Boolean>"     | PropertyLocation.script
 
         value = (type != _) ? wrapValueBasedOnType(rawValue, type) : rawValue
         providedValue = (location == PropertyLocation.script) ? type : value

--- a/src/main/groovy/wooga/gradle/unity/UnityPluginConventions.groovy
+++ b/src/main/groovy/wooga/gradle/unity/UnityPluginConventions.groovy
@@ -20,6 +20,7 @@ package wooga.gradle.unity
 import com.wooga.gradle.PropertyLookup
 import wooga.gradle.unity.utils.PlatformUtils
 import wooga.gradle.unity.utils.PlatformUtilsImpl
+import wooga.gradle.unity.utils.UnityFileTree
 
 class UnityPluginConventions implements PlatformUtilsImpl {
 
@@ -73,7 +74,7 @@ class UnityPluginConventions implements PlatformUtilsImpl {
     /**
      * The path to the Unity Editor executable
      */
-    static final PropertyLookup unityPath = new PropertyLookup(["UNITY_UNITY_PATH", "UNITY_PATH"], "unity.unityPath", { getPlatformUnityPath().absolutePath })
+    static final PropertyLookup unityPath = new PropertyLookup(["UNITY_UNITY_PATH", "UNITY_PATH"], "unity.unityPath", { getPlatformUnityPath().absolutePath })    /**
     /**
      * Used for authentication with Unity's servers
      */
@@ -143,7 +144,6 @@ class UnityPluginConventions implements PlatformUtilsImpl {
      */
     static File getPlatformUnityPath() {
         File unityPath = null
-
         if (isWindows()) {
             if (is64BitArchitecture()) {
                 unityPath = UnityPluginConventions.UNITY_PATH_WIN
@@ -158,6 +158,9 @@ class UnityPluginConventions implements PlatformUtilsImpl {
         unityPath
     }
 
+    static UnityFileTree getUnityFileTree(File unityExec) {
+        return UnityFileTree.fromUnityExecutable(unityExec)
+     }
 
 }
 

--- a/src/main/groovy/wooga/gradle/unity/traits/UnityBaseSpec.groovy
+++ b/src/main/groovy/wooga/gradle/unity/traits/UnityBaseSpec.groovy
@@ -16,6 +16,7 @@
 
 package wooga.gradle.unity.traits
 
+import org.gradle.api.file.ProjectLayout
 import org.gradle.api.model.ObjectFactory
 import org.gradle.api.provider.ProviderFactory
 import org.gradle.internal.impldep.org.eclipse.jgit.errors.NotSupportedException
@@ -25,13 +26,17 @@ import javax.inject.Inject
 trait UnityBaseSpec {
 
     @Inject
+    ProjectLayout getLayout() {
+        throw new NotSupportedException("ProjectLayout is supposed to be injected here by gradle")
+    }
+    @Inject
     ProviderFactory getProviderFactory() {
-        throw new NotSupportedException("")
+        throw new NotSupportedException("ProviderFactory is supposed to be injected here by gradle")
     }
 
     @Inject
     ObjectFactory getObjects() {
-        throw new NotSupportedException("")
+        throw new NotSupportedException("ObjectFactory is supposed to be injected here by gradle")
     }
 
 }

--- a/src/main/groovy/wooga/gradle/unity/traits/UnitySpec.groovy
+++ b/src/main/groovy/wooga/gradle/unity/traits/UnitySpec.groovy
@@ -16,27 +16,20 @@
 
 package wooga.gradle.unity.traits
 
-import org.gradle.api.model.ObjectFactory
+
 import org.gradle.api.file.Directory
 import org.gradle.api.file.DirectoryProperty
 import org.gradle.api.file.RegularFile
 import org.gradle.api.file.RegularFileProperty
 import org.gradle.api.provider.Property
 import org.gradle.api.provider.Provider
-import org.gradle.api.provider.ProviderFactory
-import org.gradle.api.tasks.Input
-import org.gradle.api.tasks.InputDirectory
 import org.gradle.api.tasks.InputFile
 import org.gradle.api.tasks.Internal
 import org.gradle.api.tasks.Optional
 import org.gradle.api.tasks.OutputFile
-import org.gradle.api.tasks.SkipWhenEmpty
-import org.gradle.internal.impldep.org.eclipse.jgit.errors.NotSupportedException
 import wooga.gradle.unity.UnityPluginConventions
-import wooga.gradle.unity.models.BuildTarget
 import wooga.gradle.unity.utils.ProjectSettingsFile
-
-import javax.inject.Inject
+import wooga.gradle.unity.utils.UnityFileTree
 
 trait UnitySpec extends UnityBaseSpec {
 
@@ -75,6 +68,33 @@ trait UnitySpec extends UnityBaseSpec {
     }
     void setUnityPath(Provider<RegularFile> value) {
         unityPath.set(value)
+    }
+
+    private Provider<UnityFileTree> getUnityFileTree() {
+        return unityPath.map({ RegularFile unityExec ->
+            UnityPluginConventions.getUnityFileTree(unityExec.asFile)
+        }.memoize())
+    }
+
+    /**
+     * @return The path to the Unity root directory
+     */
+    Provider<Directory> getUnityRootDir() {
+        return layout.dir(getUnityFileTree().map({it.unityRoot}.memoize()))
+    }
+
+    /**
+     * @return The path to Unity .NET Core dotnet executable
+     */
+    Provider<RegularFile> getDotnetExecutable() {
+        return layout.file(getUnityFileTree().map({it.dotnetExecutable}.memoize()))
+    }
+
+    /**
+     * @return The path to the Unity mono framework directory (MonoBleedingEdge)
+     */
+    Provider<Directory> getMonoFrameworkDir() {
+        return layout.dir(getUnityFileTree().map({it.unityMonoFramework}.memoize()))
     }
 
     private RegularFileProperty unityLogFile = objects.fileProperty()

--- a/src/main/groovy/wooga/gradle/unity/utils/UnityFileTree.groovy
+++ b/src/main/groovy/wooga/gradle/unity/utils/UnityFileTree.groovy
@@ -1,0 +1,114 @@
+package wooga.gradle.unity.utils
+
+import java.nio.file.Files
+import java.nio.file.Path
+
+class UnityFileTreeFactory {
+
+    public UnityFileTreeFactory() {
+    }
+
+    public UnityFileTree fromExecutable(File unityExecutable) {
+        def root = getPlatformRootUnityDir(unityExecutable.toPath()).toFile()
+        return new UnityFileTree(root, unityExecutable)
+    }
+
+    private Path getPlatformRootUnityDir(Path unityExec) {
+        Optional<Path> maybeRoot = findUnityRootUsingParent(unityExec.parent)
+        if(!maybeRoot.present) {
+            maybeRoot = Optional.of(pinpointUnityRoot(unityExec))
+        }
+        return maybeRoot.get()
+
+    }
+    private Optional<Path> findUnityRootUsingParent(Path path) {
+        if(path != null && isUnityRoot(path)) {
+            return Optional.of(path)
+        } else if(path != null && path.root != path) {
+            return findUnityRootUsingParent(path.parent)
+        }
+        return Optional.empty()
+    }
+
+    private static boolean isUnityRoot(Path path) {
+        def normalizedFolderName = path.fileName.toString().toLowerCase()
+        if(PlatformUtils.isWindows()) {
+            return normalizedFolderName.startsWith("unity")
+        } else if(PlatformUtils.isLinux()) {
+            return normalizedFolderName.startsWith("unity")
+        } else if(PlatformUtils.isMac()) {
+            return normalizedFolderName.endsWith(".app")
+        }
+        throw new UnsupportedOperationException("OS not supported")
+    }
+
+    private static Path pinpointUnityRoot(Path unityExecutable) {
+        if(PlatformUtils.isWindows()) {
+            return unityExecutable.parent.parent
+        } else if(PlatformUtils.isLinux()) {
+            return unityExecutable.parent.parent
+        } else if(PlatformUtils.isMac()) {
+            return unityExecutable.parent.parent.parent
+        }
+        throw new UnsupportedOperationException("OS not supported")
+    }
+}
+
+class UnityFileTree {
+
+    private final File unityRoot
+    private final File unityExecutable
+    private File dotnetExecutable
+    private File unityMonoFramework
+
+    static UnityFileTree fromUnityExecutable(File unityExecutable) {
+        return new UnityFileTreeFactory().fromExecutable(unityExecutable)
+    }
+
+    UnityFileTree(File unityRoot, File unityExecutable) {
+        this.unityRoot = unityRoot
+        this.unityExecutable = unityExecutable
+    }
+
+    File findUnityDotnetExecutable() {
+        if(this.unityRoot.exists()) {
+            def walkStream = Files.walk(this.unityRoot.toPath())
+            return walkStream.filter {currentPath ->
+                currentPath.toFile().isFile() && currentPath.fileName.toString().toLowerCase() in ["dotnet", "dotnet.exe"]
+            }.findFirst().map{it.toFile()}.orElse(null)
+        }
+        return null
+    }
+
+    File findUnityMonoFramework() {
+        if(this.unityRoot.exists()) {
+            def walkStream = Files.walk(this.unityRoot.toPath())
+            return walkStream.filter {currentPath ->
+                currentPath.toFile().isDirectory() && currentPath.fileName.toString() == "MonoBleedingEdge"
+            }.findFirst().map{it.toFile()}.orElse(null)
+        }
+        return null
+    }
+
+    File getUnityRoot() {
+        return unityRoot
+    }
+
+    File getUnityExecutable() {
+        return unityExecutable
+    }
+
+    File getDotnetExecutable() {
+        if(dotnetExecutable == null) {
+            this.dotnetExecutable = findUnityDotnetExecutable()
+        }
+        return this.dotnetExecutable
+    }
+
+    File getUnityMonoFramework() {
+        if(this.unityMonoFramework == null) {
+            this.unityMonoFramework = findUnityMonoFramework()
+        }
+        return unityMonoFramework
+    }
+}

--- a/src/test/groovy/wooga/gradle/unity/utils/UnityFileTreeTest.groovy
+++ b/src/test/groovy/wooga/gradle/unity/utils/UnityFileTreeTest.groovy
@@ -1,0 +1,123 @@
+package wooga.gradle.unity.utils
+
+import spock.lang.Requires
+import spock.lang.Specification
+import spock.lang.Unroll
+
+import java.nio.file.Files
+import java.nio.file.Paths
+
+class UnityFileTreeTest extends Specification {
+
+    @Unroll
+    @Requires({os.isWindows()})
+    def "creates unity file tree from given windows unity installation named #rootName"() {
+        given:"a unity file tree"
+        def tree = fakeWindowsUnityFileTree(rootName)
+        when:
+        def generatedTree = UnityFileTree.fromUnityExecutable(tree.unityExecutable)
+        then:
+        generatedTree.unityRoot == tree.unityRoot
+        generatedTree.unityExecutable == tree.unityExecutable
+        generatedTree.dotnetExecutable == tree.dotnetExecutable
+        generatedTree.unityMonoFramework == tree.unityMonoFramework
+        cleanup:
+        deleteFolder(tree.unityRoot)
+        where:
+        rootName << ["Unity_win", "win_unity"]
+    }
+
+
+    @Unroll
+    @Requires({os.isMacOs()})
+    def "creates unity file tree from given macOS unity installation named #rootName"() {
+        given:"a unity file tree"
+        def tree = fakeMacOSUnityFileTree(rootName)
+        when:
+        def generatedTree = UnityFileTree.fromUnityExecutable(tree.unityExecutable)
+        then:
+        generatedTree.unityRoot == tree.unityRoot
+        generatedTree.unityExecutable == tree.unityExecutable
+        generatedTree.dotnetExecutable == tree.dotnetExecutable
+        generatedTree.unityMonoFramework == tree.unityMonoFramework
+        cleanup:
+        deleteFolder(tree.unityRoot)
+        where:
+        rootName << ["Unity.app", "unity_mac"]
+    }
+
+    @Unroll
+    @Requires({os.isLinux()})
+    def "creates unity file tree from given linux unity installation named #rootName"() {
+        given:"a unity file tree"
+        def tree = fakeLinuxUnityFileTree(rootName)
+        when:
+        def generatedTree = UnityFileTree.fromUnityExecutable(tree.unityExecutable)
+        then:
+        generatedTree.unityRoot == tree.unityRoot
+        generatedTree.unityExecutable == tree.unityExecutable
+        generatedTree.dotnetExecutable == tree.dotnetExecutable
+        generatedTree.unityMonoFramework == tree.unityMonoFramework
+        cleanup:
+        deleteFolder(tree.unityRoot)
+        where:
+        rootName << ["linux_unity", "unity_linux"]
+    }
+
+    def fakeWindowsUnityFileTree(String rootname) {
+        def root = Paths.get(rootname)
+        def executable = Paths.get(root.fileName.toString(), "Editor/Unity.exe")
+        def monoDir = Paths.get(root.fileName.toString(), "Editor/Data/MonoBleedingEdge")
+        def dotnetExec = Paths.get(root.fileName.toString(), "Editor/Data/NetCore/Sdk-2.2.107/dotnet.exe")
+        Files.createDirectories(root)
+        Files.createDirectories(monoDir)
+        Files.createDirectories(executable.parent)
+        Files.createDirectories(dotnetExec.parent)
+        executable.toFile().createNewFile()
+        dotnetExec.toFile().createNewFile()
+        return [unityRoot: root.toFile(),
+                unityExecutable: executable.toFile(),
+                dotnetExecutable: dotnetExec.toFile(),
+                unityMonoFramework: monoDir.toFile()]
+    }
+
+    def fakeMacOSUnityFileTree(String rootName) {
+        def root = Paths.get(rootName)
+        def monoDir = Paths.get(root.fileName.toString(), "Contents/MonoBleedingEdge")
+        def executable = Paths.get(root.fileName.toString(), "Contents/MacOS/unity")
+        def dotnetExec = Paths.get(root.fileName.toString(), "Contents/NetCore/Sdk-2.2.107/dotnet")
+        Files.createDirectories(root)
+        Files.createDirectories(monoDir)
+        Files.createDirectories(executable.parent)
+        Files.createDirectories(dotnetExec.parent)
+        executable.toFile().createNewFile()
+        dotnetExec.toFile().createNewFile()
+        return [unityRoot: root.toFile(),
+                unityExecutable: executable.toFile(),
+                dotnetExecutable: dotnetExec.toFile(),
+                unityMonoFramework: monoDir.toFile()]
+    }
+
+    def fakeLinuxUnityFileTree(String rootName) {
+        def root = Paths.get(rootName)
+        def monoDir = Paths.get(root.fileName.toString(), "Contents/MonoBleedingEdge")
+        def executable = Paths.get(root.fileName.toString(), "Editor/Unity")
+        def dotnetExec = Paths.get(root.fileName.toString(), "Editor/Data/NetCore/Sdk-2.2.107/dotnet")
+        Files.createDirectories(root)
+        Files.createDirectories(monoDir)
+        Files.createDirectories(executable.parent)
+        Files.createDirectories(dotnetExec.parent)
+        executable.toFile().createNewFile()
+        dotnetExec.toFile().createNewFile()
+        return [unityRoot: root.toFile(),
+                unityExecutable: executable.toFile(),
+                dotnetExecutable: dotnetExec.toFile(),
+                unityMonoFramework: monoDir.toFile()]
+    }
+
+    def deleteFolder(File folder) {
+        Files.walk(folder.toPath()).
+                sorted(Comparator.reverseOrder()).map{it.toFile()}.forEach{it.delete()};
+    }
+
+}


### PR DESCRIPTION
## Description
Created properties for key executables/folders inside unity folder structure. As unity folder structure differs by OS, we try first to find the root folder by name, and if this fails, we just go up the file tree a bunch of times hoping to hit the right directory. Then, from this root directory, we try to find the dotnet executable and mono framework folder. All of these can be overwritten by user by informing them explicitly on the extension.

All of these file tree-related operations are on the UnityFileTree class.

## Changes
* ![ADD] Added unityRoot property to extension
* ![ADD] Added unityDotnet property to extension
* ![ADD] Added unityMonoFramework property to extension

[NEW]:https://atlas-resources.wooga.com/icons/icon_new.svg "New"
[ADD]:http://resources.atlas.wooga.com/icons/icon_add.svg "Add"
[IMPROVE]:http://resources.atlas.wooga.com/icons/icon_improve.svg "IMPROVE"
[CHANGE]:http://resources.atlas.wooga.com/icons/icon_change.svg "Change"
[FIX]:http://resources.atlas.wooga.com/icons/icon_fix.svg "Fix"
[UPDATE]:http://resources.atlas.wooga.com/icons/icon_update.svg "Update"

[BREAK]:http://resources.atlas.wooga.com/icons/icon_break.svg "Remove"
[REMOVE]:http://resources.atlas.wooga.com/icons/icon_remove.svg "Remove"
[IOS]:http://resources.atlas.wooga.com/icons/icon_iOS.svg "iOS"
[ANDROID]:http://resources.atlas.wooga.com/icons/icon_android.svg "Android"
[WEBGL]:http://resources.atlas.wooga.com/icons/icon_webGL.svg "Web:GL"
