### PR TITLE
Fix predicate for package directory on generate UPM package task

### DIFF
--- a/src/integrationTest/groovy/wooga/gradle/unity/tasks/GenerateUpmPackageTaskIntegrationSpec.groovy
+++ b/src/integrationTest/groovy/wooga/gradle/unity/tasks/GenerateUpmPackageTaskIntegrationSpec.groovy
@@ -130,13 +130,13 @@ class GenerateUpmPackageTaskIntegrationSpec extends UnityIntegrationSpec {
         and:
         def generateUpmPackageTaskName = "upmPack"
         List<String> taskStatements = new ArrayList<String>()
-        if (failure != GenerateUpmPackage.Failure.packageDirectoryNotSet) {
+        if (predicate != GenerateUpmPackage.Message.packageDirectoryNotSet) {
             taskStatements.add("packageDirectory.set(${wrapValueBasedOnType(projectPath, Directory)})")
         }
-        if (failure != GenerateUpmPackage.Failure.versionNotSet) {
+        if (predicate != GenerateUpmPackage.Message.versionNotSet) {
             taskStatements.add("archiveVersion.set(${wrapValueBasedOnType(packageVersion, String)})")
         }
-        if (failure != GenerateUpmPackage.Failure.packageNameNotSet) {
+        if (predicate != GenerateUpmPackage.Message.packageNameNotSet) {
             taskStatements.add("packageName = ${wrapValueBasedOnType(packageName, String)}")
         }
 
@@ -146,14 +146,17 @@ class GenerateUpmPackageTaskIntegrationSpec extends UnityIntegrationSpec {
         def result = runTasks(generateUpmPackageTaskName)
 
         then:
-        result.failure || result.wasSkipped(generateUpmPackageTaskName)
+        // TODO: Utility method to check either skip reason (NO-SOURCES, etc)
+        result.wasSkipped(generateUpmPackageTaskName) || outputContains(result, "${generateUpmPackageTaskName} NO-SOURCE")
         outputContains(result, reason)
 
         where:
-        packageName        | packageVersion | failure
-        "com.wooga.foobar" | "0.0.1"        | GenerateUpmPackage.Failure.packageDirectoryNotSet
-        "com.wooga.foobar" | "0.0.1"        | GenerateUpmPackage.Failure.versionNotSet
-        "com.wooga.foobar" | "0.0.1"        | GenerateUpmPackage.Failure.packageNameNotSet
-        reason = failure.message
+        packageName        | packageVersion | predicate
+        "com.wooga.foobar" | "0.0.1"        | GenerateUpmPackage.Message.packageDirectoryNotSet
+        "com.wooga.foobar" | "0.0.1"        | GenerateUpmPackage.Message.versionNotSet
+        "com.wooga.foobar" | "0.0.1"        | GenerateUpmPackage.Message.packageNameNotSet
+        reason = predicate.message
     }
+
+
 }


### PR DESCRIPTION
## Description
Fixes the predicate for package directory on the generate upm package task.

## Changes
* ![FIX] Fixes the predicate for package directory on the generate upm package task.

[NEW]:      https://resources.atlas.wooga.com/icons/icon_new.svg "New"
[ADD]:      https://resources.atlas.wooga.com/icons/icon_add.svg "Add"
[IMPROVE]:  https://resources.atlas.wooga.com/icons/icon_improve.svg "Improve"
[CHANGE]:   https://resources.atlas.wooga.com/icons/icon_change.svg "Change"
[FIX]:      https://resources.atlas.wooga.com/icons/icon_fix.svg "Fix"
[UPDATE]:   https://resources.atlas.wooga.com/icons/icon_update.svg "Update"

[BREAK]:    https://resources.atlas.wooga.com/icons/icon_break.svg "Remove"
[REMOVE]:   https://resources.atlas.wooga.com/icons/icon_remove.svg "Remove"
[IOS]:      https://resources.atlas.wooga.com/icons/icon_iOS.svg "iOS"
[ANDROID]:  https://resources.atlas.wooga.com/icons/icon_android.svg "Android"
[WEBGL]:    https://resources.atlas.wooga.com/icons/icon_webGL.svg "WebGL"
[GRADLE]:   https://resources.atlas.wooga.com/icons/icon_gradle.svg "GRADLE"
[UNITY]:    https://resources.atlas.wooga.com/icons/icon_unity.svg "Unity"
[LINUX]:    https://resources.atlas.wooga.com/icons/icon_linux.svg "Linux"
[WIN]:      https://resources.atlas.wooga.com/icons/icon_windows.svg "Windows"
[MACOS]:    https://resources.atlas.wooga.com/icons/icon_iOS.svg "macOS"
