### PR TITLE
Adds an interface for generating the upm package

### DIFF
--- a/src/main/groovy/wooga/gradle/unity/tasks/GenerateUpmPackage.groovy
+++ b/src/main/groovy/wooga/gradle/unity/tasks/GenerateUpmPackage.groovy
@@ -7,26 +7,18 @@ import org.gradle.api.file.Directory
 import org.gradle.api.file.DirectoryProperty
 import org.gradle.api.file.FileCollection
 import org.gradle.api.file.RegularFile
-import org.gradle.api.provider.ListProperty
 import org.gradle.api.provider.MapProperty
 import org.gradle.api.provider.Property
 import org.gradle.api.provider.Provider
 import org.gradle.api.specs.Spec
-import org.gradle.api.tasks.Input
-import org.gradle.api.tasks.InputDirectory
-import org.gradle.api.tasks.InputFile
-import org.gradle.api.tasks.InputFiles
-import org.gradle.api.tasks.Internal
-import org.gradle.api.tasks.Optional
-import org.gradle.api.tasks.SkipWhenEmpty
+import org.gradle.api.tasks.*
 import org.gradle.api.tasks.bundling.Compression
 import org.gradle.api.tasks.bundling.Tar
-import org.gradle.internal.impldep.com.google.common.collect.ImmutableMap
-
+import wooga.gradle.unity.traits.GenerateUpmPackageSpec
 /**
  * A task that will generate an UPM package from a given Unity project
  */
