### PR TITLE
Add task to set the project package resolution strategy

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -52,7 +52,7 @@ github {
 
 dependencies {
 
-    api 'com.wooga.gradle:gradle-commons:[1.6.3,2['
+    api 'com.wooga.gradle:gradle-commons:[1.7.0,2['
     implementation 'org.apache.maven:maven-artifact:3.8.5'
     implementation "org.yaml:snakeyaml:1.30"
     implementation 'net.wooga:unity-version-manager-jni:[1,2['

--- a/src/integrationTest/groovy/wooga/gradle/unity/tasks/CreateProjectTaskIntegrationSpec.groovy
+++ b/src/integrationTest/groovy/wooga/gradle/unity/tasks/CreateProjectTaskIntegrationSpec.groovy
@@ -25,7 +25,7 @@ class CreateProjectTaskIntegrationSpec extends UnityTaskIntegrationSpec<CreatePr
         def projectPath = "Wooga.Foobar"
         buildFile << """
         unity {
-        projectDirectory.set(${wrapValueBasedOnType(projectPath, Directory)})
+            projectDirectory.set(${wrapValueBasedOnType(projectPath, Directory)})
         }
         """.stripIndent()
 

--- a/src/integrationTest/groovy/wooga/gradle/unity/tasks/ProjectManifestTaskSpec.groovy
+++ b/src/integrationTest/groovy/wooga/gradle/unity/tasks/ProjectManifestTaskSpec.groovy
@@ -1,0 +1,33 @@
+package wooga.gradle.unity.tasks
+
+import com.wooga.gradle.test.TaskIntegrationSpec
+import com.wooga.gradle.test.queries.TestValue
+import com.wooga.gradle.test.writers.PropertyGetterTaskWriter
+import com.wooga.gradle.test.writers.PropertySetterWriter
+import spock.lang.Unroll
+import wooga.gradle.unity.UnityIntegrationSpec
+
+abstract class ProjectManifestTaskSpec<T extends ProjectManifestTask>
+    extends UnityIntegrationSpec
+    implements TaskIntegrationSpec<T> {
+
+    @Override
+    String getSubjectUnderTestName() {
+        return "${super.getSubjectUnderTestName()}Test"
+    }
+
+    @Unroll
+    def "can set property #propertyName with #type"() {
+        expect:
+        runPropertyQuery(getter, setter).matches(value)
+
+        where:
+        propertyName          | type                    | value
+        "projectManifestFile" | File                    | TestValue.projectFile("foobar")
+        "projectLockFile"     | File                    | TestValue.projectFile("foobar")
+
+        setter = new PropertySetterWriter(subjectUnderTestName, propertyName)
+            .set(value, type)
+        getter = new PropertyGetterTaskWriter(setter)
+    }
+}

--- a/src/integrationTest/groovy/wooga/gradle/unity/tasks/SetResolutionStrategyTaskIntegrationSpec.groovy
+++ b/src/integrationTest/groovy/wooga/gradle/unity/tasks/SetResolutionStrategyTaskIntegrationSpec.groovy
@@ -1,0 +1,83 @@
+package wooga.gradle.unity.tasks
+
+
+import com.wooga.gradle.test.writers.PropertyGetterTaskWriter
+import com.wooga.gradle.test.writers.PropertySetterWriter
+import com.wooga.spock.extensions.unity.UnityPluginTestOptions
+import groovy.json.JsonOutput
+import groovy.json.JsonSlurper
+import spock.lang.Unroll
+import wooga.gradle.unity.models.ResolutionStrategy
+
+class SetResolutionStrategyTaskIntegrationSpec extends ProjectManifestTaskSpec<SetResolutionStrategy> {
+
+    @Unroll
+    def "can set property #propertyName with #type"() {
+        expect:
+        runPropertyQuery(getter, setter).matches(value)
+
+        where:
+        propertyName         | type   | value
+        "resolutionStrategy" | String | ResolutionStrategy.lowest
+        "resolutionStrategy" | String | ResolutionStrategy.highest
+
+        setter = new PropertySetterWriter(subjectUnderTestName, propertyName)
+            .set(value, type)
+        getter = new PropertyGetterTaskWriter(setter)
+    }
+
+    @UnityPluginTestOptions(forceMockTaskRun = false)
+    def "skips when the resolution strategy is not set"() {
+
+        when:
+        def result = runTasks(subjectUnderTestName)
+
+        then:
+        result.wasSkipped(subjectUnderTestName)
+    }
+
+    @UnityPluginTestOptions(forceMockTaskRun = false)
+    @Unroll
+    def "#verb the resolution strategy #strategy"() {
+
+        given: "an unity project with the manifest file set"
+        def manifestPath = "build/test_project/Packages/manifest.json"
+        def manifestFile = new File(projectDir, manifestPath)
+        manifestFile.parentFile.mkdirs()
+        manifestFile.createNewFile()
+
+        and: "an existing manifest file"
+        def packages = ["com.unity.ugui": "1.0.0"]
+
+        Map<String, Object> manifestContents = [
+            "dependencies": packages
+        ]
+        if (originalStrategy != _) {
+            manifestContents["resolutionStrategy"] = originalStrategy
+        }
+        manifestFile << JsonOutput.toJson(manifestContents)
+
+        and: "task configuration"
+        appendToSubjectTask("""
+                resolutionStrategy = ${wrapValueBasedOnType(strategy, String)}
+                projectManifestFile = ${wrapValueBasedOnType(manifestPath, File)}
+            """.stripIndent()
+        )
+
+        when:
+        runTasksSuccessfully(subjectUnderTestName)
+
+        then: "manifest file contains resolution strategy"
+        def actual = new JsonSlurper().parse(manifestFile)["resolutionStrategy"]
+        actual == strategy
+
+        where:
+        originalStrategy | strategy
+        "katzen"         | "highestMinor"
+        _                | "highestMinor"
+        _                | "lowest"
+        "highest"        | "highestPatch"
+
+        verb = originalStrategy != _ ? "overrides" : "sets"
+    }
+}

--- a/src/main/groovy/wooga/gradle/unity/UnityPluginConventions.groovy
+++ b/src/main/groovy/wooga/gradle/unity/UnityPluginConventions.groovy
@@ -19,6 +19,7 @@ package wooga.gradle.unity
 
 import com.wooga.gradle.PlatformUtils
 import com.wooga.gradle.PropertyLookup
+import wooga.gradle.unity.models.ResolutionStrategy
 import wooga.gradle.unity.utils.UnityFileTree
 
 class UnityPluginConventions {
@@ -127,6 +128,11 @@ class UnityPluginConventions {
      * Automatic unity activation (get/return license)
      */
     static final PropertyLookup autoActivate = new PropertyLookup("UNITY_AUTO_ACTIVATE", "unity.autoActivate", true)
+    /**
+     * For customizing how the Package Manager selects indirect dependencies based on Semantic Versioning rules.
+     * (https://docs.unity3d.com/Manual/upm-manifestPrj.html#resolutionStrategy)
+     */
+    static final PropertyLookup resolutionStrategy = new PropertyLookup(["UNITY_RESOLUTION_STRATEGY", "UPM_RESOLUTION_STRATEGY"], "unity.resolutionStrategy", null)
 
     /**
      * The path to the Unity license directory

--- a/src/main/groovy/wooga/gradle/unity/UnityPluginExtension.groovy
+++ b/src/main/groovy/wooga/gradle/unity/UnityPluginExtension.groovy
@@ -26,17 +26,23 @@ import org.gradle.api.provider.Property
 import org.gradle.api.provider.Provider
 import org.gradle.api.tasks.Internal
 import wooga.gradle.unity.traits.APICompatibilityLevelSpec
+import wooga.gradle.unity.traits.AddUnityPackagesSpec
+import wooga.gradle.unity.traits.ResolutionStrategySpec
 import wooga.gradle.unity.traits.UnityAuthenticationSpec
 import wooga.gradle.unity.traits.UnityCommandLineSpec
 import wooga.gradle.unity.traits.UnityLicenseSpec
+import wooga.gradle.unity.traits.UnityPackageSpec
 import wooga.gradle.unity.traits.UnitySpec
 import wooga.gradle.unity.traits.UnityTestSpec
 
 trait UnityPluginExtension implements UnitySpec,
-        UnityTestSpec,
-        APICompatibilityLevelSpec,
-        UnityLicenseSpec,
-        UnityAuthenticationSpec {
+    UnityTestSpec,
+    APICompatibilityLevelSpec,
+    UnityLicenseSpec,
+    UnityAuthenticationSpec,
+    UnityPackageSpec,
+    AddUnityPackagesSpec,
+    ResolutionStrategySpec {
 
     private final DirectoryProperty logsDir = objects.directoryProperty()
 
@@ -82,6 +88,24 @@ trait UnityPluginExtension implements UnitySpec,
 
     void setAssetsDir(Provider<Directory> value) {
         assetsDir.set(value)
+    }
+
+    private final DirectoryProperty packagesDir = objects.directoryProperty()
+
+    /**
+     * @return The Packages directory, where all resolved packages by an Unity project are recorded
+     */
+    @Internal
+    DirectoryProperty getPackagesDir() {
+        packagesDir
+    }
+
+    void setPackagesDir(Provider<Directory> value) {
+        packagesDir.set(value)
+    }
+
+    void setPackagesDir(File value) {
+        packagesDir.set(value)
     }
 
     private final DirectoryProperty pluginsDir = objects.directoryProperty()
@@ -255,7 +279,7 @@ trait UnityPluginExtension implements UnitySpec,
                 return project.properties.get("unity.testBuildTargets").toString().split(",").collect({
                     it
                 })
-            } else if (!defaultBuildTarget.isPresent() ) {
+            } else if (!defaultBuildTarget.isPresent()) {
                 return new HashSet<String>()
             }
         }
@@ -271,18 +295,5 @@ trait UnityPluginExtension implements UnitySpec,
         }
 
         targets
-    }
-
-    private final MapProperty<String, String> upmPackages = objects.mapProperty(String, String)
-
-    /**
-     * @return The UPM packages to add
-     */
-    MapProperty<String, String> getUpmPackages() {
-        upmPackages
-    }
-
-    void setUpmPackages(MapProperty<String, String> upmPackages) {
-        upmPackages.set(upmPackages)
     }
 }

