### PR TITLE
Remove exclusion of Samples~ folder from copy task

### DIFF
--- a/settings.gradle
+++ b/settings.gradle
@@ -21,6 +21,8 @@ include 'shared'
 include 'api'
 include 'services:webservice'
 */
+import org.apache.tools.ant.DirectoryScanner
+
 pluginManagement {
   repositories {
     mavenCentral()
@@ -29,3 +31,6 @@ pluginManagement {
 }
 
 rootProject.name = 'unity'
+
+DirectoryScanner.defaultExcludes.each { if (it.endsWith("~")) {DirectoryScanner.removeDefaultExclude it} }
+

--- a/src/main/groovy/wooga/gradle/unity/tasks/GenerateUpmPackage.groovy
+++ b/src/main/groovy/wooga/gradle/unity/tasks/GenerateUpmPackage.groovy
@@ -15,7 +15,6 @@ import org.gradle.api.tasks.*
 import org.gradle.api.tasks.bundling.Compression
 import org.gradle.api.tasks.bundling.Tar
 import wooga.gradle.unity.traits.GenerateUpmPackageSpec
-import org.apache.tools.ant.DirectoryScanner
 /**
  * A task that will generate an UPM package from a given Unity project
  */
@@ -123,9 +122,6 @@ class GenerateUpmPackage extends Tar implements BaseSpec, GenerateUpmPackageSpec
             logger.warn(Message.packageDirectoryNotSet.message)
         }
 
-        // We need this workaround - to clear the defaultExcludes, because of this gradle issue: https://issues.gradle.org/browse/GRADLE-1883
-        // ...because we have a Samples~ folder
-        DirectoryScanner.defaultExcludes.each { if (it.endsWith("~")) {DirectoryScanner.removeDefaultExclude it} }
         project.copy {
             from(packageDirectory)
             include(packageManifestFileName)
@@ -136,7 +132,6 @@ class GenerateUpmPackage extends Tar implements BaseSpec, GenerateUpmPackageSpec
 
         from(temporaryDir)
         from(packageDirectory)
-        DirectoryScanner.resetDefaultExcludes()
         super.copy()
     }
 

--- a/src/main/groovy/wooga/gradle/unity/tasks/GenerateUpmPackage.groovy
+++ b/src/main/groovy/wooga/gradle/unity/tasks/GenerateUpmPackage.groovy
@@ -15,6 +15,7 @@ import org.gradle.api.tasks.*
 import org.gradle.api.tasks.bundling.Compression
 import org.gradle.api.tasks.bundling.Tar
 import wooga.gradle.unity.traits.GenerateUpmPackageSpec
+import org.apache.tools.ant.DirectoryScanner
 /**
  * A task that will generate an UPM package from a given Unity project
  */
@@ -122,6 +123,9 @@ class GenerateUpmPackage extends Tar implements BaseSpec, GenerateUpmPackageSpec
             logger.warn(Message.packageDirectoryNotSet.message)
         }
 
+        // We need this workaround - to clear the defaultExcludes, because of this gradle issue: https://issues.gradle.org/browse/GRADLE-1883
+        // ...because we have a Samples~ folder
+        DirectoryScanner.defaultExcludes.each { if (it.endsWith("~")) {DirectoryScanner.removeDefaultExclude it} }
         project.copy {
             from(packageDirectory)
             include(packageManifestFileName)
@@ -132,6 +136,7 @@ class GenerateUpmPackage extends Tar implements BaseSpec, GenerateUpmPackageSpec
 
         from(temporaryDir)
         from(packageDirectory)
+        DirectoryScanner.resetDefaultExcludes()
         super.copy()
     }
 


### PR DESCRIPTION
## Description
To include samples in unity packages, they need to have a special name. We need to implement samples the "unity way" because otherwise scene cannot be opened. This PR is only concerned about the possibility of adding samples, the sample integration must happen in the WDK.

## Changes
* ![CHANGE] Folders ending with "~" are now copied instead of being ignored

[NEW]:      https://resources.atlas.wooga.com/icons/icon_new.svg "New"
[ADD]:      https://resources.atlas.wooga.com/icons/icon_add.svg "Add"
[IMPROVE]:  https://resources.atlas.wooga.com/icons/icon_improve.svg "Improve"
[CHANGE]:   https://resources.atlas.wooga.com/icons/icon_change.svg "Change"
[FIX]:      https://resources.atlas.wooga.com/icons/icon_fix.svg "Fix"
[UPDATE]:   https://resources.atlas.wooga.com/icons/icon_update.svg "Update"

[BREAK]:    https://resources.atlas.wooga.com/icons/icon_break.svg "Remove"
[REMOVE]:   https://resources.atlas.wooga.com/icons/icon_remove.svg "Remove"
[IOS]:      https://resources.atlas.wooga.com/icons/icon_iOS.svg "iOS"
[ANDROID]:  https://resources.atlas.wooga.com/icons/icon_android.svg "Android"
[WEBGL]:    https://resources.atlas.wooga.com/icons/icon_webGL.svg "WebGL"
[GRADLE]:   https://resources.atlas.wooga.com/icons/icon_gradle.svg "GRADLE"
[UNITY]:    https://resources.atlas.wooga.com/icons/icon_unity.svg "Unity"
[LINUX]:    https://resources.atlas.wooga.com/icons/icon_linux.svg "Linux"
[WIN]:      https://resources.atlas.wooga.com/icons/icon_windows.svg "Windows"
[MACOS]:    https://resources.atlas.wooga.com/icons/icon_iOS.svg "macOS"
