### PR TITLE
Fix PlayMode test tasks are executed as EditMode

### DIFF
--- a/src/integrationTest/groovy/wooga/gradle/unity/tasks/TestTaskIntegrationSpec.groovy
+++ b/src/integrationTest/groovy/wooga/gradle/unity/tasks/TestTaskIntegrationSpec.groovy
@@ -217,6 +217,10 @@ class TestTaskIntegrationSpec extends UnityTaskIntegrationSpec<Test> {
             enableTestCodeCoverage = ${enableTestCodeCoverage}
         }
         """
+
+        and: "a mocked unity project with enabled playmode tests"
+        setProjectSettingsFile(ProjectSettingsFile.TEMPLATE_CONTENT_ENABLED)
+
         when:
         ExecutionResult result = unityVersion?
                 runTasksSuccessfully("test", "-PdefaultUnityTestVersion=${unityVersion}") :

--- a/src/integrationTest/groovy/wooga/gradle/unity/tasks/TestTaskIntegrationSpec.groovy
+++ b/src/integrationTest/groovy/wooga/gradle/unity/tasks/TestTaskIntegrationSpec.groovy
@@ -256,6 +256,10 @@ class TestTaskIntegrationSpec extends UnityTaskIntegrationSpec<Test> {
             enableTestCodeCoverage.set(false)
         }
         """
+        
+        and: "a mocked unity project with enabled playmode tests"
+        setProjectSettingsFile(ProjectSettingsFile.TEMPLATE_CONTENT_ENABLED)
+
         when:
         def result = runTasksSuccessfully("test")
 

--- a/src/main/groovy/wooga/gradle/unity/UnityPlugin.groovy
+++ b/src/main/groovy/wooga/gradle/unity/UnityPlugin.groovy
@@ -189,7 +189,7 @@ class UnityPlugin implements Plugin<Project> {
             extension.getTestBuildTargets(project).each { target ->
                 def suffix = target.toString().capitalize()
                 createTestTask(TestPlatform.editmode, project, Tasks.testEditMode.toString() + suffix, target)
-                createTestTask(TestPlatform.editmode, project, Tasks.testPlayMode.toString() + suffix, target)
+                createTestTask(TestPlatform.playmode, project, Tasks.testPlayMode.toString() + suffix, target)
             }
         }
 


### PR DESCRIPTION
 ## Description

During PP UBS integration we noticed that their build executes EditMode tests twice and ignores the PlayMode tests.
There was a typo introduced in 2.x.

## Changes
* ![FIX] PlayMode test tasks are executed as EditMode

[NEW]:https://atlas-resources.wooga.com/icons/icon_new.svg "New"
[ADD]:http://resources.atlas.wooga.com/icons/icon_add.svg "Add"
[IMPROVE]:http://resources.atlas.wooga.com/icons/icon_improve.svg "IMPROVE"
[CHANGE]:http://resources.atlas.wooga.com/icons/icon_change.svg "Change"
[FIX]:http://resources.atlas.wooga.com/icons/icon_fix.svg "Fix"
[UPDATE]:http://resources.atlas.wooga.com/icons/icon_update.svg "Update"

[BREAK]:http://resources.atlas.wooga.com/icons/icon_break.svg "Remove"
[REMOVE]:http://resources.atlas.wooga.com/icons/icon_remove.svg "Remove"
[IOS]:http://resources.atlas.wooga.com/icons/icon_iOS.svg "iOS"
[ANDROID]:http://resources.atlas.wooga.com/icons/icon_android.svg "Android"
[WEBGL]:http://resources.atlas.wooga.com/icons/icon_webGL.svg "Web:GL"
