### PR TITLE
Add basic UPM package install logic

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -51,7 +51,7 @@ dependencies {
         exclude module: 'logback-classic'
     }
 
-    testImplementation("com.wooga.spock.extensions:spock-unity-version-manager-extension:0.1.0") {
+    testImplementation("com.wooga.spock.extensions:spock-unity-version-manager-extension:0.2.0") {
         exclude module: 'groovy-all'
     }
 

--- a/src/integrationTest/groovy/wooga/gradle/unity/UnityPluginIntegrationSpec.groovy
+++ b/src/integrationTest/groovy/wooga/gradle/unity/UnityPluginIntegrationSpec.groovy
@@ -196,9 +196,9 @@ class UnityPluginIntegrationSpec extends UnityIntegrationSpec {
         "enableTestCodeCoverage"   | "setEnableTestCodeCoverage"  | true                      | _                                                               | Boolean                 | PropertyLocation.script
         "enableTestCodeCoverage"   | "setEnableTestCodeCoverage"  | true                      | _                                                               | "Provider<Boolean>"     | PropertyLocation.script
 
-        "upmPackages"              | "setUpmPackages"             | _                         | [:]                                                            | _                       | PropertyLocation.none
-        "upmPackages"              | "setUpmPackages"             | ["unity.package": "ver"]  | ["unity.package": "ver"]                                                               | Map                     | PropertyLocation.script
-        "upmPackages"              | "upmPackages.set"            | ["unity.package": "ver"]  | ["unity.package": "ver"]                                                               | Map                     | PropertyLocation.script
+        "upmPackages"              | "setUpmPackages"             | _                         | [:]                                                             | _                       | PropertyLocation.none
+        "upmPackages"              | "setUpmPackages"             | ["unity.package": "ver"]  | ["unity.package": "ver"]                                        | Map                     | PropertyLocation.script
+        "upmPackages"              | "upmPackages.set"            | ["unity.package": "ver"]  | ["unity.package": "ver"]                                        | Map                     | PropertyLocation.script
 
         value = (type != _) ? wrapValueBasedOnType(rawValue, type) : rawValue
         providedValue = (location == PropertyLocation.script) ? type : value
@@ -342,6 +342,31 @@ class UnityPluginIntegrationSpec extends UnityIntegrationSpec {
 
         then:
         result.wasExecuted("generateSolution")
+    }
+
+    @Unroll
+    def "runs addUPMPackages task if there are packages to add"() {
+        given:
+        buildFile << """
+            unity {
+                enableTestCodeCoverage = ${testCoverageEnabled}
+                upmPackages = ${wrapValueBasedOnType(packagesToInstall, Map)}
+            }
+        """
+        when:
+        def result = runTasks("test")
+
+        then:
+        shouldRun ?
+                result.wasExecuted("addUPMPackages") :
+                result.standardOutput.contains("Task :addUPMPackages SKIPPED")
+
+        where:
+        testCoverageEnabled | packagesToInstall  | shouldRun
+        false               | [:]                | false
+        false               | ["package": "ver"] | true
+        true                | [:]                | true
+        true                | ["package": "ver"] | true
     }
 
 }

--- a/src/integrationTest/groovy/wooga/gradle/unity/UnityPluginIntegrationSpec.groovy
+++ b/src/integrationTest/groovy/wooga/gradle/unity/UnityPluginIntegrationSpec.groovy
@@ -168,7 +168,7 @@ class UnityPluginIntegrationSpec extends UnityIntegrationSpec {
         def result = runTasksSuccessfully(query.taskName)
 
         then:
-        query.matches(result.standardOutput, testValue)
+        query.matches(result, testValue)
 
         where:
         property                   | method                       | rawValue                  | expectedValue                                                   | type                    | location
@@ -239,7 +239,7 @@ class UnityPluginIntegrationSpec extends UnityIntegrationSpec {
         def result = runTasks(query.taskName)
 
         then:
-        query.matches(result.standardOutput, "${path.path}")
+        query.matches(result, "${path.path}")
 
         where:
         property     | expectedPath

--- a/src/integrationTest/groovy/wooga/gradle/unity/UnityPluginIntegrationSpec.groovy
+++ b/src/integrationTest/groovy/wooga/gradle/unity/UnityPluginIntegrationSpec.groovy
@@ -107,7 +107,8 @@ class UnityPluginIntegrationSpec extends UnityIntegrationSpec {
         def result = runTasksSuccessfully("Custom")
 
         then:
-        result.standardOutput.contains(UnityCommandLineOption.batchMode.flag) == expectBatchModeFlag
+        def taskStdOut = result.standardOutput.substring(result.standardOutput.indexOf("Task :Custom"))
+        taskStdOut.contains(UnityCommandLineOption.batchMode.flag) == expectBatchModeFlag
 
         where:
         testPlatform | useBatchMode | location                     | expectBatchModeFlag
@@ -167,7 +168,7 @@ class UnityPluginIntegrationSpec extends UnityIntegrationSpec {
         def result = runTasksSuccessfully(query.taskName)
 
         then:
-        query.matches(result, testValue)
+        query.matches(result.standardOutput, testValue)
 
         where:
         property                   | method                       | rawValue                  | expectedValue                                                   | type                    | location
@@ -189,10 +190,15 @@ class UnityPluginIntegrationSpec extends UnityIntegrationSpec {
         "assetsDir"                | _                            | _                         | osPath("#projectDir#/Assets")                                   | "Provider<Directory>"   | PropertyLocation.none
         "logsDir"                  | _                            | _                         | osPath("#projectDir#/build/logs")                               | "Provider<Directory>"   | PropertyLocation.none
         "reportsDir"               | _                            | _                         | osPath("#projectDir#/build/reports")                            | "Provider<Directory>"   | PropertyLocation.none
+
         "enableTestCodeCoverage"   | _                            | _                         | false                                                           | Boolean                 | PropertyLocation.none
         "enableTestCodeCoverage"   | "enableTestCodeCoverage.set" | true                      | _                                                               | "Provider<Boolean>"     | PropertyLocation.script
         "enableTestCodeCoverage"   | "setEnableTestCodeCoverage"  | true                      | _                                                               | Boolean                 | PropertyLocation.script
         "enableTestCodeCoverage"   | "setEnableTestCodeCoverage"  | true                      | _                                                               | "Provider<Boolean>"     | PropertyLocation.script
+
+        "upmPackages"              | "setUpmPackages"             | _                         | [:]                                                            | _                       | PropertyLocation.none
+        "upmPackages"              | "setUpmPackages"             | ["unity.package": "ver"]  | ["unity.package": "ver"]                                                               | Map                     | PropertyLocation.script
+        "upmPackages"              | "upmPackages.set"            | ["unity.package": "ver"]  | ["unity.package": "ver"]                                                               | Map                     | PropertyLocation.script
 
         value = (type != _) ? wrapValueBasedOnType(rawValue, type) : rawValue
         providedValue = (location == PropertyLocation.script) ? type : value
@@ -233,7 +239,7 @@ class UnityPluginIntegrationSpec extends UnityIntegrationSpec {
         def result = runTasks(query.taskName)
 
         then:
-        query.matches(result, "${path.path}")
+        query.matches(result.standardOutput, "${path.path}")
 
         where:
         property     | expectedPath
@@ -328,6 +334,7 @@ class UnityPluginIntegrationSpec extends UnityIntegrationSpec {
         result.wasExecuted("activateUnity")
     }
 
+
     @UnityPluginTestOptions(forceMockTaskRun = false, disableAutoActivateAndLicense = false)
     def "runs generateSolution task"() {
         when:
@@ -336,4 +343,5 @@ class UnityPluginIntegrationSpec extends UnityIntegrationSpec {
         then:
         result.wasExecuted("generateSolution")
     }
+
 }

--- a/src/integrationTest/groovy/wooga/gradle/unity/UnityTaskIntegrationSpec.groovy
+++ b/src/integrationTest/groovy/wooga/gradle/unity/UnityTaskIntegrationSpec.groovy
@@ -17,7 +17,7 @@
 
 package wooga.gradle.unity
 
-
+import groovy.json.JsonOutput
 import org.gradle.api.logging.LogLevel
 import spock.lang.IgnoreIf
 import spock.lang.Unroll
@@ -71,8 +71,10 @@ abstract class UnityTaskIntegrationSpec<T extends UnityTask> extends UnityIntegr
 
         then:
         result.wasExecuted(subjectUnderTestName)
-        result.standardOutput.contains("Starting process 'command '")
-        value == result.standardOutput.contains(" $expectedCommandlineSwitch")
+        def taskLogBeginIndex = result.standardOutput.indexOf("Task :${subjectUnderTestName}")
+        def stdOut = result.standardOutput.substring(taskLogBeginIndex)
+        stdOut.contains("Starting process 'command '")
+        value == stdOut.contains(" $expectedCommandlineSwitch")
 
         where:
         [testCase, useSetter, value] <<
@@ -103,9 +105,10 @@ abstract class UnityTaskIntegrationSpec<T extends UnityTask> extends UnityIntegr
 
         then:
         result.wasExecuted(subjectUnderTestName)
-        result.standardOutput.contains("Starting process 'command '")
-        value == result.standardOutput.contains(" $expectedCommandlineSwitch")
-        query.matches(result, value)
+        def taskLogBeginIndex = result.standardOutput.indexOf("Task :${subjectUnderTestName}")
+        def stdOut = result.standardOutput.substring(taskLogBeginIndex)
+        stdOut.contains("Starting process 'command '")
+        query.matches(result.standardOutput, value)
 
         where:
         [testCase, useGetter, value] <<
@@ -142,9 +145,11 @@ abstract class UnityTaskIntegrationSpec<T extends UnityTask> extends UnityIntegr
 
         then:
         result.wasExecuted(subjectUnderTestName)
-        result.standardOutput.contains("Starting process 'command '")
+        def taskLogBeginIndex = result.standardOutput.indexOf("Task :${subjectUnderTestName}")
+        def stdOut = result.standardOutput.substring(taskLogBeginIndex)
+        stdOut.contains("Starting process 'command '")
         def shouldContain = value != ""
-        shouldContain == result.standardOutput.contains(" $expectedCommandlineSwitch")
+        shouldContain == stdOut.contains(" $expectedCommandlineSwitch")
 
         where:
         [testCase, useSetter, value] <<
@@ -179,10 +184,12 @@ abstract class UnityTaskIntegrationSpec<T extends UnityTask> extends UnityIntegr
 
         then:
         result.wasExecuted(subjectUnderTestName)
-        result.standardOutput.contains("Starting process 'command '")
+        def taskLogBeginIndex = result.standardOutput.indexOf("Task :${subjectUnderTestName}")
+        def stdOut = result.standardOutput.substring(taskLogBeginIndex)
+        stdOut.contains("Starting process 'command '")
         def shouldContain = value != ""
-        shouldContain == result.standardOutput.contains(" $expectedCommandlineSwitch")
-        query.matches(result, value)
+        shouldContain == stdOut.contains(" $expectedCommandlineSwitch")
+        query.matches(stdOut, value)
 
         where:
         [testCase, useSetter, value] <<
@@ -222,7 +229,7 @@ abstract class UnityTaskIntegrationSpec<T extends UnityTask> extends UnityIntegr
         def result = runTasksSuccessfully(query.taskName)
 
         then:
-        query.matches(result, expectedValue)
+        query.matches(result.standardOutput, expectedValue)
 
         where:
         method                    | rawValue         | type                      | append | expectedValue
@@ -280,7 +287,7 @@ abstract class UnityTaskIntegrationSpec<T extends UnityTask> extends UnityIntegr
         then:
         result.wasExecuted(subjectUnderTestName)
         def resultPath = new File(projectDir, "/build/logs/${path}").getPath()
-        query.matches(result, resultPath)
+        query.matches(result.standardOutput, resultPath)
 
         where:
         rawValue     | useSetter | path
@@ -393,7 +400,9 @@ abstract class UnityTaskIntegrationSpec<T extends UnityTask> extends UnityIntegr
         def result = runTasks(subjectUnderTestName)
 
         then:
-        !result.standardOutput.contains(mockUnityStartupMessage)
+        def taskLogBeginIndex = result.standardOutput.indexOf("Task :${subjectUnderTestName}")
+        def stdOut = result.standardOutput.substring(taskLogBeginIndex)
+        !stdOut.contains(mockUnityStartupMessage)
 
         when:
         appendToSubjectTask("""
@@ -402,7 +411,8 @@ abstract class UnityTaskIntegrationSpec<T extends UnityTask> extends UnityIntegr
         result = runTasks(subjectUnderTestName)
 
         then:
-        result.standardOutput.contains(mockUnityStartupMessage)
+        def taskBeginIndex = result.standardOutput.indexOf("Task :${subjectUnderTestName}")
+        result.standardOutput.substring(taskBeginIndex).contains(mockUnityStartupMessage)
     }
 
     def "redirects unity log to stdout and custom logfile if provided"() {
@@ -422,7 +432,7 @@ abstract class UnityTaskIntegrationSpec<T extends UnityTask> extends UnityIntegr
         then:
         result.standardOutput.contains(mockUnityStartupMessage)
         logFile.text.contains(mockUnityStartupMessage)
-        !query.matches(result, logFile.path)
+        !query.matches(result.standardOutput, logFile.path)
     }
 
     @Unroll

--- a/src/integrationTest/groovy/wooga/gradle/unity/tasks/AddUPMPackagesTaskIntegrationSpec.groovy
+++ b/src/integrationTest/groovy/wooga/gradle/unity/tasks/AddUPMPackagesTaskIntegrationSpec.groovy
@@ -3,32 +3,72 @@ package wooga.gradle.unity.tasks
 import com.wooga.spock.extensions.unity.UnityPathResolution
 import com.wooga.spock.extensions.unity.UnityPluginTestOptions
 import com.wooga.spock.extensions.uvm.UnityInstallation
+import groovy.json.JsonOutput
+import groovy.json.JsonSlurper
 import net.wooga.uvm.Installation
 import spock.lang.Requires
 import wooga.gradle.unity.UnityTaskIntegrationSpec
 
 class AddUPMPackagesTaskIntegrationSpec extends UnityTaskIntegrationSpec<AddUPMPackages> {
 
+
     @Requires({ os.macOs })
     @UnityPluginTestOptions(unityPath = UnityPathResolution.Default)
-    @UnityInstallation(version = "2019.4.24f1", cleanup = false)
-    def "adds Packages"(Installation unity) {
+    @UnityInstallation(version = "2019.4.19f1", cleanup = false)
+    def "creates unity manifest and adds package to it when running AddUPMTask task"(Installation unity) {
         given: "an unity3D project"
-        def project_path = "build/test_project"
+        def projectPath = "build/test_project"
         environmentVariables.set("UNITY_PATH", unity.getExecutable().getPath())
+
+
+        //Test using the extension
+        and: "a setup AddUPMPackageTask"
         appendToSubjectTask("""
-                createProject = "${project_path}"
+                createProject = "${projectPath}"
                 buildTarget = "Android"
-                manifestPath.set("${project_path}/Packages/manifest.json")
-                upmPackages.put("com.unity.testtools.codecoverage", "1.1.0")
-            """.stripIndent())
+                upmPackages.put("com.unity.testtools.codecoverage", "1.1.0") 
+                upmPackages.put("com.unity.package", "anyString")
+            """.stripIndent()
+        )
 
-        when:"add UPM packages"
-        def result = runTasksSuccessfully(subjectUnderTestName)
+        when: "add UPM packages"
+        runTasksSuccessfully(subjectUnderTestName)
 
-        then:"solution file is generated"
-        result.standardOutput.contains("Starting process 'command '${unity.getExecutable().getPath()}'")
-        fileExists(project_path)
-        fileExists(project_path, "Packages/manifest.json")
+        then: "manifest file is generated"
+        def manifestFile = new File(new File(projectDir, projectPath), "Packages/manifest.json")
+        manifestFile.exists()
+        and: "manifest file contains added packages"
+        def dependencies = new JsonSlurper().parse(manifestFile)["dependencies"]
+        dependencies["com.unity.testtools.codecoverage"] == "1.1.0"
+        dependencies["com.unity.package"] == "anyString"
+    }
+
+    def "adds package to existing unity manifest file when running AddUPMTask task"() {
+        given: "an unity3D project"
+        def manifestPath = "build/test_project/Packages/custom/manifest.json"
+        def manifestFile = new File(projectDir, manifestPath)
+        manifestFile.parentFile.mkdirs()
+        manifestFile.createNewFile()
+
+        and: "an existing manifest file"
+        def packages = ["com.unity.testtools.codecoverage": "1.1.0"]
+        manifestFile << JsonOutput.toJson(["dependencies": packages])
+
+        and: "a setup AddUPMPackageTask"
+        appendToSubjectTask("""
+                buildTarget = "Android"
+                manifestPath = new File("build/test_project/Packages/custom/manifest.json")
+                upmPackages.put("com.unity.package", "anyString")
+            """.stripIndent()
+        )
+
+        when: "add UPM packages"
+        runTasksSuccessfully(subjectUnderTestName)
+
+        then: "manifest file contains added packages"
+        def dependencies = new JsonSlurper().parse(manifestFile)["dependencies"]
+        dependencies["com.unity.testtools.codecoverage"] == "1.1.0"
+        dependencies["com.unity.package"] == "anyString"
     }
 }
+

--- a/src/integrationTest/groovy/wooga/gradle/unity/tasks/AddUPMPackagesTaskIntegrationSpec.groovy
+++ b/src/integrationTest/groovy/wooga/gradle/unity/tasks/AddUPMPackagesTaskIntegrationSpec.groovy
@@ -11,7 +11,7 @@ class AddUPMPackagesTaskIntegrationSpec extends UnityTaskIntegrationSpec<AddUPMP
 
     @Requires({ os.macOs })
     @UnityPluginTestOptions(unityPath = UnityPathResolution.Default)
-    @UnityInstallation(version = "2019.4.24f1", cleanup = false, basePath = "/Applications/Unity/Hub/Editor")
+    @UnityInstallation(version = "2019.4.24f1", cleanup = false)
     def "adds Packages"(Installation unity) {
         given: "an unity3D project"
         def project_path = "build/test_project"

--- a/src/integrationTest/groovy/wooga/gradle/unity/tasks/AddUPMPackagesTaskIntegrationSpec.groovy
+++ b/src/integrationTest/groovy/wooga/gradle/unity/tasks/AddUPMPackagesTaskIntegrationSpec.groovy
@@ -1,0 +1,34 @@
+package wooga.gradle.unity.tasks
+
+import com.wooga.spock.extensions.unity.UnityPathResolution
+import com.wooga.spock.extensions.unity.UnityPluginTestOptions
+import com.wooga.spock.extensions.uvm.UnityInstallation
+import net.wooga.uvm.Installation
+import spock.lang.Requires
+import wooga.gradle.unity.UnityTaskIntegrationSpec
+
+class AddUPMPackagesTaskIntegrationSpec extends UnityTaskIntegrationSpec<AddUPMPackages> {
+
+    @Requires({ os.macOs })
+    @UnityPluginTestOptions(unityPath = UnityPathResolution.Default)
+    @UnityInstallation(version = "2019.4.24f1", cleanup = false, basePath = "/Applications/Unity/Hub/Editor")
+    def "adds Packages"(Installation unity) {
+        given: "an unity3D project"
+        def project_path = "build/test_project"
+        environmentVariables.set("UNITY_PATH", unity.getExecutable().getPath())
+        appendToSubjectTask("""
+                createProject = "${project_path}"
+                buildTarget = "Android"
+                manifestPath.set("${project_path}/Packages/manifest.json")
+                upmPackages.put("com.unity.testtools.codecoverage", "1.1.0")
+            """.stripIndent())
+
+        when:"add UPM packages"
+        def result = runTasksSuccessfully(subjectUnderTestName)
+
+        then:"solution file is generated"
+        result.standardOutput.contains("Starting process 'command '${unity.getExecutable().getPath()}'")
+        fileExists(project_path)
+        fileExists(project_path, "Packages/manifest.json")
+    }
+}

--- a/src/integrationTest/groovy/wooga/gradle/unity/tasks/AddUPMPackagesTaskIntegrationSpec.groovy
+++ b/src/integrationTest/groovy/wooga/gradle/unity/tasks/AddUPMPackagesTaskIntegrationSpec.groovy
@@ -25,6 +25,7 @@ class AddUPMPackagesTaskIntegrationSpec extends UnityTaskIntegrationSpec<AddUPMP
         and: "a setup AddUPMPackageTask"
         appendToSubjectTask("""
                 createProject = "${projectPath}"
+                manifestPath = new File("${projectPath}/Packages/manifest.json")
                 buildTarget = "Android"
                 upmPackages.put("com.unity.testtools.codecoverage", "1.1.0") 
                 upmPackages.put("com.unity.package", "anyString")

--- a/src/integrationTest/groovy/wooga/gradle/unity/testutils/GradleRunResult.groovy
+++ b/src/integrationTest/groovy/wooga/gradle/unity/testutils/GradleRunResult.groovy
@@ -6,6 +6,19 @@ class GradleRunResult {
     private final ArrayList<String> args;
     private final Map<String, String> envs;
 
+    static String taskLog(String task, String stdOutput) {
+        if(!task.startsWith(":")) {
+            task = ":" + task
+        }
+        String taskString = "> Task ${task}"
+        int taskBeginIdx = stdOutput.indexOf(taskString) + taskString.length()
+        String taskTail = stdOutput.substring(taskBeginIdx)
+        int taskEndIdx = taskTail.indexOf("> Task")
+
+        def logs = taskEndIdx > 0? taskTail.substring(0, taskEndIdx) : taskTail
+        return taskString + logs
+    }
+
     GradleRunResult(String stdOutput) {
         this(null, stdOutput)
     }
@@ -30,15 +43,6 @@ class GradleRunResult {
         def argIndex = args.indexOf(key)
         def value = args[argIndex+1]
         return matcher(value)
-    }
-
-    private static String taskLog(String task, String stdOutput) {
-        String taskString = "> Task ${task}"
-        int taskBeginIdx = stdOutput.indexOf(taskString) + taskString.length()
-        String taskTail = stdOutput.substring(taskBeginIdx)
-        int taskEndIdx = taskTail.indexOf("> Task")
-        def logs = taskTail.substring(0, taskEndIdx)
-        return logs
     }
 
     private static ArrayList<String> loadArgs(String stdOutput) {

--- a/src/integrationTest/groovy/wooga/gradle/utils/PropertyQueryTaskWriter.groovy
+++ b/src/integrationTest/groovy/wooga/gradle/utils/PropertyQueryTaskWriter.groovy
@@ -65,8 +65,8 @@ class PropertyQueryTaskWriter extends BasePropertyQueryTaskWriter {
     /**
      * @return True if the property's toString() matches the given value
      */
-    Boolean matches(ExecutionResult result, Object value) {
-        result.standardOutput.contains("${path}${separator}${value}")
+    Boolean matches(String stdOut, Object value) {
+        stdOut.contains("${path}${separator}${value}")
     }
 }
 

--- a/src/integrationTest/groovy/wooga/gradle/utils/PropertyQueryTaskWriter.groovy
+++ b/src/integrationTest/groovy/wooga/gradle/utils/PropertyQueryTaskWriter.groovy
@@ -65,6 +65,13 @@ class PropertyQueryTaskWriter extends BasePropertyQueryTaskWriter {
     /**
      * @return True if the property's toString() matches the given value
      */
+    Boolean matches(ExecutionResult result, Object value) {
+        matches(result.standardOutput, value)
+    }
+
+    /**
+     * @return True if the property's toString() matches the given value
+     */
     Boolean matches(String stdOut, Object value) {
         stdOut.contains("${path}${separator}${value}")
     }

--- a/src/main/groovy/wooga/gradle/unity/UnityPlugin.groovy
+++ b/src/main/groovy/wooga/gradle/unity/UnityPlugin.groovy
@@ -348,10 +348,10 @@ class UnityPlugin implements Plugin<Project> {
             }
         })
 
-        project.tasks.withType(UnityTask).configureEach({ t ->
-            if (!Activate.isInstance(t) && !AddUPMPackages.isInstance(t)) {
-                t.dependsOn(addUPMPackagesTask)
-            }
-        })
+//        project.tasks.withType(UnityTask).configureEach({ t ->
+//            if (!Activate.isInstance(t) && !AddUPMPackages.isInstance(t)) {
+//                t.dependsOn(addUPMPackagesTask)
+//            }
+//        })
     }
 }

--- a/src/main/groovy/wooga/gradle/unity/UnityPlugin.groovy
+++ b/src/main/groovy/wooga/gradle/unity/UnityPlugin.groovy
@@ -337,9 +337,9 @@ class UnityPlugin implements Plugin<Project> {
             task.group = GROUP
             task.manifestPath.convention(manifestFile)
             task.upmPackages.putAll(extension.upmPackages)
-            if (extension.enableTestCodeCoverage.getOrElse(false)) {
-                task.upmPackages.put("com.unity.testtools.codecoverage", "1.1.0")
-            }
+            task.upmPackages.put("com.unity.testtools.codecoverage", extension.enableTestCodeCoverage.map({
+                it ? "1.1.0" : null
+            }))
         }
         project.tasks.withType(Test).configureEach {testTask ->
             testTask.dependsOn(addUPMPackagesTask)

--- a/src/main/groovy/wooga/gradle/unity/UnityPlugin.groovy
+++ b/src/main/groovy/wooga/gradle/unity/UnityPlugin.groovy
@@ -344,5 +344,11 @@ class UnityPlugin implements Plugin<Project> {
         project.tasks.withType(Test).configureEach {testTask ->
             testTask.dependsOn(addUPMPackagesTask)
         }
+        project.afterEvaluate {
+            addUPMPackagesTask.configure {task ->
+                def upmPackageCount = task.upmPackages.forUseAtConfigurationTime().getOrElse([:]).size()
+                task.onlyIf { upmPackageCount > 0 }
+            }
+        }
     }
 }

--- a/src/main/groovy/wooga/gradle/unity/UnityPlugin.groovy
+++ b/src/main/groovy/wooga/gradle/unity/UnityPlugin.groovy
@@ -154,7 +154,7 @@ class UnityPlugin implements Plugin<Project> {
             t.unityLogFile.convention(extension.logsDir.file(project.provider {
                 t.logCategory.get().isEmpty() ? "${t.name}.log" : "${t.logCategory.get()}/${t.name}.log"
             }))
-            t.environment.putAll(project.provider({System.getenv()}))
+            t.environment.putAll(project.provider({ System.getenv() }))
         }
     }
 
@@ -219,9 +219,9 @@ class UnityPlugin implements Plugin<Project> {
             t.reports.xml.outputLocation.convention(extension.reportsDir.file(t.name + "/" + t.name + "." + reports.xml.name))
             t.enableCodeCoverage.convention(extension.enableTestCodeCoverage)
             t.coverageResultsPath.convention(extension.enableTestCodeCoverage.map {
-                return it? extension.reportsDir.getOrElse(null)?.asFile?.absolutePath: null
+                return it ? extension.reportsDir.getOrElse(null)?.asFile?.absolutePath : null
             })
-            t.coverageOptions.convention(extension.enableTestCodeCoverage.map {it? "generateAdditionalMetrics" : null})
+            t.coverageOptions.convention(extension.enableTestCodeCoverage.map { it ? "generateAdditionalMetrics" : null })
             t.debugCodeOptimization.convention(extension.enableTestCodeCoverage) //needed from 2020.1 and on for coverage
         })
 
@@ -325,7 +325,7 @@ class UnityPlugin implements Plugin<Project> {
     }
 
     private static void addGenerateSolutionTask(Project project) {
-        project.tasks.register(Tasks.generateSolution.toString(), GenerateSolution) {task ->
+        project.tasks.register(Tasks.generateSolution.toString(), GenerateSolution) { task ->
             task.description = "Generates a synchronized solution file for the unity project"
             task.group = GROUP
         }
@@ -333,21 +333,22 @@ class UnityPlugin implements Plugin<Project> {
 
     private static void addAddUPMPackagesTask(Project project, final UnityPluginExtension extension) {
         def manifestFile = project.layout.projectDirectory.file("Packages/manifest.json")
-        def addUPMPackagesTask = project.tasks.register(Tasks.addUPMPackages.toString(), AddUPMPackages) {task ->
+        def addUPMPackagesTask = project.tasks.register(Tasks.addUPMPackages.toString(), AddUPMPackages) { task ->
             task.group = GROUP
             task.manifestPath.convention(manifestFile)
             task.upmPackages.putAll(extension.upmPackages)
-            task.upmPackages.put("com.unity.testtools.codecoverage", extension.enableTestCodeCoverage.map({
-                it ? "1.1.0" : null
-            }))
+            task.upmPackages.putAll(extension.enableTestCodeCoverage.map {
+                it? ["com.unity.testtools.codecoverage": "1.1.0"] : [:]
+            })
         }
-        project.tasks.withType(Test).configureEach {testTask ->
+        project.tasks.withType(Test).configureEach { testTask ->
             testTask.dependsOn(addUPMPackagesTask)
         }
-    addUPMPackagesTask.configure {task ->
-        task.onlyIf { 
-            def upmPackageCount = task.upmPackages.forUseAtConfigurationTime().getOrElse([:]).size()
-            upmPackageCount > 0 
+        addUPMPackagesTask.configure { task ->
+            task.onlyIf {
+                def upmPackageCount = task.upmPackages.forUseAtConfigurationTime().getOrElse([:]).size()
+                upmPackageCount > 0
+            }
         }
     }
 }

--- a/src/main/groovy/wooga/gradle/unity/UnityPlugin.groovy
+++ b/src/main/groovy/wooga/gradle/unity/UnityPlugin.groovy
@@ -344,11 +344,10 @@ class UnityPlugin implements Plugin<Project> {
         project.tasks.withType(Test).configureEach {testTask ->
             testTask.dependsOn(addUPMPackagesTask)
         }
-        project.afterEvaluate {
-            addUPMPackagesTask.configure {task ->
-                def upmPackageCount = task.upmPackages.forUseAtConfigurationTime().getOrElse([:]).size()
-                task.onlyIf { upmPackageCount > 0 }
-            }
+    addUPMPackagesTask.configure {task ->
+        task.onlyIf { 
+            def upmPackageCount = task.upmPackages.forUseAtConfigurationTime().getOrElse([:]).size()
+            upmPackageCount > 0 
         }
     }
 }

--- a/src/main/groovy/wooga/gradle/unity/UnityPluginExtension.groovy
+++ b/src/main/groovy/wooga/gradle/unity/UnityPluginExtension.groovy
@@ -21,6 +21,7 @@ package wooga.gradle.unity
 import org.gradle.api.Project
 import org.gradle.api.file.Directory
 import org.gradle.api.file.DirectoryProperty
+import org.gradle.api.provider.MapProperty
 import org.gradle.api.provider.Property
 import org.gradle.api.provider.Provider
 import org.gradle.api.tasks.Internal
@@ -256,4 +257,17 @@ trait UnityPluginExtension implements UnitySpec,
         targets
     }
 
+    private final MapProperty<String, String> upmPackages = objects.mapProperty(String, String)
+
+    /**
+     * @return The UPM packages to add
+     */
+    MapProperty<String, String> getUPMPackages() {
+        upmPackages
+    }
+
+    void setUPMPackage(MapProperty<String, String> upmPackages) {
+        upmPackages.clear()
+        upmPackages.putAll(upmPackages)
+    }
 }

--- a/src/main/groovy/wooga/gradle/unity/UnityPluginExtension.groovy
+++ b/src/main/groovy/wooga/gradle/unity/UnityPluginExtension.groovy
@@ -267,7 +267,6 @@ trait UnityPluginExtension implements UnitySpec,
     }
 
     void setUpmPackages(MapProperty<String, String> upmPackages) {
-        upmPackages.clear()
-        upmPackages.putAll(upmPackages)
+        upmPackages.set(upmPackages)
     }
 }

--- a/src/main/groovy/wooga/gradle/unity/UnityPluginExtension.groovy
+++ b/src/main/groovy/wooga/gradle/unity/UnityPluginExtension.groovy
@@ -262,11 +262,11 @@ trait UnityPluginExtension implements UnitySpec,
     /**
      * @return The UPM packages to add
      */
-    MapProperty<String, String> getUPMPackages() {
+    MapProperty<String, String> getUpmPackages() {
         upmPackages
     }
 
-    void setUPMPackage(MapProperty<String, String> upmPackages) {
+    void setUpmPackages(MapProperty<String, String> upmPackages) {
         upmPackages.clear()
         upmPackages.putAll(upmPackages)
     }

--- a/src/main/groovy/wooga/gradle/unity/tasks/AddUPMPackages.groovy
+++ b/src/main/groovy/wooga/gradle/unity/tasks/AddUPMPackages.groovy
@@ -37,6 +37,9 @@ class AddUPMPackages extends UnityTask implements UnityBaseSpec {
             } else {
                 project.logger.warn("manifest.json not found, skipping UPM packages install: ${upmPackages.get()}")
             }
+        } else {
+            project.logger.warn("this unity version (${unityVersion.majorVersion}.${unityVersion.minorVersion}) " +
+                    "does not support UPM packages, skipping")
         }
     }
 

--- a/src/main/groovy/wooga/gradle/unity/tasks/AddUPMPackages.groovy
+++ b/src/main/groovy/wooga/gradle/unity/tasks/AddUPMPackages.groovy
@@ -1,38 +1,69 @@
 package wooga.gradle.unity.tasks
 
+import org.gradle.api.file.RegularFile
+import org.gradle.api.file.RegularFileProperty
 import org.gradle.api.provider.MapProperty
-import org.gradle.api.provider.Property
 import groovy.json.JsonOutput
 import groovy.json.JsonSlurper
+import org.gradle.api.provider.Provider
+import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.Internal
+import org.gradle.api.tasks.Optional
 import org.gradle.process.ExecResult
 import wooga.gradle.unity.UnityTask
 import wooga.gradle.unity.traits.UnityBaseSpec
 
-import javax.inject.Inject
-
 class AddUPMPackages extends UnityTask implements UnityBaseSpec {
 
-    public Property<String> manifestPath = objects.property(String)
-    public MapProperty<String, String> upmPackages = objects.mapProperty(String, String)
+    final RegularFileProperty manifestPath = objects.fileProperty()
+    final MapProperty<String, String> upmPackages = objects.mapProperty(String, String)
 
-    @Inject
     AddUPMPackages() {
         description = "Adds UPM packages to Unity project"
-        quit = true
     }
 
     @Override
     protected void postExecute(ExecResult result) {
-        if(unityVersion.majorVersion > 2018 && unityVersion.minorVersion > 3) {
-            def manifestFile =  new File(project.projectDir, manifestPath.get())
-            def data = new JsonSlurper().parse(manifestFile)
-
-            upmPackages.get().each {
-                data.dependencies[it.key] = it.value
+        if(unityVersion.majorVersion > 2018 ||
+            (unityVersion.majorVersion == 2018 && unityVersion.minorVersion > 3)) {
+            def manifestFile = manifestPath.asFile.getOrNull()
+            if(manifestFile && manifestFile.exists()) {
+                def data = new JsonSlurper().parse(manifestFile)
+                upmPackages.get().each {
+                    data.dependencies[it.key] = it.value
+                }
+                def json = JsonOutput.prettyPrint(JsonOutput.toJson(data))
+                manifestFile.write(json)
+            } else {
+                project.logger.warn("manifest.json not found, skipping UPM packages install: ${upmPackages.get()}")
             }
-            def json = JsonOutput.prettyPrint(JsonOutput.toJson(data))
-            print(json)
-            manifestFile.write(json)
         }
+    }
+
+    @Internal
+    RegularFileProperty getManifestPath() {
+        return manifestPath
+    }
+
+    void setManifestPath(File manifestPath) {
+        this.manifestPath.set(manifestPath)
+    }
+
+    void setManifestPath(Provider<RegularFile> manifestPath) {
+        this.manifestPath.set(manifestPath)
+    }
+
+    @Input
+    @Optional
+    MapProperty<String, String> getUpmPackages() {
+        return upmPackages
+    }
+
+    void setUpmPackages(MapProperty<String, String> upmPackages) {
+        this.upmPackages.set(upmPackages)
+    }
+
+    void setUpmPackages(Map<String, String> upmPackages) {
+        this.upmPackages.set(upmPackages)
     }
 }

--- a/src/main/groovy/wooga/gradle/unity/tasks/AddUPMPackages.groovy
+++ b/src/main/groovy/wooga/gradle/unity/tasks/AddUPMPackages.groovy
@@ -1,0 +1,38 @@
+package wooga.gradle.unity.tasks
+
+import org.gradle.api.provider.MapProperty
+import org.gradle.api.provider.Property
+import groovy.json.JsonOutput
+import groovy.json.JsonSlurper
+import org.gradle.process.ExecResult
+import wooga.gradle.unity.UnityTask
+import wooga.gradle.unity.traits.UnityBaseSpec
+
+import javax.inject.Inject
+
+class AddUPMPackages extends UnityTask implements UnityBaseSpec {
+
+    public Property<String> manifestPath = objects.property(String)
+    public MapProperty<String, String> upmPackages = objects.mapProperty(String, String)
+
+    @Inject
+    AddUPMPackages() {
+        description = "Adds UPM packages to Unity project"
+        quit = true
+    }
+
+    @Override
+    protected void postExecute(ExecResult result) {
+        if(unityVersion.majorVersion > 2018 && unityVersion.minorVersion > 3) {
+            def manifestFile =  new File(project.projectDir, manifestPath.get())
+            def data = new JsonSlurper().parse(manifestFile)
+
+            upmPackages.get().each {
+                data.dependencies[it.key] = it.value
+            }
+            def json = JsonOutput.prettyPrint(JsonOutput.toJson(data))
+            print(json)
+            manifestFile.write(json)
+        }
+    }
+}

--- a/src/main/groovy/wooga/gradle/unity/tasks/GenerateSolution.groovy
+++ b/src/main/groovy/wooga/gradle/unity/tasks/GenerateSolution.groovy
@@ -6,6 +6,5 @@ class GenerateSolution extends UnityTask {
 
     GenerateSolution() {
         executeMethod = "UnityEditor.SyncVS.SyncSolution"
-        quit = true
     }
 }

--- a/src/test/groovy/wooga/gradle/unity/UnityPluginTest.groovy
+++ b/src/test/groovy/wooga/gradle/unity/UnityPluginTest.groovy
@@ -21,6 +21,8 @@ import nebula.test.ProjectSpec
 import org.gradle.api.DefaultTask
 import spock.lang.Unroll
 import wooga.gradle.unity.internal.DefaultUnityPluginExtension
+import wooga.gradle.unity.tasks.AddUPMPackages
+import wooga.gradle.unity.tasks.GenerateSolution
 
 class UnityPluginTest extends ProjectSpec {
 
@@ -53,10 +55,46 @@ class UnityPluginTest extends ProjectSpec {
         taskType.isInstance(task)
 
         where:
-        taskName                       | taskType
-        UnityPlugin.Tasks.test         | DefaultTask
-        UnityPlugin.Tasks.testEditMode | DefaultTask
-        UnityPlugin.Tasks.testPlayMode | DefaultTask
+        taskName                           | taskType
+        UnityPlugin.Tasks.test             | DefaultTask
+        UnityPlugin.Tasks.testEditMode     | DefaultTask
+        UnityPlugin.Tasks.testPlayMode     | DefaultTask
+        UnityPlugin.Tasks.generateSolution | GenerateSolution
+        UnityPlugin.Tasks.addUPMPackages   | AddUPMPackages
+    }
+
+    @Unroll
+    def "configures addUPMPackages task "() {
+        given: "project without applied atlas-unity plugin"
+        assert !project.plugins.hasPlugin(PLUGIN_NAME)
+
+        when: "applying atlas unity plugin"
+        project.plugins.apply(PLUGIN_NAME)
+        and: "configured unity extension"
+        project.extensions.unity.with {
+            upmPackages = extUPMPackages
+            enableTestCodeCoverage = coverageEnabled
+        }
+
+        then:
+        def task = project.tasks.findByName(UnityPlugin.Tasks.addUPMPackages.toString()) as AddUPMPackages
+        def packages = task.upmPackages.get()
+        task.manifestPath.present
+        task.manifestPath.get().asFile == new File(projectDir, "Packages/manifest.json")
+        packages.entrySet().containsAll(extUPMPackages.entrySet())
+        if(coverageEnabled) {
+            packages["com.unity.testtools.codecoverage"] == "1.1.0"
+            packages.size() == extUPMPackages.size() + 1
+        } else {
+            packages.size() == extUPMPackages.size()
+        }
+
+        where:
+        coverageEnabled | extUPMPackages
+        true            | [:]
+        false           | [:]
+        false           | ["unity.pkg": "ver", "otherpkg": "0.0.1"]
+        true            | ["unity.pkg": "ver", "otherpkg": "0.0.1"]
     }
 
 }

--- a/src/test/groovy/wooga/gradle/unity/UnityPluginTest.groovy
+++ b/src/test/groovy/wooga/gradle/unity/UnityPluginTest.groovy
@@ -19,6 +19,7 @@ package wooga.gradle.unity
 
 import nebula.test.ProjectSpec
 import org.gradle.api.DefaultTask
+import org.gradle.api.Task
 import spock.lang.Unroll
 import wooga.gradle.unity.internal.DefaultUnityPluginExtension
 import wooga.gradle.unity.tasks.AddUPMPackages
@@ -64,7 +65,7 @@ class UnityPluginTest extends ProjectSpec {
     }
 
     @Unroll
-    def "configures addUPMPackages task "() {
+    def "configures addUPMPackages task"() {
         given: "project without applied atlas-unity plugin"
         assert !project.plugins.hasPlugin(PLUGIN_NAME)
 
@@ -79,10 +80,12 @@ class UnityPluginTest extends ProjectSpec {
         then:
         def task = project.tasks.findByName(UnityPlugin.Tasks.addUPMPackages.toString()) as AddUPMPackages
         def packages = task.upmPackages.get()
+        and: "task has a manifest file"
         task.manifestPath.present
         task.manifestPath.get().asFile == new File(projectDir, "Packages/manifest.json")
+        and: "task contains expected packages"
         packages.entrySet().containsAll(extUPMPackages.entrySet())
-        if(coverageEnabled) {
+        if (coverageEnabled) {
             packages["com.unity.testtools.codecoverage"] == "1.1.0"
             packages.size() == extUPMPackages.size() + 1
         } else {


### PR DESCRIPTION
## Description
Added task for installing UPM packages, as well as interlinking it with the test task (as these packages may be necessary to build the project and run tests). Work here was done partially by me (Joaquim) and another part by Sebu. Packages for this task can be put into the task itself, or using the `upmPackages` extension property.

Some relevant test changes were needed as the old tests would pick up logs from all tasks that were being ran, not just from the task being tested. Usage right now is more akin to this, as `upmPackages` is a gradle `PropertyMap`.

```gradle
unity {
  upmPackages.with {
    put("package", "version")
  }
}
```

or

```gradle
unity {
  upmPackages.put("package", "version")
}
```

## Changes
* ![ADD] `AddUPMPackages` task


[NEW]:https://atlas-resources.wooga.com/icons/icon_new.svg "New"
[ADD]:http://resources.atlas.wooga.com/icons/icon_add.svg "Add"
[IMPROVE]:http://resources.atlas.wooga.com/icons/icon_improve.svg "IMPROVE"
[CHANGE]:http://resources.atlas.wooga.com/icons/icon_change.svg "Change"
[FIX]:http://resources.atlas.wooga.com/icons/icon_fix.svg "Fix"
[UPDATE]:http://resources.atlas.wooga.com/icons/icon_update.svg "Update"

[BREAK]:http://resources.atlas.wooga.com/icons/icon_break.svg "Remove"
[REMOVE]:http://resources.atlas.wooga.com/icons/icon_remove.svg "Remove"
[IOS]:http://resources.atlas.wooga.com/icons/icon_iOS.svg "iOS"
[ANDROID]:http://resources.atlas.wooga.com/icons/icon_android.svg "Android"
[WEBGL]:http://resources.atlas.wooga.com/icons/icon_webGL.svg "Web:GL"