--- a/src/main/groovy/wooga/gradle/unity/models/ResolutionStrategy.groovy
+++ b/src/main/groovy/wooga/gradle/unity/models/ResolutionStrategy.groovy
@@ -1,0 +1,24 @@
+package wooga.gradle.unity.models
+
+enum ResolutionStrategy {
+    /**
+     * Do not upgrade indirect dependencies. Instead, it uses exactly the requested version. This is the default mode.
+     */
+    lowest,
+    /**
+     * Upgrade to the highest version with the same Major and Minor components.
+     * For example, with the requested version 1.2.3, this strategy selects the highest version in the range
+     * [1.2.3, 1.3.0) (that is, >= 1.2.3 and < 1.3.0).
+     */
+    highestPatch,
+    /**
+     * Upgrade to the highest version with the same Major component. For example, with the requested version 1.2.3,
+     * this strategy selects the highest version in the range [1.2.3, 2.0.0) (that is, >= 1.2.3 and < 2.0.0).
+     */
+    highestMinor,
+    /**
+     * Upgrade to the highest version. For example, with the requested version 1.2.3, this strategy selects the
+     * highest version in the range [1.2.3,) (that is, >= 1.2.3 with no upper bound)
+     */
+    highest
+}

--- a/src/main/groovy/wooga/gradle/unity/models/UnityProjectManifest.groovy
+++ b/src/main/groovy/wooga/gradle/unity/models/UnityProjectManifest.groovy
@@ -1,0 +1,76 @@
+package wooga.gradle.unity.models
+
+import groovy.json.JsonOutput
+import groovy.json.JsonSlurper
+
+class UnityProjectManifest extends HashMap<String, Object> implements GroovyInterceptable {
+
+    UnityProjectManifest(Map<String, Object> map) {
+        this.putAll(map)
+    }
+
+    static UnityProjectManifest deserialize(File file) {
+        Map data = new JsonSlurper().parse(file)
+        new UnityProjectManifest(data)
+    }
+
+    static UnityProjectManifest deserialize(String serialization) {
+        Map data = new JsonSlurper().parseText(serialization)
+        new UnityProjectManifest(data)
+    }
+
+    String serialize() {
+        JsonOutput.prettyPrint(JsonOutput.toJson(this))
+    }
+
+    def propertyMissing(String name, Object value) {
+        this[name] = value
+    }
+
+    def propertyMissing(String name) {
+        this[name]
+    }
+
+    // ResolutionStrategy
+    private static final String resolutionStrategyKey = "resolutionStrategy"
+
+    String getResolutionStrategy() {
+        getOrDefault(resolutionStrategyKey, null)
+    }
+
+    void setResolutionStrategy(String value) {
+        super.put(resolutionStrategyKey, value)
+    }
+
+    void setResolutionStrategy(ResolutionStrategy value) {
+        setResolutionStrategy(value.toString())
+    }
+
+    // Map<String, ?>
+    private static final String dependenciesKey = "dependencies"
+
+    Map getDependencies() {
+        if (!containsKey(dependenciesKey)) {
+            this[dependenciesKey] = [:]
+        }
+
+        (Map)this[dependenciesKey]
+    }
+
+    void setDependencies(Map<String, Object> map) {
+        this[dependenciesKey] = map
+    }
+
+    void addDependencies(Map<String, Object> map) {
+        getDependencies().putAll(map)
+    }
+
+    void addDependency(String key, Object value) {
+        getDependencies()[key] = value
+    }
+}
+
+
+
+
+

