### PR TITLE
Add task to setup project

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 build/
 .idea/
 out/
+bin/
 
 # Ignore Gradle GUI config
 gradle-app.setting

--- a/src/integrationTest/groovy/wooga/gradle/unity/UnityPluginIntegrationSpec.groovy
+++ b/src/integrationTest/groovy/wooga/gradle/unity/UnityPluginIntegrationSpec.groovy
@@ -136,7 +136,7 @@ class UnityPluginIntegrationSpec extends UnityIntegrationSpec {
     }
 
     @UnityPluginTestOptions(unityPath = UnityPathResolution.None, addPluginTestDefaults = false,
-            disableAutoActivateAndLicense = false)
+        disableAutoActivateAndLicense = false)
     @Unroll
     def "extension property :#property returns '#testValue' if #reason"() {
         given: "an applied plugin"
@@ -183,7 +183,9 @@ class UnityPluginIntegrationSpec extends UnityIntegrationSpec {
         "unityRootDir"             | _                            | _                         | getUnityFileTree(getPlatformUnityPath()).unityRoot.absolutePath | "Provider<Directory>"   | PropertyLocation.none
 
         "defaultBuildTarget"       | _                            | _                         | null                                                            | _                       | PropertyLocation.none
-        "autoActivateUnity"        | _                            | _                         | true                                                            | Boolean                 | PropertyLocation.none
+        "autoActivate"             | _                            | _                         | true                                                            | Boolean                 | PropertyLocation.none
+        "autoActivate"             | _                            | false                     | false                                                           | Boolean                 | PropertyLocation.property
+        "autoActivate"             | _                            | false                     | false                                                           | Boolean                 | PropertyLocation.environment
         "autoReturnLicense"        | _                            | _                         | true                                                            | Boolean                 | PropertyLocation.none
         "logCategory"              | _                            | _                         | "unity"                                                         | "Property<String>"      | PropertyLocation.none
         "batchModeForEditModeTest" | _                            | _                         | true                                                            | Boolean                 | PropertyLocation.none
@@ -360,8 +362,8 @@ class UnityPluginIntegrationSpec extends UnityIntegrationSpec {
 
         then:
         shouldRun ?
-                result.wasExecuted("addUPMPackages") :
-                result.standardOutput.contains("Task :addUPMPackages SKIPPED")
+            result.wasExecuted("addUPMPackages") :
+            result.standardOutput.contains("Task :addUPMPackages SKIPPED")
 
         where:
         testCoverageEnabled | packagesToInstall  | shouldRun

--- a/src/integrationTest/groovy/wooga/gradle/unity/tasks/SetupProjectIntegrationSpec.groovy
+++ b/src/integrationTest/groovy/wooga/gradle/unity/tasks/SetupProjectIntegrationSpec.groovy
@@ -1,0 +1,53 @@
+package wooga.gradle.unity.tasks
+
+import com.wooga.spock.extensions.unity.UnityPathResolution
+import com.wooga.spock.extensions.unity.UnityPluginTestOptions
+import com.wooga.spock.extensions.uvm.UnityInstallation
+import net.wooga.uvm.Installation
+import org.gradle.api.file.Directory
+import spock.lang.Requires
+import wooga.gradle.unity.UnityTaskIntegrationSpec
+
+import static org.apache.commons.io.FileUtils.getFile
+
+class SetupProjectIntegrationSpec extends UnityTaskIntegrationSpec<SetupProject> {
+
+    @Requires({ os.macOs })
+    @UnityPluginTestOptions(unityPath = UnityPathResolution.Default)
+    @UnityInstallation(version = "2020.3.19f1", cleanup = false)
+    def "resolves packages"(Installation unity) {
+
+        given: "a pre installed unity editor"
+        environmentVariables.set("UNITY_PATH", unity.getExecutable().getPath())
+
+        and: "configuration of the new project"
+        def projectPath = "Wooga.Foobar"
+        def createProjectTaskName = "createProject"
+
+        buildFile << """
+        unity {
+        projectDirectory.set(${wrapValueBasedOnType(projectPath, Directory)})
+        }        
+        """.stripIndent()
+        addTask(createProjectTaskName, CreateProject, true)
+
+        when: "creating the project"
+        def createProject = runTasksSuccessfully(createProjectTaskName)
+
+        then:
+        createProject.success
+        getFile(projectDir, projectPath, "Assets").exists()
+
+        def packageDirectory = getFile(projectDir, projectPath, "Packages")
+        def packageLockFile = new File(packageDirectory, SetupProject.lockFileName)
+        packageLockFile.delete()
+        !packageLockFile.exists()
+
+        when: "resolving the project packages when there's no lock file"
+        def setupProject = runTasksSuccessfully("setupProject")
+
+        then:
+        setupProject.success
+        packageLockFile.exists()
+    }
+}

--- a/src/main/groovy/wooga/gradle/unity/UnityPlugin.groovy
+++ b/src/main/groovy/wooga/gradle/unity/UnityPlugin.groovy
@@ -120,8 +120,8 @@ class UnityPlugin implements Plugin<Project> {
         extension.reportsDir.convention(project.layout.buildDirectory.dir(project.provider({ reportingExtension.file("unity").path })))
 
         extension.licenseDirectory.convention(project.layout.buildDirectory.dir(project.provider({ UnityPluginConventions.licenseDirectory.path })))
-        extension.autoActivateUnity.convention(true)
-        extension.autoReturnLicense.convention(extension.autoActivateUnity)
+        extension.autoActivate.convention(UnityPluginConventions.autoActivate.getBooleanValueProvider(project))
+        extension.autoReturnLicense.convention(extension.autoActivate)
 
         extension.unityPath.convention(UnityPluginConventions.unityPath.getFileValueProvider(project))
 
@@ -366,7 +366,9 @@ class UnityPlugin implements Plugin<Project> {
             t.onlyIf { extension.autoReturnLicense.get() }
         })
 
+        // Have all tasks return the license
         project.tasks.withType(UnityTask).configureEach({ t ->
+            // If it's neither the activate/return license task
             if (!Activate.isInstance(t) && !ReturnLicense.isInstance(t)) {
                 t.dependsOn(activateTask)
                 t.finalizedBy(returnLicenseTask)

--- a/src/main/groovy/wooga/gradle/unity/UnityPlugin.groovy
+++ b/src/main/groovy/wooga/gradle/unity/UnityPlugin.groovy
@@ -37,7 +37,7 @@ import wooga.gradle.unity.models.UnityCommandLineOption
 import wooga.gradle.unity.tasks.Activate
 import wooga.gradle.unity.tasks.AddUPMPackages
 import wooga.gradle.unity.tasks.GenerateSolution
-import wooga.gradle.unity.tasks.GenerateUpmPackage
+import wooga.gradle.unity.tasks.SetupProject
 import wooga.gradle.unity.tasks.ReturnLicense
 import wooga.gradle.unity.tasks.SetAPICompatibilityLevel
 import wooga.gradle.unity.tasks.Test
@@ -79,7 +79,8 @@ class UnityPlugin implements Plugin<Project> {
         setAPICompatibilityLevel(APICompatibilityLevel),
         unsetAPICompatibilityLevel(APICompatibilityLevel),
         generateSolution(GenerateSolution),
-        addUPMPackages(AddUPMPackages)
+        addUPMPackages(AddUPMPackages),
+        setupProject(SetupProject)
 
         private final Class taskClass
 
@@ -405,9 +406,9 @@ class UnityPlugin implements Plugin<Project> {
     }
 
     private static void configurePackageTasks(UnityPluginExtension extension, final Project project) {
-        // TODO: Perhaps hook the task to generate meta files
-        project.tasks.withType(GenerateUpmPackage).configureEach({ t ->
-        })
+        project.tasks.register(Tasks.setupProject.toString(), Tasks.setupProject.taskClass) {
+            it.group = GROUP
+        }
     }
 
 }

--- a/src/main/groovy/wooga/gradle/unity/UnityPluginConventions.groovy
+++ b/src/main/groovy/wooga/gradle/unity/UnityPluginConventions.groovy
@@ -73,8 +73,9 @@ class UnityPluginConventions {
     /**
      * The path to the Unity Editor executable
      */
-    static final PropertyLookup unityPath = new PropertyLookup(["UNITY_UNITY_PATH", "UNITY_PATH"], "unity.unityPath", { getPlatformUnityPath().absolutePath })    /**
+    static final PropertyLookup unityPath = new PropertyLookup(["UNITY_UNITY_PATH", "UNITY_PATH"], "unity.unityPath", { getPlatformUnityPath().absolutePath })
     /**
+     /**
      * Used for authentication with Unity's servers
      */
     static final PropertyLookup user = new PropertyLookup(["UNITY_USR", "UNITY_AUTHENTICATION_USERNAME"], "unity.authentication.username", null)
@@ -121,7 +122,11 @@ class UnityPluginConventions {
     /**
      * Test filtering
      */
-    static final PropertyLookup testFilter  = new PropertyLookup("UNITY_TEST_FILTER", "unity.testFilter", null)
+    static final PropertyLookup testFilter = new PropertyLookup("UNITY_TEST_FILTER", "unity.testFilter", null)
+    /**
+     * Automatic unity activation (get/return license)
+     */
+    static final PropertyLookup autoActivate = new PropertyLookup("UNITY_AUTO_ACTIVATE", "unity.autoActivate", true)
 
     /**
      * The path to the Unity license directory
@@ -163,7 +168,7 @@ class UnityPluginConventions {
 
     static UnityFileTree getUnityFileTree(File unityExec) {
         return UnityFileTree.fromUnityExecutable(unityExec)
-     }
+    }
 
 }
 

--- a/src/main/groovy/wooga/gradle/unity/UnityPluginExtension.groovy
+++ b/src/main/groovy/wooga/gradle/unity/UnityPluginExtension.groovy
@@ -134,7 +134,7 @@ trait UnityPluginExtension implements UnitySpec,
         autoReturnLicense
     }
 
-    final Provider<Boolean> shouldReturnLicense = providerFactory.provider({ getAutoActivateUnity().get() && getAutoReturnLicense().get() })
+    final Provider<Boolean> shouldReturnLicense = providerFactory.provider({ getAutoActivate().get() && getAutoReturnLicense().get() })
 
     void setAutoReturnLicense(Provider<Boolean> value) {
         autoReturnLicense.set(value)
@@ -144,24 +144,37 @@ trait UnityPluginExtension implements UnitySpec,
         autoReturnLicense.set(value)
     }
 
-    private final Property<Boolean> autoActivateUnity = objects.property(Boolean)
+    @Deprecated
+    Property<Boolean> getAutoActivateUnity() {
+        autoActivate
+    }
+
+    @Deprecated
+    void setAutoActivateUnity(Boolean value) {
+        setAutoActivate(value)
+    }
+
+    @Deprecated
+    void setAutoActivateUnity(Provider<Boolean> value) {
+        setAutoActivate(value)
+    }
 
     /**
      * @return Whether a task to activate the Unity license should be executed before any task of type {@code UnityTask}
      */
-    Property<Boolean> getAutoActivateUnity() {
-        autoActivateUnity
+    Property<Boolean> getAutoActivate() {
+        autoActivate
     }
 
-    void setAutoActivateUnity(Boolean value) {
-        autoActivateUnity.set(value)
+    private final Property<Boolean> autoActivate = objects.property(Boolean)
+
+    void setAutoActivate(Provider<Boolean> value) {
+        autoActivate.set(value)
     }
 
-    void setAutoActivateUnity(Provider<Boolean> value) {
-        autoActivateUnity.set(value)
+    void setAutoActivate(Boolean value) {
+        autoActivate.set(value)
     }
-
-    private Property<String> defaultBuildTarget = objects.property(String)
 
     /**
      * @return If assigned, what the build target will be assigned to by convention
@@ -169,6 +182,8 @@ trait UnityPluginExtension implements UnitySpec,
     Property<String> getDefaultBuildTarget() {
         defaultBuildTarget
     }
+
+    private Property<String> defaultBuildTarget = objects.property(String)
 
     void setDefaultBuildTarget(Provider<String> value) {
         defaultBuildTarget.set(value)

--- a/src/main/groovy/wooga/gradle/unity/tasks/SetupProject.groovy
+++ b/src/main/groovy/wooga/gradle/unity/tasks/SetupProject.groovy
@@ -1,0 +1,19 @@
+package wooga.gradle.unity.tasks
+
+import wooga.gradle.unity.UnityTask
+
+/**
+ * A task that will set up the Unity project by just invoking it
+ * from batchmode (opening then closing the project).
+ * This, for example, ensures the packages are resolved.
+ */
+class SetupProject extends UnityTask {
+
+    static String manifestFileName = "manifest.json"
+    static String lockFileName = "packages-lock.json"
+
+    SetupProject() {
+        batchMode.set(true)
+        description = "Resolves packages through UPM"
+    }
+}


### PR DESCRIPTION
## Description

Adds a task, `setupProject` that will set up the project, building the library, resolving UPM packages by virtue of... opening then closing the project in batchmode. 

One of its use cases will be during our unity wdk pipelines, for the upm setup.

## Changes
* ![ADD] `setupProject` task.

[NEW]:      https://resources.atlas.wooga.com/icons/icon_new.svg "New"
[ADD]:      https://resources.atlas.wooga.com/icons/icon_add.svg "Add"
[IMPROVE]:  https://resources.atlas.wooga.com/icons/icon_improve.svg "Improve"
[CHANGE]:   https://resources.atlas.wooga.com/icons/icon_change.svg "Change"
[FIX]:      https://resources.atlas.wooga.com/icons/icon_fix.svg "Fix"
[UPDATE]:   https://resources.atlas.wooga.com/icons/icon_update.svg "Update"

[BREAK]:    https://resources.atlas.wooga.com/icons/icon_break.svg "Remove"
[REMOVE]:   https://resources.atlas.wooga.com/icons/icon_remove.svg "Remove"
[IOS]:      https://resources.atlas.wooga.com/icons/icon_iOS.svg "iOS"
[ANDROID]:  https://resources.atlas.wooga.com/icons/icon_android.svg "Android"
[WEBGL]:    https://resources.atlas.wooga.com/icons/icon_webGL.svg "WebGL"
[GRADLE]:   https://resources.atlas.wooga.com/icons/icon_gradle.svg "GRADLE"
[UNITY]:    https://resources.atlas.wooga.com/icons/icon_unity.svg "Unity"
[LINUX]:    https://resources.atlas.wooga.com/icons/icon_linux.svg "Linux"
[WIN]:      https://resources.atlas.wooga.com/icons/icon_windows.svg "Windows"
[MACOS]:    https://resources.atlas.wooga.com/icons/icon_iOS.svg "macOS"
