### PR TITLE
Test task up-to-date fix

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -16,7 +16,7 @@
  */
 
 plugins {
-    id 'net.wooga.plugins' version '2.2.2'
+    id 'net.wooga.plugins' version '2.2.3'
 }
 
 group 'net.wooga.gradle'

--- a/src/main/groovy/wooga/gradle/unity/UnityPlugin.groovy
+++ b/src/main/groovy/wooga/gradle/unity/UnityPlugin.groovy
@@ -21,6 +21,7 @@ package wooga.gradle.unity
 import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.gradle.api.Task
+import org.gradle.api.file.FileTreeElement
 import org.gradle.api.plugins.BasePlugin
 import org.gradle.api.plugins.ReportingBasePlugin
 import org.gradle.api.provider.Provider
@@ -28,6 +29,7 @@ import org.gradle.api.reporting.ReportingExtension
 import org.gradle.api.specs.Spec
 import org.gradle.api.tasks.TaskProvider
 import org.gradle.language.base.plugins.LifecycleBasePlugin
+import wooga.gradle.unity.internal.InputFileTreeFactory
 import wooga.gradle.unity.models.APICompatibilityLevel
 import wooga.gradle.unity.models.DefaultUnityAuthentication
 import wooga.gradle.unity.internal.DefaultUnityPluginExtension