--- a/src/main/groovy/wooga/gradle/unity/tasks/ProjectManifestTask.groovy
+++ b/src/main/groovy/wooga/gradle/unity/tasks/ProjectManifestTask.groovy
@@ -1,0 +1,34 @@
+package wooga.gradle.unity.tasks
+
+
+import org.gradle.api.DefaultTask
+import org.gradle.api.tasks.TaskAction
+import wooga.gradle.unity.models.UnityProjectManifest
+import wooga.gradle.unity.traits.UnityPackageSpec
+
+abstract class ProjectManifestTask extends DefaultTask implements
+    UnityPackageSpec {
+
+    final static String manifestFileName = "manifest.json"
+    final static String lockFileName = "packages-lock.json"
+
+    abstract void modifyProjectManifest(UnityProjectManifest manifest)
+
+    @TaskAction
+    void execute() {
+        def manifestFile = projectManifestFile.asFile.getOrNull()
+        if (manifestFile && manifestFile.exists()) {
+            // Deserialize
+            def manifest = UnityProjectManifest.deserialize(manifestFile)
+            // Modify
+            modifyProjectManifest(manifest)
+            // Serialize
+            def serialization = manifest.serialize()
+            manifestFile.write(serialization)
+        } else {
+            project.logger.warn("${manifestFileName} not found, skipping UPM packages install: ${upmPackages.get()}")
+        }
+    }
+}
+
+

