### PR TITLE
Pin version of com.wooga.gradle:gradle-commons [ATLAS-268]

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -42,7 +42,7 @@ github {
 
 dependencies {
 
-    implementation 'com.wooga.gradle:gradle-commons:[0, 1)'
+    implementation 'com.wooga.gradle:gradle-commons:0.1.0'
     implementation 'org.apache.maven:maven-artifact:3.8.2'
     implementation "org.yaml:snakeyaml:1.28"
     implementation 'net.wooga:unity-version-manager-jni:[1,2)'


### PR DESCRIPTION
## Description

The 0. version range should never be declared with a range since any new minor release can contain breaking changes. We need to pin to a compatible version and update manually or through use of dependabot.

## Changes

* ![FIX] pin unstable version of `com.wooga.gradle:gradle-commons`


[NEW]:https://atlas-resources.wooga.com/icons/icon_new.svg "New"
[ADD]:http://resources.atlas.wooga.com/icons/icon_add.svg "Add"
[IMPROVE]:http://resources.atlas.wooga.com/icons/icon_improve.svg "IMPROVE"
[CHANGE]:http://resources.atlas.wooga.com/icons/icon_change.svg "Change"
[FIX]:http://resources.atlas.wooga.com/icons/icon_fix.svg "Fix"
[UPDATE]:http://resources.atlas.wooga.com/icons/icon_update.svg "Update"

[BREAK]:http://resources.atlas.wooga.com/icons/icon_break.svg "Remove"
[REMOVE]:http://resources.atlas.wooga.com/icons/icon_remove.svg "Remove"
[IOS]:http://resources.atlas.wooga.com/icons/icon_iOS.svg "iOS"
[ANDROID]:http://resources.atlas.wooga.com/icons/icon_android.svg "Android"
[WEBGL]:http://resources.atlas.wooga.com/icons/icon_webGL.svg "Web:GL"
