### PR TITLE
Fix the cache server upload/download options

### DIFF
--- a/src/integrationTest/groovy/wooga/gradle/unity/tasks/DefaultUnityTaskIntegrationSpec.groovy
+++ b/src/integrationTest/groovy/wooga/gradle/unity/tasks/DefaultUnityTaskIntegrationSpec.groovy
@@ -136,8 +136,6 @@ class DefaultUnityTaskIntegrationSpec extends UnityTaskIntegrationSpec<Unity> {
                     UnityCommandLineOption.disableAssemblyUpdater,
                     UnityCommandLineOption.deepProfiling,
                     UnityCommandLineOption.enableCacheServer,
-                    UnityCommandLineOption.cacheServerEnableDownload,
-                    UnityCommandLineOption.cacheServerEnableUpload,
                 ]
                     .collect({ it -> [it.toString()] }),
                 [true, false],
@@ -156,6 +154,44 @@ class DefaultUnityTaskIntegrationSpec extends UnityTaskIntegrationSpec<Unity> {
             .withPropertyKey(propertyKey)
             .withEnvironmentKey(envKey)
             .to(location)
+        getter = new PropertyGetterTaskWriter(setter)
+    }
+
+    // Options that are (boolean) flags but need to be passed as arguments
+    @Unroll
+    def "can set command line argument boolean option #option when #location with key #keyString to #value"() {
+
+        when:
+        def query = runPropertyQuery(getter, setter)
+
+        then:
+        query.success
+        query.matches(value, String)
+
+        where:
+        [testCase, value, location] <<
+            [
+                [
+                    UnityCommandLineOption.cacheServerEnableDownload,
+                    UnityCommandLineOption.cacheServerEnableUpload,
+                ]
+                    .collect({ it -> [it.toString()] }),
+                [true, false],
+                [PropertyLocation.property, PropertyLocation.environment, PropertyLocation.script]
+            ].combinations()
+
+        option = testCase[0]
+        propertyKey = "${extensionName}." + option
+        envKey = PropertyUtils.envNameFromProperty(propertyKey)
+        keyString = location == PropertyLocation.property
+            ? propertyKey : envKey
+
+        setter = new PropertySetterWriter(subjectUnderTestName, option)
+            .set(value, Boolean)
+            .withPropertyKey(propertyKey)
+            .withEnvironmentKey(envKey)
+            .to(location)
+
         getter = new PropertyGetterTaskWriter(setter)
     }
 }