--- a/src/main/groovy/wooga/gradle/unity/tasks/SetResolutionStrategy.groovy
+++ b/src/main/groovy/wooga/gradle/unity/tasks/SetResolutionStrategy.groovy
@@ -1,0 +1,22 @@
+package wooga.gradle.unity.tasks
+
+
+import wooga.gradle.unity.models.UnityProjectManifest
+import wooga.gradle.unity.traits.ResolutionStrategySpec
+/**
+ * Sets the project's package resolution strategy by modifying the project manifest
+ */
+class SetResolutionStrategy extends ProjectManifestTask
+    implements ResolutionStrategySpec {
+
+    @Override
+    void modifyProjectManifest(UnityProjectManifest manifest) {
+        manifest.setResolutionStrategy(resolutionStrategy.get())
+    }
+
+    SetResolutionStrategy() {
+        onlyIf {
+            resolutionStrategy.present
+        }
+    }
+}

--- a/src/main/groovy/wooga/gradle/unity/traits/AddUnityPackagesSpec.groovy
+++ b/src/main/groovy/wooga/gradle/unity/traits/AddUnityPackagesSpec.groovy
@@ -1,0 +1,32 @@
+package wooga.gradle.unity.traits
+
+import com.wooga.gradle.BaseSpec
+import org.gradle.api.provider.MapProperty
+import org.gradle.api.provider.Property
+import org.gradle.api.provider.Provider
+import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.Optional
+import wooga.gradle.unity.models.ResolutionStrategy
+
+trait AddUnityPackagesSpec extends BaseSpec {
+
+    /**
+     * @return The UPM packages to be added onto the project manifest
+     */
+    @Input
+    @Optional
+    MapProperty<String, String> getUpmPackages() {
+        upmPackages
+    }
+
+    private final MapProperty<String, String> upmPackages = objects.mapProperty(String, String)
+
+    void setUpmPackages(MapProperty<String, String> values) {
+        upmPackages.set(values)
+    }
+
+    void setUpmPackages(Map<String, String> values) {
+        upmPackages.set(values)
+    }
+}
+

