### PR TITLE
Add snyk monitoring

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -19,7 +19,8 @@
 withCredentials([usernameColonPassword(credentialsId: 'artifactory_publish', variable: 'artifactory_publish'),
                  usernameColonPassword(credentialsId: 'artifactory_deploy', variable: 'artifactory_deploy'),
                  string(credentialsId: 'atlas_unity_coveralls_token', variable: 'coveralls_token'),
-                 string(credentialsId: 'atlas_plugins_sonar_token', variable: 'sonar_token')]) {
+                 string(credentialsId: 'atlas_plugins_sonar_token', variable: 'sonar_token'),
+                 string(credentialsId: 'atlas_plugins_snyk_token', variable: 'SNYK_TOKEN')]) {
 
     def testEnvironment = [
                             "artifactoryCredentials=${artifactory_publish}",

--- a/build.gradle
+++ b/build.gradle
@@ -16,7 +16,10 @@
  */
 
 plugins {
-    id 'net.wooga.plugins' version '2.2.3'
+    id 'net.wooga.plugins' version '2.3.0'
+    id 'net.wooga.snyk' version '0.10.0'
+    id "net.wooga.snyk-gradle-plugin" version "0.2.0"
+    id "net.wooga.cve-dependency-resolution" version "0.4.0"
 }
 
 group 'net.wooga.gradle'
@@ -36,6 +39,10 @@ pluginBundle {
     }
 }
 
+cveHandler {
+    configurations("compileClasspath", "runtimeClasspath", "testCompileClasspath", "testRuntimeClasspath", "integrationTestCompileClasspath", "integrationTestRuntimeClasspath")
+}
+
 github {
     repositoryName = "wooga/atlas-unity"
 }
@@ -45,20 +52,14 @@ dependencies {
     implementation 'com.wooga.gradle:gradle-commons:[1,2['
     implementation 'org.apache.maven:maven-artifact:3.8.5'
     implementation "org.yaml:snakeyaml:1.30"
-    implementation('net.wooga:unity-version-manager-jni') {
-        version {
-            strictly "1.5.2"
-        }
-    }
+    implementation 'net.wooga:unity-version-manager-jni:[1,2['
 
     testImplementation('org.jfrog.artifactory.client:artifactory-java-client-services:+') {
         exclude module: 'logback-classic'
     }
 
-    testImplementation("com.wooga.spock.extensions:spock-unity-version-manager-extension:0.3.0") {
-        exclude module: 'groovy-all'
-    }
+    testImplementation("com.wooga.spock.extensions:spock-unity-version-manager-extension:0.3.0")
 
-    testImplementation 'com.github.stefanbirkner:system-rules:1.18.0'
+    testImplementation 'com.github.stefanbirkner:system-rules:[1.18['
 
 }

--- a/settings.gradle
+++ b/settings.gradle
@@ -21,5 +21,11 @@ include 'shared'
 include 'api'
 include 'services:webservice'
 */
+pluginManagement {
+  repositories {
+    mavenCentral()
+    gradlePluginPortal()
+  }
+}
 
 rootProject.name = 'atlas-unity'


### PR DESCRIPTION
## Decription

This patch adds snyk monitoring to the build pipeline. It will hook itself into the check and publish stages.

The patch also sets a dependency helper plugin net.wooga.cve-dependency-resolution which applies overrides for dependencies with know fixes for security issues.

## Changes

* ![ADD] `snyk` monitoring
* ![ADD] `net.wooga.snyk-wdk-java` snyk convention plugin
* ![ADD] `net.wogoa.cve-dependency-resolution` plugin

[NEW]:https://atlas-resources.wooga.com/icons/icon_new.svg "New"
[ADD]:http://resources.atlas.wooga.com/icons/icon_add.svg "Add"
[IMPROVE]:http://resources.atlas.wooga.com/icons/icon_improve.svg "IMPROVE"
[CHANGE]:http://resources.atlas.wooga.com/icons/icon_change.svg "Change"
[FIX]:http://resources.atlas.wooga.com/icons/icon_fix.svg "Fix"
[UPDATE]:http://resources.atlas.wooga.com/icons/icon_update.svg "Update"

[BREAK]:http://resources.atlas.wooga.com/icons/icon_break.svg "Remove"
[REMOVE]:http://resources.atlas.wooga.com/icons/icon_remove.svg "Remove"
[IOS]:http://resources.atlas.wooga.com/icons/icon_iOS.svg "iOS"
[ANDROID]:http://resources.atlas.wooga.com/icons/icon_android.svg "Android"
[WEBGL]:http://resources.atlas.wooga.com/icons/icon_webGL.svg "Web:GL"