--- a/src/main/groovy/wooga/gradle/unity/models/UnityCommandLineOption.groovy
+++ b/src/main/groovy/wooga/gradle/unity/models/UnityCommandLineOption.groovy
@@ -291,12 +291,12 @@ enum UnityCommandLineOption {
      * Enable downloading from the newer Accelerator Cache Server.
      * <p>Example:-cacheServerEnableDownload true
      */
-    cacheServerEnableDownload("-cacheServerEnableDownload"),
+    cacheServerEnableDownload("-cacheServerEnableDownload", true),
     /**
      * Enable uploading to the newer Accelerator Cache Server.
      * <p>Example:-cacheServerEnableUpload false
      */
-    cacheServerEnableUpload("--cacheServerEnableUpload"),
+    cacheServerEnableUpload("--cacheServerEnableUpload", true),
     /**
      * Enables usage of the older (v1) Cache Server, and specifies the IP Address to connect to on startup.
      * This overrides any configuration stored in the Editor Preferences.

--- a/src/main/groovy/wooga/gradle/unity/tasks/Activate.groovy
+++ b/src/main/groovy/wooga/gradle/unity/tasks/Activate.groovy
@@ -39,7 +39,7 @@ class Activate extends UnityTask implements UnityAuthenticationSpec {
     Activate() {
         description = " Activates a Unity installation with unity account and a serial number"
         authentication = new DefaultUnityAuthentication(project.objects)
-        cacheServerEnableUpload.set(false)
+        setCacheServerEnableUpload(false)
         onlyIf({
 
             // If all 3 haven't been assigned, don't throw since this is optional

--- a/src/main/groovy/wooga/gradle/unity/tasks/AddUPMPackages.groovy
+++ b/src/main/groovy/wooga/gradle/unity/tasks/AddUPMPackages.groovy
@@ -20,7 +20,7 @@ class AddUPMPackages extends UnityTask implements BaseSpec {
 
     AddUPMPackages() {
         description = "Adds UPM packages to Unity project"
-        cacheServerEnableUpload.set(false)
+        setCacheServerEnableUpload(false)
     }
 
     @Override

--- a/src/main/groovy/wooga/gradle/unity/tasks/ReturnLicense.groovy
+++ b/src/main/groovy/wooga/gradle/unity/tasks/ReturnLicense.groovy
@@ -30,6 +30,6 @@ class ReturnLicense extends UnityTask implements UnityLicenseSpec {
     ReturnLicense() {
         description = "Return the currently active license to the license server."
         returnLicense = true
-        cacheServerEnableUpload.set(false)
+        setCacheServerEnableUpload(false)
     }
 }

--- a/src/main/groovy/wooga/gradle/unity/traits/UnityCommandLineSpec.groovy
+++ b/src/main/groovy/wooga/gradle/unity/traits/UnityCommandLineSpec.groovy
@@ -623,7 +623,7 @@ trait UnityCommandLineSpec extends UnitySpec {
     }
 
     @Internal
-    Property<String> getCacheServerNamespacePrefix() {
+    Property<Boolean> getCacheServerNamespacePrefix() {
         return getCommandLineOption(UnityCommandLineOption.cacheServerNamespacePrefix).arguments
     }
     void setCacheServerNamespacePrefix(Provider<String> value) {
@@ -634,28 +634,40 @@ trait UnityCommandLineSpec extends UnitySpec {
         setCommandLineOption(UnityCommandLineOption.cacheServerNamespacePrefix, value)
     }
 
+    // Special case because this is a boolean option but needs to be set as a string
     @Internal
-    Property<Boolean> getCacheServerEnableDownload() {
-        return getCommandLineOption(UnityCommandLineOption.cacheServerEnableDownload).enabled
+    Property<String> getCacheServerEnableDownload() {
+        return getCommandLineOption(UnityCommandLineOption.cacheServerEnableDownload).arguments
     }
-    void setCacheServerEnableDownload(Provider<Boolean> value) {
-        toggleCommandLineOption(UnityCommandLineOption.cacheServerEnableDownload, value)
+
+    void setCacheServerEnableDownload(Provider<String> value) {
+        setCommandLineOption(UnityCommandLineOption.cacheServerEnableDownload, value)
+    }
+
+    void setCacheServerEnableDownload(String value) {
+        setCommandLineOption(UnityCommandLineOption.cacheServerEnableDownload, value)
     }
 
     void setCacheServerEnableDownload(Boolean value) {
-        toggleCommandLineOption(UnityCommandLineOption.cacheServerEnableDownload, value)
+        setCommandLineOption(UnityCommandLineOption.cacheServerEnableDownload, value.toString())
     }
 
+    // Special case because this is a boolean option but needs to be set as a string
     @Internal
-    Property<Boolean> getCacheServerEnableUpload() {
-        return getCommandLineOption(UnityCommandLineOption.cacheServerEnableUpload).enabled
+    Property<String> getCacheServerEnableUpload() {
+        return getCommandLineOption(UnityCommandLineOption.cacheServerEnableUpload).arguments
     }
-    void setCacheServerEnableUpload(Provider<Boolean> value) {
-        toggleCommandLineOption(UnityCommandLineOption.cacheServerEnableUpload, value)
+
+    void setCacheServerEnableUpload(Provider<String> value) {
+        setCommandLineOption(UnityCommandLineOption.cacheServerEnableUpload, value)
+    }
+
+    void setCacheServerEnableUpload(String value) {
+        setCommandLineOption(UnityCommandLineOption.cacheServerEnableUpload, value)
     }
 
     void setCacheServerEnableUpload(Boolean value) {
-        toggleCommandLineOption(UnityCommandLineOption.cacheServerEnableUpload, value)
+        setCommandLineOption(UnityCommandLineOption.cacheServerEnableUpload, value.toString())
     }
 
     @Internal


### PR DESCRIPTION
## Description
Fix the cache server upload/download options not being disabled.

## Changes
* ![UPDATE] `UnityCommandLineOption`

[NEW]:      https://resources.atlas.wooga.com/icons/icon_new.svg "New"
[ADD]:      https://resources.atlas.wooga.com/icons/icon_add.svg "Add"
[IMPROVE]:  https://resources.atlas.wooga.com/icons/icon_improve.svg "Improve"
[CHANGE]:   https://resources.atlas.wooga.com/icons/icon_change.svg "Change"
[FIX]:      https://resources.atlas.wooga.com/icons/icon_fix.svg "Fix"
[UPDATE]:   https://resources.atlas.wooga.com/icons/icon_update.svg "Update"

[BREAK]:    https://resources.atlas.wooga.com/icons/icon_break.svg "Remove"
[REMOVE]:   https://resources.atlas.wooga.com/icons/icon_remove.svg "Remove"
[IOS]:      https://resources.atlas.wooga.com/icons/icon_iOS.svg "iOS"
[ANDROID]:  https://resources.atlas.wooga.com/icons/icon_android.svg "Android"
[WEBGL]:    https://resources.atlas.wooga.com/icons/icon_webGL.svg "WebGL"
[GRADLE]:   https://resources.atlas.wooga.com/icons/icon_gradle.svg "GRADLE"
[UNITY]:    https://resources.atlas.wooga.com/icons/icon_unity.svg "Unity"
[LINUX]:    https://resources.atlas.wooga.com/icons/icon_linux.svg "Linux"
[WIN]:      https://resources.atlas.wooga.com/icons/icon_windows.svg "Windows"
[MACOS]:    https://resources.atlas.wooga.com/icons/icon_iOS.svg "macOS"