--- a/src/main/groovy/wooga/gradle/unity/traits/ResolutionStrategySpec.groovy
+++ b/src/main/groovy/wooga/gradle/unity/traits/ResolutionStrategySpec.groovy
@@ -1,0 +1,28 @@
+package wooga.gradle.unity.traits
+
+import com.wooga.gradle.BaseSpec
+import org.gradle.api.provider.Property
+import org.gradle.api.provider.Provider
+import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.Optional
+import wooga.gradle.unity.models.ResolutionStrategy
+
+trait ResolutionStrategySpec extends BaseSpec {
+
+    private final Property<ResolutionStrategy> resolutionStrategy = objects.property(ResolutionStrategy)
+
+    @Input
+    @Optional
+    Property<ResolutionStrategy> getResolutionStrategy() {
+        resolutionStrategy
+    }
+
+    void setResolutionStrategy(Provider<ResolutionStrategy> value) {
+        resolutionStrategy.set(value)
+    }
+
+    void setResolutionStrategy(String value) {
+        resolutionStrategy.set(ResolutionStrategy.valueOf(value))
+    }
+
+}

--- a/src/main/groovy/wooga/gradle/unity/traits/UnityPackageSpec.groovy
+++ b/src/main/groovy/wooga/gradle/unity/traits/UnityPackageSpec.groovy
@@ -1,0 +1,47 @@
+package wooga.gradle.unity.traits
+
+import com.wooga.gradle.BaseSpec
+import org.gradle.api.file.RegularFile
+import org.gradle.api.file.RegularFileProperty
+import org.gradle.api.provider.Provider
+import org.gradle.api.tasks.Internal
+
+trait UnityPackageSpec extends BaseSpec {
+
+    /**
+     * @return The project manifest file (manifest.json), which manages UPM packages
+     */
+    @Internal
+    RegularFileProperty getProjectManifestFile() {
+        return projectManifestFile
+    }
+
+    private final RegularFileProperty projectManifestFile = objects.fileProperty()
+
+    void setProjectManifestFile(File value) {
+        this.projectManifestFile.set(value)
+    }
+
+    void setProjectManifestFile(Provider<RegularFile> value) {
+        this.projectManifestFile.set(value)
+    }
+
+    private final RegularFileProperty projectLockFile = objects.fileProperty()
+
+    /**
+     * @return The project package lock file (packages-lock.json), where the resolved UPM packages are recorded
+     */
+    @Internal
+    RegularFileProperty getProjectLockFile() {
+        projectLockFile
+    }
+
+    void setProjectLockFile(Provider<RegularFile> value) {
+        projectLockFile.set(value)
+    }
+
+    void setProjectLockFile(File value) {
+        projectLockFile.set(value)
+    }
+
+}

--- a/src/main/groovy/wooga/gradle/unity/traits/UnitySpec.groovy
+++ b/src/main/groovy/wooga/gradle/unity/traits/UnitySpec.groovy
@@ -17,6 +17,7 @@
 package wooga.gradle.unity.traits
 
 import com.wooga.gradle.BaseSpec
