### PR TITLE
Add a convention for the autoActivate property, deprecate the older name

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 build/
 .idea/
 out/
+bin/
 
 # Ignore Gradle GUI config
 gradle-app.setting

--- a/src/integrationTest/groovy/wooga/gradle/unity/UnityPluginIntegrationSpec.groovy
+++ b/src/integrationTest/groovy/wooga/gradle/unity/UnityPluginIntegrationSpec.groovy
@@ -136,7 +136,7 @@ class UnityPluginIntegrationSpec extends UnityIntegrationSpec {
     }
 
     @UnityPluginTestOptions(unityPath = UnityPathResolution.None, addPluginTestDefaults = false,
-            disableAutoActivateAndLicense = false)
+        disableAutoActivateAndLicense = false)
     @Unroll
     def "extension property :#property returns '#testValue' if #reason"() {
         given: "an applied plugin"
@@ -184,6 +184,9 @@ class UnityPluginIntegrationSpec extends UnityIntegrationSpec {
 
         "defaultBuildTarget"       | _                            | _                         | null                                                            | _                       | PropertyLocation.none
         "autoActivateUnity"        | _                            | _                         | true                                                            | Boolean                 | PropertyLocation.none
+        "autoActivate"             | _                            | _                         | true                                                            | Boolean                 | PropertyLocation.none
+        "autoActivate"             | _                            | false                     | false                                                           | Boolean                 | PropertyLocation.property
+        "autoActivate"             | _                            | false                     | false                                                           | Boolean                 | PropertyLocation.environment
         "autoReturnLicense"        | _                            | _                         | true                                                            | Boolean                 | PropertyLocation.none
         "logCategory"              | _                            | _                         | "unity"                                                         | "Property<String>"      | PropertyLocation.none
         "batchModeForEditModeTest" | _                            | _                         | true                                                            | Boolean                 | PropertyLocation.none
@@ -360,8 +363,8 @@ class UnityPluginIntegrationSpec extends UnityIntegrationSpec {
 
         then:
         shouldRun ?
-                result.wasExecuted("addUPMPackages") :
-                result.standardOutput.contains("Task :addUPMPackages SKIPPED")
+            result.wasExecuted("addUPMPackages") :
+            result.standardOutput.contains("Task :addUPMPackages SKIPPED")
 
         where:
         testCoverageEnabled | packagesToInstall  | shouldRun

--- a/src/main/groovy/wooga/gradle/unity/UnityPlugin.groovy
+++ b/src/main/groovy/wooga/gradle/unity/UnityPlugin.groovy
@@ -120,8 +120,8 @@ class UnityPlugin implements Plugin<Project> {
         extension.reportsDir.convention(project.layout.buildDirectory.dir(project.provider({ reportingExtension.file("unity").path })))
 
         extension.licenseDirectory.convention(project.layout.buildDirectory.dir(project.provider({ UnityPluginConventions.licenseDirectory.path })))
-        extension.autoActivateUnity.convention(true)
-        extension.autoReturnLicense.convention(extension.autoActivateUnity)
+        extension.autoActivate.convention(UnityPluginConventions.autoActivate.getBooleanValueProvider(project))
+        extension.autoReturnLicense.convention(extension.autoActivate)
 
         extension.unityPath.convention(UnityPluginConventions.unityPath.getFileValueProvider(project))
 

--- a/src/main/groovy/wooga/gradle/unity/UnityPluginConventions.groovy
+++ b/src/main/groovy/wooga/gradle/unity/UnityPluginConventions.groovy
@@ -73,7 +73,8 @@ class UnityPluginConventions {
     /**
      * The path to the Unity Editor executable
      */
-    static final PropertyLookup unityPath = new PropertyLookup(["UNITY_UNITY_PATH", "UNITY_PATH"], "unity.unityPath", { getPlatformUnityPath().absolutePath })    /**
+    static final PropertyLookup unityPath = new PropertyLookup(["UNITY_UNITY_PATH", "UNITY_PATH"], "unity.unityPath", { getPlatformUnityPath().absolutePath })
+
     /**
      * Used for authentication with Unity's servers
      */
@@ -86,9 +87,9 @@ class UnityPluginConventions {
      * Used for authentication with Unity's servers
      */
     static final PropertyLookup serial = new PropertyLookup("UNITY_AUTHENTICATION_SERIAL", "unity.authentication.serial", null)
+
     /**
      * Used in specifying the directory where unity logs are written to
-     *
      * @environmentVariable "XCODEBUILD_LOGS_DIR"
      * @propertyName "xcodebuild.logsDir"
      * @defaultValue "logs"
@@ -121,7 +122,11 @@ class UnityPluginConventions {
     /**
      * Test filtering
      */
-    static final PropertyLookup testFilter  = new PropertyLookup("UNITY_TEST_FILTER", "unity.testFilter", null)
+    static final PropertyLookup testFilter = new PropertyLookup("UNITY_TEST_FILTER", "unity.testFilter", null)
+    /**
+     * Automatic unity activation (get/return license)
+     */
+    static final PropertyLookup autoActivate = new PropertyLookup("UNITY_AUTO_ACTIVATE", "unity.autoActivate", true)
 
     /**
      * The path to the Unity license directory
@@ -163,7 +168,7 @@ class UnityPluginConventions {
 
     static UnityFileTree getUnityFileTree(File unityExec) {
         return UnityFileTree.fromUnityExecutable(unityExec)
-     }
+    }
 
 }
 

--- a/src/main/groovy/wooga/gradle/unity/UnityPluginExtension.groovy
+++ b/src/main/groovy/wooga/gradle/unity/UnityPluginExtension.groovy
@@ -134,7 +134,7 @@ trait UnityPluginExtension implements UnitySpec,
         autoReturnLicense
     }
 
-    final Provider<Boolean> shouldReturnLicense = providerFactory.provider({ getAutoActivateUnity().get() && getAutoReturnLicense().get() })
+    final Provider<Boolean> shouldReturnLicense = providerFactory.provider({ getAutoActivate().get() && getAutoReturnLicense().get() })
 
     void setAutoReturnLicense(Provider<Boolean> value) {
         autoReturnLicense.set(value)
@@ -144,24 +144,37 @@ trait UnityPluginExtension implements UnitySpec,
         autoReturnLicense.set(value)
     }
 
-    private final Property<Boolean> autoActivateUnity = objects.property(Boolean)
+    @Deprecated
+    Property<Boolean> getAutoActivateUnity() {
+        autoActivate
+    }
+
+    @Deprecated
+    void setAutoActivateUnity(Boolean value) {
+        setAutoActivate(value)
+    }
+
+    @Deprecated
+    void setAutoActivateUnity(Provider<Boolean> value) {
+        setAutoActivate(value)
+    }
 
     /**
      * @return Whether a task to activate the Unity license should be executed before any task of type {@code UnityTask}
      */
-    Property<Boolean> getAutoActivateUnity() {
-        autoActivateUnity
+    Property<Boolean> getAutoActivate() {
+        autoActivate
     }
 
-    void setAutoActivateUnity(Boolean value) {
-        autoActivateUnity.set(value)
+    private final Property<Boolean> autoActivate = objects.property(Boolean)
+
+    void setAutoActivate(Provider<Boolean> value) {
+        autoActivate.set(value)
     }
 
-    void setAutoActivateUnity(Provider<Boolean> value) {
-        autoActivateUnity.set(value)
+    void setAutoActivate(Boolean value) {
+        autoActivate.set(value)
     }
-
-    private Property<String> defaultBuildTarget = objects.property(String)
 
     /**
      * @return If assigned, what the build target will be assigned to by convention
@@ -169,6 +182,8 @@ trait UnityPluginExtension implements UnitySpec,
     Property<String> getDefaultBuildTarget() {
         defaultBuildTarget
     }
+
+    private Property<String> defaultBuildTarget = objects.property(String)
 
     void setDefaultBuildTarget(Provider<String> value) {
         defaultBuildTarget.set(value)


### PR DESCRIPTION
## Description

Adds a convention for the `autoActivate` property (previously named `autoActivateUnity`), so that local developers need not have their license revoked!

## Changes
* ![ADD] Conventions setup for `autoActivate`
* ![ADD] ignore `bin` directory

[NEW]:      https://resources.atlas.wooga.com/icons/icon_new.svg "New"
[ADD]:      https://resources.atlas.wooga.com/icons/icon_add.svg "Add"
[IMPROVE]:  https://resources.atlas.wooga.com/icons/icon_improve.svg "Improve"
[CHANGE]:   https://resources.atlas.wooga.com/icons/icon_change.svg "Change"
[FIX]:      https://resources.atlas.wooga.com/icons/icon_fix.svg "Fix"
[UPDATE]:   https://resources.atlas.wooga.com/icons/icon_update.svg "Update"

[BREAK]:    https://resources.atlas.wooga.com/icons/icon_break.svg "Remove"
[REMOVE]:   https://resources.atlas.wooga.com/icons/icon_remove.svg "Remove"
[IOS]:      https://resources.atlas.wooga.com/icons/icon_iOS.svg "iOS"
[ANDROID]:  https://resources.atlas.wooga.com/icons/icon_android.svg "Android"
[WEBGL]:    https://resources.atlas.wooga.com/icons/icon_webGL.svg "WebGL"
[GRADLE]:   https://resources.atlas.wooga.com/icons/icon_gradle.svg "GRADLE"
[UNITY]:    https://resources.atlas.wooga.com/icons/icon_unity.svg "Unity"
[LINUX]:    https://resources.atlas.wooga.com/icons/icon_linux.svg "Linux"
[WIN]:      https://resources.atlas.wooga.com/icons/icon_windows.svg "Windows"
[MACOS]:    https://resources.atlas.wooga.com/icons/icon_iOS.svg "macOS"
