### PR TITLE
Fix removed PropertyLookup API

### DIFF
--- a/src/main/groovy/wooga/gradle/unity/utils/PropertyLookup.groovy
+++ b/src/main/groovy/wooga/gradle/unity/utils/PropertyLookup.groovy
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2018-2020 Wooga GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package wooga.gradle.unity.utils
+
+import groovy.transform.InheritConstructors
+
+/**
+ * Utility object to help fetch properties from environment/gradle properties.
+ * <p>
+ * This implementation is deprecated.
+ * Please use {@code com.wooga.gradle.PropertyLookup} from {@code gradle-commons}
+ * @see https://github.com/wooga/gradle-commons
+ */
+@InheritConstructors
+@Deprecated
+class PropertyLookup extends com.wooga.gradle.PropertyLookup {
+}


### PR DESCRIPTION
## Description

The patch [#110] removed the class `wooga.gradle.unity.utils.PropertyLookup` in favor of `com.wooga.gradle.PropertyLookup` from the new library `com.wooga.gradle:gradle-commons`. This introduced a breaking API change as some downstream projects are using the utility class from this package. I added the class back but instead of adding a copy Iextended the new util from `gradle-commons`. I marked this class as deprecated to discurage the further usage.

## Changes

* ![FIX] revert `PropertyLookup` API with a standin class

[NEW]:https://atlas-resources.wooga.com/icons/icon_new.svg "New"
[ADD]:http://resources.atlas.wooga.com/icons/icon_add.svg "Add"
[IMPROVE]:http://resources.atlas.wooga.com/icons/icon_improve.svg "IMPROVE"
[CHANGE]:http://resources.atlas.wooga.com/icons/icon_change.svg "Change"
[FIX]:http://resources.atlas.wooga.com/icons/icon_fix.svg "Fix"
[UPDATE]:http://resources.atlas.wooga.com/icons/icon_update.svg "Update"

[BREAK]:http://resources.atlas.wooga.com/icons/icon_break.svg "Remove"
[REMOVE]:http://resources.atlas.wooga.com/icons/icon_remove.svg "Remove"
[IOS]:http://resources.atlas.wooga.com/icons/icon_iOS.svg "iOS"
[ANDROID]:http://resources.atlas.wooga.com/icons/icon_android.svg "Android"
[WEBGL]:http://resources.atlas.wooga.com/icons/icon_webGL.svg "Web:GL"
