### PR TITLE
FIx: Coverage version floor comparison

### DIFF
--- a/src/main/groovy/wooga/gradle/unity/tasks/Test.groovy
+++ b/src/main/groovy/wooga/gradle/unity/tasks/Test.groovy
@@ -65,7 +65,7 @@ abstract class Test extends UnityTask implements UnityTestSpec {
                 throw new StopExecutionException("PlayMode tests not activated for this project. Please activate PlayMode tests first")
             }
 
-            if(unityVersion.majorVersion >= 2018 && unityVersion.minorVersion >= 3) {
+            if(unityVersion.majorVersion <= 2018 && unityVersion.minorVersion <= 3) {
                 enableCodeCoverage.convention(false)
             }
 


### PR DESCRIPTION
## Description

Turning on CodeCoverage reporting on Unity 2019 project

```groovy
unity {
    enableTestCodeCoverage = true
}
```

adds most code coverage parameters except `-enableCodeCoverage`.

resolves #117

## Changes
* ![FIX] version number comparison for enableCodeCoverage argument in the `Test` task .

[NEW]:https://atlas-resources.wooga.com/icons/icon_new.svg "New"
[ADD]:http://resources.atlas.wooga.com/icons/icon_add.svg "Add"
[IMPROVE]:http://resources.atlas.wooga.com/icons/icon_improve.svg "IMPROVE"
[CHANGE]:http://resources.atlas.wooga.com/icons/icon_change.svg "Change"
[FIX]:http://resources.atlas.wooga.com/icons/icon_fix.svg "Fix"
[UPDATE]:http://resources.atlas.wooga.com/icons/icon_update.svg "Update"

[BREAK]:http://resources.atlas.wooga.com/icons/icon_break.svg "Remove"
[REMOVE]:http://resources.atlas.wooga.com/icons/icon_remove.svg "Remove"
[IOS]:http://resources.atlas.wooga.com/icons/icon_iOS.svg "iOS"
[ANDROID]:http://resources.atlas.wooga.com/icons/icon_android.svg "Android"
[WEBGL]:http://resources.atlas.wooga.com/icons/icon_webGL.svg "Web:GL"
