### PR TITLE
Add missing internal annotations

### DIFF
--- a/src/main/groovy/wooga/gradle/unity/traits/UnitySpec.groovy
+++ b/src/main/groovy/wooga/gradle/unity/traits/UnitySpec.groovy
@@ -79,6 +79,7 @@ trait UnitySpec extends UnityBaseSpec {
     /**
      * @return The path to the Unity root directory
      */
+    @Internal
     Provider<Directory> getUnityRootDir() {
         return layout.dir(getUnityFileTree().map({it.unityRoot}.memoize()))
     }
@@ -86,6 +87,7 @@ trait UnitySpec extends UnityBaseSpec {
     /**
      * @return The path to Unity .NET Core dotnet executable
      */
+    @Internal
     Provider<RegularFile> getDotnetExecutable() {
         return layout.file(getUnityFileTree().map({it.dotnetExecutable}.memoize()))
     }
@@ -93,6 +95,7 @@ trait UnitySpec extends UnityBaseSpec {
     /**
      * @return The path to the Unity mono framework directory (MonoBleedingEdge)
      */
+    @Internal
     Provider<Directory> getMonoFrameworkDir() {
         return layout.dir(getUnityFileTree().map({it.unityMonoFramework}.memoize()))
     }


### PR DESCRIPTION
## Description

The newer UnitySpec properties were missing @Internal annotations.

## Changes
* ![UPDATE] UnitySpec

[NEW]:https://atlas-resources.wooga.com/icons/icon_new.svg "New"
[ADD]:http://resources.atlas.wooga.com/icons/icon_add.svg "Add"
[IMPROVE]:http://resources.atlas.wooga.com/icons/icon_improve.svg "IMPROVE"
[CHANGE]:http://resources.atlas.wooga.com/icons/icon_change.svg "Change"
[FIX]:http://resources.atlas.wooga.com/icons/icon_fix.svg "Fix"
[UPDATE]:http://resources.atlas.wooga.com/icons/icon_update.svg "Update"

[BREAK]:http://resources.atlas.wooga.com/icons/icon_break.svg "Remove"
[REMOVE]:http://resources.atlas.wooga.com/icons/icon_remove.svg "Remove"
[IOS]:http://resources.atlas.wooga.com/icons/icon_iOS.svg "iOS"
[ANDROID]:http://resources.atlas.wooga.com/icons/icon_android.svg "Android"
[WEBGL]:http://resources.atlas.wooga.com/icons/icon_webGL.svg "Web:GL"