-class GenerateUpmPackage extends Tar implements BaseSpec {
+class GenerateUpmPackage extends Tar implements BaseSpec, GenerateUpmPackageSpec {
 
     /**
      * A custom message that is presented when the packaging task fails
@@ -49,24 +41,6 @@ class GenerateUpmPackage extends Tar implements BaseSpec {
     }
 
     /**
-     * @return The directory where the package source files are located
-     */
-    @InputDirectory
-    DirectoryProperty getPackageDirectory() {
-        packageDirectory
-    }
-
-    private final DirectoryProperty packageDirectory = project.objects.directoryProperty()
-
-    void setPackageDirectory(Provider<Directory> value) {
-        packageDirectory.set(value)
-    }
-
-    void setPackageDirectory(File value) {
-        packageDirectory.set(value)
-    }
-
-    /**
      * @return All files in the package, if present
      */
     @SkipWhenEmpty
@@ -77,58 +51,6 @@ class GenerateUpmPackage extends Tar implements BaseSpec {
         }
         project.files()
     }
-
-    /**
-     * @return The package manifest file, `package.json`, which defines the package dependencies and other metadata.
-     */
-    @Internal("part of packageFiles")
-    Provider<RegularFile> getPackageManifestFile() {
-        packageManifestFile
-    }
-
-    private final Provider<RegularFile> packageManifestFile = packageDirectory.file(packageManifestFileName)
-
-    /**
-     * @return The officially registered package name. This name must conform to the Unity Package Manager naming convention,
-     * which uses reverse domain name notation.
-     */
-    @Input
-    @Optional
-    Provider<String> getPackageName() {
-        packageName
-    }
-
-    private final Property<String> packageName = objects.property(String)
-
-    void setPackageName(Provider<String> value) {
-        packageName.set(value)
-    }
-
-    void setPackageName(String value) {
-        packageName.set(value)
-    }
-
-    /**
-     * @return Optional dependencies to set
-     */
-    @Input
-    @Optional
-    MapProperty<String, String> getDependencies() {
-        dependencies
-    }
-
-    private MapProperty<String, String> dependencies = objects.mapProperty(String, String)
-
-    /**
-     * @return Optional patches to be applied onto the manifest before it is packaged
-     */
-    @Input
-    @Optional
-    MapProperty<String, Object> getPatches() {
-        patches
-    }
-
-    private MapProperty<String, Object> patches = objects.mapProperty(String, Object)
 
     /**
      * The default file name for the package manifest, as decided by Unity
@@ -258,31 +180,11 @@ class GenerateUpmPackage extends Tar implements BaseSpec {
         }
     }
 
-    /**
-     * Patches the version of a single dependency in the manifest
-     * @param name The name of the package
-     * @param version The version to set
-     */
-    void patchDependency(String name, Object version) {
-        def key = "dependencies"
-        if (!patches.get().containsKey(key)) {
-            patches[key] = new HashMap<String, Object>()
-        }
 
-        def dependencies = patches[key].get() as Map
-        dependencies[name] = version
-    }
 
     /**
-     * Patches a single property in the manifest
-     * @param key The property to patch
-     * @param value The value to set
+     * @return The merged contents of two maps
      */
-    void patch(String key, Object value) {
-        def provider = providers.provider({ value })
-        patches.put(key, provider)
-    }
-
     private static Map merge(Map lhs, Map rhs) {
 
         // Have to do this since we cannot clone an ImmutableMap

--- a/src/main/groovy/wooga/gradle/unity/traits/GenerateUpmPackageSpec.groovy
+++ b/src/main/groovy/wooga/gradle/unity/traits/GenerateUpmPackageSpec.groovy
@@ -1,0 +1,122 @@
+package wooga.gradle.unity.traits
+
+import com.wooga.gradle.BaseSpec
+import org.gradle.api.file.Directory
+import org.gradle.api.file.DirectoryProperty
+import org.gradle.api.file.FileCollection
+import org.gradle.api.file.RegularFile
+import org.gradle.api.provider.MapProperty
+import org.gradle.api.provider.Property
+import org.gradle.api.provider.Provider
+import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.InputDirectory
+import org.gradle.api.tasks.InputFiles
+import org.gradle.api.tasks.Internal
+import org.gradle.api.tasks.Optional
+import org.gradle.api.tasks.SkipWhenEmpty
+import wooga.gradle.unity.tasks.GenerateUpmPackage
+
+// TODO: Had issues in making this a trait rather than interface
+/**
+ * Generates an UPM package with optional configuration of its manifest
+ */
+trait GenerateUpmPackageSpec extends BaseSpec {
+
+/**
+ * @return The directory where the package source files are located
+ */
+    @InputDirectory
+    DirectoryProperty getPackageDirectory() {
+        packageDirectory
+    }
+
+    private final DirectoryProperty packageDirectory = objects.directoryProperty()
+
+    void setPackageDirectory(Provider<Directory> value) {
+        packageDirectory.set(value)
+    }
+
+    void setPackageDirectory(File value) {
+        packageDirectory.set(value)
+    }
+
+    /**
+     * @return The package manifest file, `package.json`, which defines the package dependencies and other metadata.
+     */
+    @Internal("part of packageFiles")
+    Provider<RegularFile> getPackageManifestFile() {
+        if (packageManifestFile == null) {
+            packageManifestFile =  packageDirectory.file(GenerateUpmPackage.packageManifestFileName)
+        }
+        packageManifestFile
+    }
+    private Provider<RegularFile> packageManifestFile
+
+    /**
+     * @return The officially registered package name. This name must conform to the Unity Package Manager naming convention,
+     * which uses reverse domain name notation.
+     */
+    @Input
+    @Optional
+    Provider<String> getPackageName() {
+        packageName
+    }
+
+    private final Property<String> packageName = objects.property(String)
+
+    void setPackageName(Provider<String> value) {
+        packageName.set(value)
+    }
+
+    void setPackageName(String value) {
+        packageName.set(value)
+    }
+
+    /**
+     * @return Optional dependencies to set
+     */
+    @Input
+    @Optional
+    MapProperty<String, String> getDependencies() {
+        dependencies
+    }
+
+    private MapProperty<String, String> dependencies = objects.mapProperty(String, String)
+
+    /**
+     * @return Optional patches to be applied onto the manifest before it is packaged
+     */
+    @Input
+    @Optional
+    MapProperty<String, Object> getPatches() {
+        patches
+    }
+
+    private MapProperty<String, Object> patches = objects.mapProperty(String, Object)
+
+    /**
+     * Patches the version of a single dependency in the manifest
+     * @param name The name of the package
+     * @param version The version to set
+     */
+    void patchDependency(String name, Object version) {
+        def key = "dependencies"
+        if (!patches.get().containsKey(key)) {
+            patches[key] = new HashMap<String, Object>()
+        }
+
+        def dependencies = patches[key].get() as Map
+        dependencies[name] = version
+    }
+
+    /**
+     * Patches a single property in the manifest
+     * @param key The property to patch
+     * @param value The value to set
+     */
+    void patch(String key, Object value) {
+        def provider = providers.provider({ value })
+        patches.put(key, provider)
+    }
+
+}


### PR DESCRIPTION
## Description
Adds an interface for generating the upm package on the existing task. This is to expose closures on it without having to expose the whole `Task` API.

## Changes
* ![ADD] `GenerateUpmPackageSpec`

[NEW]:      https://resources.atlas.wooga.com/icons/icon_new.svg "New"
[ADD]:      https://resources.atlas.wooga.com/icons/icon_add.svg "Add"
[IMPROVE]:  https://resources.atlas.wooga.com/icons/icon_improve.svg "Improve"
[CHANGE]:   https://resources.atlas.wooga.com/icons/icon_change.svg "Change"
[FIX]:      https://resources.atlas.wooga.com/icons/icon_fix.svg "Fix"
[UPDATE]:   https://resources.atlas.wooga.com/icons/icon_update.svg "Update"

[BREAK]:    https://resources.atlas.wooga.com/icons/icon_break.svg "Remove"
[REMOVE]:   https://resources.atlas.wooga.com/icons/icon_remove.svg "Remove"
[IOS]:      https://resources.atlas.wooga.com/icons/icon_iOS.svg "iOS"
[ANDROID]:  https://resources.atlas.wooga.com/icons/icon_android.svg "Android"
[WEBGL]:    https://resources.atlas.wooga.com/icons/icon_webGL.svg "WebGL"
[GRADLE]:   https://resources.atlas.wooga.com/icons/icon_gradle.svg "GRADLE"
[UNITY]:    https://resources.atlas.wooga.com/icons/icon_unity.svg "Unity"
[LINUX]:    https://resources.atlas.wooga.com/icons/icon_linux.svg "Linux"
[WIN]:      https://resources.atlas.wooga.com/icons/icon_windows.svg "Windows"
[MACOS]:    https://resources.atlas.wooga.com/icons/icon_iOS.svg "macOS"
