### PR TITLE
Fix the cache server enable upload flag, which had an extra -

### DIFF
--- a/src/main/groovy/wooga/gradle/unity/models/UnityCommandLineOption.groovy
+++ b/src/main/groovy/wooga/gradle/unity/models/UnityCommandLineOption.groovy
@@ -296,7 +296,7 @@ enum UnityCommandLineOption {
      * Enable uploading to the newer Accelerator Cache Server.
      * <p>Example:-cacheServerEnableUpload false
      */
-    cacheServerEnableUpload("--cacheServerEnableUpload", true),
+    cacheServerEnableUpload("-cacheServerEnableUpload", true),
     /**
      * Enables usage of the older (v1) Cache Server, and specifies the IP Address to connect to on startup.
      * This overrides any configuration stored in the Editor Preferences.


### PR DESCRIPTION
## Description

The cache server flag had an extra -.

## Changes
* ![ADD] `UnityCommandLineOptions'

[NEW]:      https://resources.atlas.wooga.com/icons/icon_new.svg "New"
[ADD]:      https://resources.atlas.wooga.com/icons/icon_add.svg "Add"
[IMPROVE]:  https://resources.atlas.wooga.com/icons/icon_improve.svg "Improve"
[CHANGE]:   https://resources.atlas.wooga.com/icons/icon_change.svg "Change"
[FIX]:      https://resources.atlas.wooga.com/icons/icon_fix.svg "Fix"
[UPDATE]:   https://resources.atlas.wooga.com/icons/icon_update.svg "Update"

[BREAK]:    https://resources.atlas.wooga.com/icons/icon_break.svg "Remove"
[REMOVE]:   https://resources.atlas.wooga.com/icons/icon_remove.svg "Remove"
[IOS]:      https://resources.atlas.wooga.com/icons/icon_iOS.svg "iOS"
[ANDROID]:  https://resources.atlas.wooga.com/icons/icon_android.svg "Android"
[WEBGL]:    https://resources.atlas.wooga.com/icons/icon_webGL.svg "WebGL"
[GRADLE]:   https://resources.atlas.wooga.com/icons/icon_gradle.svg "GRADLE"
[UNITY]:    https://resources.atlas.wooga.com/icons/icon_unity.svg "Unity"
[LINUX]:    https://resources.atlas.wooga.com/icons/icon_linux.svg "Linux"
[WIN]:      https://resources.atlas.wooga.com/icons/icon_windows.svg "Windows"
[MACOS]:    https://resources.atlas.wooga.com/icons/icon_iOS.svg "macOS"