+import org.apache.maven.artifact.versioning.ArtifactVersion
 import org.gradle.api.file.Directory
 import org.gradle.api.file.DirectoryProperty
 import org.gradle.api.file.RegularFile
@@ -30,6 +31,7 @@ import org.gradle.api.tasks.OutputFile
 import wooga.gradle.unity.UnityPluginConventions
 import wooga.gradle.unity.utils.ProjectSettingsFile
 import wooga.gradle.unity.utils.UnityFileTree
+import wooga.gradle.unity.utils.UnityVersionManager
 
 trait UnitySpec extends BaseSpec {
 

--- a/src/test/groovy/wooga/gradle/unity/UnityPluginTest.groovy
+++ b/src/test/groovy/wooga/gradle/unity/UnityPluginTest.groovy
@@ -19,7 +19,6 @@ package wooga.gradle.unity
 
 import nebula.test.ProjectSpec
 import org.gradle.api.DefaultTask
-import org.gradle.api.Task
 import spock.lang.Unroll
 import wooga.gradle.unity.internal.DefaultUnityPluginExtension
 import wooga.gradle.unity.tasks.AddUPMPackages
@@ -81,8 +80,8 @@ class UnityPluginTest extends ProjectSpec {
         def task = project.tasks.findByName(UnityPlugin.Tasks.addUPMPackages.toString()) as AddUPMPackages
         def packages = task.upmPackages.get()
         and: "task has a manifest file"
-        task.manifestPath.present
-        task.manifestPath.get().asFile == new File(projectDir, "Packages/manifest.json")
+        task.projectManifestFile.present
+        task.projectManifestFile.get().asFile == new File(projectDir, "Packages/manifest.json")
         and: "task contains expected packages"
         packages.entrySet().containsAll(extUPMPackages.entrySet())
         if (coverageEnabled) {


### PR DESCRIPTION
## Description
Adds task to modify the project package resolution strategy, `setResolutionStrategy`, according to this:
(https://docs.unity3d.com/Manual/upm-manifestPrj.html#resolutionStrategy)

The task class derives from a base `ProjectManifestTask`, which is now shared with the existing `AddUpmPackages` task that was previously implemented. 

## Changes
* ![ADD] `setResolutionStrategy` plugin task
* ![IMPROVE] `AddUPMPackages` task base layout into a base task, `ProjectManifestTask`

[NEW]:      https://resources.atlas.wooga.com/icons/icon_new.svg "New"
[ADD]:      https://resources.atlas.wooga.com/icons/icon_add.svg "Add"
[IMPROVE]:  https://resources.atlas.wooga.com/icons/icon_improve.svg "Improve"
[CHANGE]:   https://resources.atlas.wooga.com/icons/icon_change.svg "Change"
[FIX]:      https://resources.atlas.wooga.com/icons/icon_fix.svg "Fix"
[UPDATE]:   https://resources.atlas.wooga.com/icons/icon_update.svg "Update"

[BREAK]:    https://resources.atlas.wooga.com/icons/icon_break.svg "Remove"
[REMOVE]:   https://resources.atlas.wooga.com/icons/icon_remove.svg "Remove"
[IOS]:      https://resources.atlas.wooga.com/icons/icon_iOS.svg "iOS"
[ANDROID]:  https://resources.atlas.wooga.com/icons/icon_android.svg "Android"
[WEBGL]:    https://resources.atlas.wooga.com/icons/icon_webGL.svg "WebGL"
[GRADLE]:   https://resources.atlas.wooga.com/icons/icon_gradle.svg "GRADLE"
[UNITY]:    https://resources.atlas.wooga.com/icons/icon_unity.svg "Unity"
[LINUX]:    https://resources.atlas.wooga.com/icons/icon_linux.svg "Linux"
[WIN]:      https://resources.atlas.wooga.com/icons/icon_windows.svg "Windows"
[MACOS]:    https://resources.atlas.wooga.com/icons/icon_iOS.svg "macOS"
