### PR TITLE
Fix GenerateUpmPackage clearing dependencies

### DIFF
--- a/src/integrationTest/groovy/wooga/gradle/unity/tasks/GenerateUpmPackageTaskIntegrationSpec.groovy
+++ b/src/integrationTest/groovy/wooga/gradle/unity/tasks/GenerateUpmPackageTaskIntegrationSpec.groovy
@@ -316,17 +316,19 @@ class GenerateUpmPackageTaskIntegrationSpec extends UnityIntegrationSpec {
         """.stripIndent()
 
         projectFile(projectPath, "README.MD")
+        def builder = new PackageManifestBuilder()
+        builder.dependencies.put(dependency1, "0.0.0")
+        builder.dependencies.put(dependency2, "0.0.0")
+        builder.dependencies.put(dependency3, "0.0.0")
+
         def manifestFile = projectFile(projectPath, GenerateUpmPackage.packageManifestFileName)
-        manifestFile.write(new PackageManifestBuilder().build())
+        manifestFile.write(builder.build())
 
         and:
         addTask(taskName, GenerateUpmPackage.class.name, false, """
         packageDirectory.set(${wrapValueBasedOnType(projectPath, Directory)})
         archiveVersion.set(${wrapValueBasedOnType(packageVersion, String)})
         packageName = ${wrapValueBasedOnType(packageName, String)}
-
-        dependencies[${wrapValueBasedOnType(dependency1, String)}] = "0.0.0"
-        dependencies[${wrapValueBasedOnType(dependency2, String)}] = "0.0.0"
 
         patchDependency(${wrapValueBasedOnType(dep, String)}, ${wrapValueBasedOnType(input, type)})
 
@@ -343,7 +345,10 @@ class GenerateUpmPackageTaskIntegrationSpec extends UnityIntegrationSpec {
         if (expected == _) {
             expected = input
         }
-        manifest["dependencies"][dep] == expected
+
+        def dependenciesMap = manifest["dependencies"] as Map
+        dependenciesMap.size() == 3
+        dependenciesMap[dep] == expected
 
         where:
         dep             | input   | type               | expected
@@ -358,6 +363,7 @@ class GenerateUpmPackageTaskIntegrationSpec extends UnityIntegrationSpec {
 
         dependency1 = "com.wooga.foo"
         dependency2 = "com.wooga.bar"
+        dependency3 = "com.wooga.foobar"
     }
 
     private File getPackageFile(String name, String version) {

--- a/src/main/groovy/wooga/gradle/unity/tasks/GenerateUpmPackage.groovy
+++ b/src/main/groovy/wooga/gradle/unity/tasks/GenerateUpmPackage.groovy
@@ -235,7 +235,11 @@ class GenerateUpmPackage extends Tar implements BaseSpec {
             }
 
             if (dependencies.present) {
-                manifestContent['dependencies'] = dependencies.get()
+                Map additions = dependencies.get()
+                if (additions.size() > 0) {
+                    Map previous = manifestContent['dependencies'] as Map
+                    manifestContent['dependencies'] = merge(previous, additions)
+                }
             }
 
             def _patches = patches.get().collectEntries {
@@ -291,8 +295,8 @@ class GenerateUpmPackage extends Tar implements BaseSpec {
                 Object value = null
                 // Unwrap Provider if needed
                 if (entry.value instanceof Provider) {
-                    value = ((Provider)entry.value).get()
-                } else{
+                    value = ((Provider) entry.value).get()
+                } else {
                     value = entry.value
                 }
                 map[entry.key] = value

--- a/src/main/groovy/wooga/gradle/unity/utils/PackageManifestBuilder.groovy
+++ b/src/main/groovy/wooga/gradle/unity/utils/PackageManifestBuilder.groovy
@@ -13,6 +13,7 @@ class PackageManifestBuilder {
     String version = ""
     String displayName = ""
     String description = ""
+    Map<String, String> dependencies = new HashMap<String, String>()
 
     PackageManifestBuilder() {
     }


### PR DESCRIPTION
## Description
Dependencies were being cleared by the `GenerateUpmPackage` task due a missing merge.

## Changes
* ![FIX] `GenerateUpmPackage` dependencies being cleared

[NEW]:      https://resources.atlas.wooga.com/icons/icon_new.svg "New"
[ADD]:      https://resources.atlas.wooga.com/icons/icon_add.svg "Add"
[IMPROVE]:  https://resources.atlas.wooga.com/icons/icon_improve.svg "Improve"
[CHANGE]:   https://resources.atlas.wooga.com/icons/icon_change.svg "Change"
[FIX]:      https://resources.atlas.wooga.com/icons/icon_fix.svg "Fix"
[UPDATE]:   https://resources.atlas.wooga.com/icons/icon_update.svg "Update"

[BREAK]:    https://resources.atlas.wooga.com/icons/icon_break.svg "Remove"
[REMOVE]:   https://resources.atlas.wooga.com/icons/icon_remove.svg "Remove"
[IOS]:      https://resources.atlas.wooga.com/icons/icon_iOS.svg "iOS"
[ANDROID]:  https://resources.atlas.wooga.com/icons/icon_android.svg "Android"
[WEBGL]:    https://resources.atlas.wooga.com/icons/icon_webGL.svg "WebGL"
[GRADLE]:   https://resources.atlas.wooga.com/icons/icon_gradle.svg "GRADLE"
[UNITY]:    https://resources.atlas.wooga.com/icons/icon_unity.svg "Unity"
[LINUX]:    https://resources.atlas.wooga.com/icons/icon_linux.svg "Linux"
[WIN]:      https://resources.atlas.wooga.com/icons/icon_windows.svg "Windows"
[MACOS]:    https://resources.atlas.wooga.com/icons/icon_iOS.svg "macOS"
