### PR TITLE
Fix logToStdout when logPath is also set

### DIFF
--- a/src/integrationTest/groovy/wooga/gradle/unity/UnityIntegrationSpec.groovy
+++ b/src/integrationTest/groovy/wooga/gradle/unity/UnityIntegrationSpec.groovy
@@ -241,4 +241,12 @@ abstract class UnityIntegrationSpec extends IntegrationSpec {
         """.stripIndent()
         buildFile << builder.toString()
     }
+
+    /**
+     * Sets the unity version parsed by the plugin
+     * @param version
+     */
+    void setUnityTestVersion(String version) {
+        createFile("gradle.properties") << "defaultUnityTestVersion=${version}"
+    }
 }

--- a/src/main/groovy/wooga/gradle/unity/UnityTask.groovy
+++ b/src/main/groovy/wooga/gradle/unity/UnityTask.groovy
@@ -104,7 +104,7 @@ abstract class UnityTask extends DefaultTask
     }
 
     @Override
-    String fetchLogFilePath() {
+    String resolveLogFilePath() {
         def unityVersion = getUnityVersion()
 
         // In Unity 2019 or greater, we need to pass this to properly redirect stdout
@@ -113,7 +113,10 @@ abstract class UnityTask extends DefaultTask
             return "-"
         }
 
-        if (unityLogFile.present) {
+        // If there's a provided log file path
+        // AND we don't want to log to std out
+        if (unityLogFile.present
+                && !(logToStdout.present && logToStdout.get())) {
             FileUtils.ensureFile(unityLogFile)
             return unityLogFile.get().asFile.path
         }

--- a/src/main/groovy/wooga/gradle/unity/traits/UnityCommandLineSpec.groovy
+++ b/src/main/groovy/wooga/gradle/unity/traits/UnityCommandLineSpec.groovy
@@ -16,7 +16,7 @@
 
 package wooga.gradle.unity.traits
 
-import org.gradle.api.file.Directory
+
 import org.gradle.api.model.ObjectFactory
 import org.gradle.api.provider.Property
 import org.gradle.api.provider.Provider
@@ -180,12 +180,12 @@ trait UnityCommandLineSpec extends UnitySpec {
             case UnityCommandLineOption.buildTarget:
                 return buildTarget.get()
             case UnityCommandLineOption.logFile:
-                return fetchLogFilePath()
+                return resolveLogFilePath()
         }
     }
 
     // TODO: Refactor this out
-    String fetchLogFilePath() {
+    String resolveLogFilePath() {
         null
     }
 


### PR DESCRIPTION
## Description

When loggin both to stdout and to a file the parameter for the `-logFile` flag must be set to `-` 
not the filepath. The internal logic will read the stdout and both print it to stdout and 
to the provided file.

resolves #120 

## Changes
* ![FIX] UnityTask: -logFile being set when logToStdout was true

[NEW]:https://atlas-resources.wooga.com/icons/icon_new.svg "New"
[ADD]:http://resources.atlas.wooga.com/icons/icon_add.svg "Add"
[IMPROVE]:http://resources.atlas.wooga.com/icons/icon_improve.svg "IMPROVE"
[CHANGE]:http://resources.atlas.wooga.com/icons/icon_change.svg "Change"
[FIX]:http://resources.atlas.wooga.com/icons/icon_fix.svg "Fix"
[UPDATE]:http://resources.atlas.wooga.com/icons/icon_update.svg "Update"

[BREAK]:http://resources.atlas.wooga.com/icons/icon_break.svg "Remove"
[REMOVE]:http://resources.atlas.wooga.com/icons/icon_remove.svg "Remove"
[IOS]:http://resources.atlas.wooga.com/icons/icon_iOS.svg "iOS"
[ANDROID]:http://resources.atlas.wooga.com/icons/icon_android.svg "Android"
[WEBGL]:http://resources.atlas.wooga.com/icons/icon_webGL.svg "Web:GL"