@@ -197,7 +199,6 @@ class UnityPlugin implements Plugin<Project> {
 
         // Override the batchmode property for edit/playmode test tasks by that of the extension
         project.tasks.withType(Test.class).configureEach({ Test t ->
-
             Provider<Boolean> testBatchModeProvider = project.provider {
                 def tp = t.testPlatform.getOrNull()
                 try {
@@ -215,6 +216,8 @@ class UnityPlugin implements Plugin<Project> {
                 }
                 true
             }
+
+            t.inputFiles.from({ ->  InputFileTreeFactory.inputFilesForUnityTask(project, extension, t) })
             t.batchMode.set(testBatchModeProvider)
             t.reports.xml.outputLocation.convention(extension.reportsDir.file(t.name + "/" + t.name + "." + reports.xml.name))
             t.enableCodeCoverage.convention(extension.enableTestCodeCoverage)

--- a/src/main/groovy/wooga/gradle/unity/internal/InputFileTreeFactory.groovy
+++ b/src/main/groovy/wooga/gradle/unity/internal/InputFileTreeFactory.groovy
@@ -1,0 +1,69 @@
+package wooga.gradle.unity.internal
+
+import org.gradle.api.Project
+import org.gradle.api.file.ConfigurableFileCollection
+import org.gradle.api.file.Directory
+import org.gradle.api.file.FileTreeElement
+import org.gradle.api.provider.Provider
+import wooga.gradle.unity.UnityPluginExtension
+import wooga.gradle.unity.UnityTask
+
+class InputFileTreeFactory {
+
+    private final Project project
+    private final UnityPluginExtension extension
+
+    InputFileTreeFactory(Project project, UnityPluginExtension extension) {
+        this.project = project
+        this.extension = extension
+    }
+
+    static ConfigurableFileCollection inputFilesForUnityTask(Project project, UnityPluginExtension extension, UnityTask task) {
+        return new InputFileTreeFactory(project, extension).inputFilesForUnityTask(task)
+    }
+
+    ConfigurableFileCollection inputFilesForBuildTarget(Provider<Directory> projectDirectory, Provider<String> buildTarget) {
+        def assetsDir = extension.assetsDir
+        def assetsFileTree = project.fileTree(assetsDir)
+        assetsFileTree.include { FileTreeElement elem ->
+            def path = elem.getRelativePath().getPathString().toLowerCase()
+            def name = elem.name.toLowerCase()
+            if (path.contains("plugins") && !((name == "plugins") || (name == "plugins.meta"))) {
+                return isPluginElemFromBuildTarget(elem, buildTarget)
+            } else {
+                return true
+            }
+        }
+
+        def projectSettingsDir = projectDirectory.map {it.dir("ProjectSettings") }
+        def projectSettingsFileTree = project.fileTree(projectSettingsDir)
+
+        def packageManagerDir = projectDirectory.map{it.dir("UnityPackageManager") }
+        def packageManagerDirFileTree = project.fileTree(packageManagerDir)
+
+        return project.files(assetsFileTree, projectSettingsFileTree, packageManagerDirFileTree)
+    }
+
+    ConfigurableFileCollection inputFilesForUnityTask(UnityTask unityTask) {
+        return inputFilesForBuildTarget(unityTask.projectDirectory, unityTask.buildTarget)
+    }
+
+    private static boolean isPluginElemFromBuildTarget(FileTreeElement element, Provider<String> buildTarget) {
+        /*
+         Why can we use / here? Because {@code element} is a {@code FileTreeElement} object.
+         The getPath() method is not the same as {@code File.getPath()}
+         From the docs:
+
+         * Returns the path of this file, relative to the root of the containing file tree. Always uses '/' as the hierarchy
+         * separator, regardless of platform file separator. Same as calling <code>getRelativePath().getPathString()</code>.
+         *
+         * @return The path. Never returns null.
+         */
+        def path = element.getRelativePath().getPathString().toLowerCase()
+        if (buildTarget.isPresent()) {
+            return path.contains("plugins/" + buildTarget.get())
+        } else {
+            return true
+        }
+    }
+}

--- a/src/main/groovy/wooga/gradle/unity/tasks/Test.groovy
+++ b/src/main/groovy/wooga/gradle/unity/tasks/Test.groovy
@@ -1,7 +1,12 @@
 package wooga.gradle.unity.tasks
 
+import org.gradle.api.file.ConfigurableFileCollection
+import org.gradle.api.file.Directory
 import org.gradle.api.provider.Property
+import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.InputFiles
 import org.gradle.api.tasks.Nested
+import org.gradle.api.tasks.SkipWhenEmpty
 import org.gradle.api.tasks.StopExecutionException
 import org.gradle.internal.reflect.Instantiator
 import org.gradle.process.ExecResult
@@ -29,6 +34,13 @@ abstract class Test extends UnityTask implements UnityTestSpec {
 
     void setReports(UnityTestTaskReport value) {
         reports = value
+    }
+
+    private final ConfigurableFileCollection inputFiles
+
+    @InputFiles
+    ConfigurableFileCollection getInputFiles() {
+        inputFiles
     }
 
     @Inject

--- a/src/main/groovy/wooga/gradle/unity/tasks/Test.groovy
+++ b/src/main/groovy/wooga/gradle/unity/tasks/Test.groovy
@@ -1,12 +1,6 @@
 package wooga.gradle.unity.tasks
 
-import org.gradle.api.file.ConfigurableFileCollection
-import org.gradle.api.file.Directory
-import org.gradle.api.provider.Property
-import org.gradle.api.tasks.Input
-import org.gradle.api.tasks.InputFiles
 import org.gradle.api.tasks.Nested
-import org.gradle.api.tasks.SkipWhenEmpty
 import org.gradle.api.tasks.StopExecutionException
 import org.gradle.internal.reflect.Instantiator
 import org.gradle.process.ExecResult
@@ -34,13 +28,6 @@ abstract class Test extends UnityTask implements UnityTestSpec {
 
     void setReports(UnityTestTaskReport value) {
         reports = value
-    }
-
-    private final ConfigurableFileCollection inputFiles
-
-    @InputFiles
-    ConfigurableFileCollection getInputFiles() {
-        inputFiles
     }
 
     @Inject

--- a/src/main/groovy/wooga/gradle/unity/traits/UnityTestSpec.groovy
+++ b/src/main/groovy/wooga/gradle/unity/traits/UnityTestSpec.groovy
@@ -16,7 +16,16 @@
 
 package wooga.gradle.unity.traits
 
+import org.gradle.api.file.ConfigurableFileCollection
+import org.gradle.api.tasks.InputFiles
+
 trait UnityTestSpec extends UnityBaseSpec {
 
+    private final ConfigurableFileCollection inputFiles = objects.fileCollection()
+
+    @InputFiles
+    ConfigurableFileCollection getInputFiles() {
+        return inputFiles
+    }
 
 }


### PR DESCRIPTION
## Description
Unity Test task inputs weren't taking as input anything related to the project file structure, so it ended up being up-to-date even when there were relevant changes to the project. the `inputFiles` Input was create on the task  in order to resolve this. 

## Changes
* ![FIX] Test task being up-to-date in wrong situations




[NEW]:https://atlas-resources.wooga.com/icons/icon_new.svg "New"
[ADD]:http://resources.atlas.wooga.com/icons/icon_add.svg "Add"
[IMPROVE]:http://resources.atlas.wooga.com/icons/icon_improve.svg "IMPROVE"
[CHANGE]:http://resources.atlas.wooga.com/icons/icon_change.svg "Change"
[FIX]:http://resources.atlas.wooga.com/icons/icon_fix.svg "Fix"
[UPDATE]:http://resources.atlas.wooga.com/icons/icon_update.svg "Update"

[BREAK]:http://resources.atlas.wooga.com/icons/icon_break.svg "Remove"
[REMOVE]:http://resources.atlas.wooga.com/icons/icon_remove.svg "Remove"
[IOS]:http://resources.atlas.wooga.com/icons/icon_iOS.svg "iOS"
[ANDROID]:http://resources.atlas.wooga.com/icons/icon_android.svg "Android"
[WEBGL]:http://resources.atlas.wooga.com/icons/icon_webGL.svg "Web:GL"
