### PR TITLE
Replace Tar packer [ATLAS-1334]

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -56,6 +56,7 @@ dependencies {
     implementation 'org.apache.maven:maven-artifact:3.8.5'
     implementation "org.yaml:snakeyaml:1.30"
     implementation 'net.wooga:unity-version-manager-jni:[1,2['
+    implementation 'org.apache.commons:commons-compress:1.24.0'
 
     testImplementation('org.jfrog.artifactory.client:artifactory-java-client-services:+') {
         exclude module: 'logback-classic'

--- a/src/integrationTest/groovy/wooga/gradle/unity/testutils/SetupProjectLayoutTestTask.groovy
+++ b/src/integrationTest/groovy/wooga/gradle/unity/testutils/SetupProjectLayoutTestTask.groovy
@@ -62,20 +62,24 @@ class SetupProjectLayoutTestTask extends DefaultTask {
 
         def runtimeDirectory = new File(packageDir.path, "Runtime")
         runtimeDirectory.mkdir()
-        def runtimeSource = new File(runtimeDirectory.path, "${packageDisplayName}.cs")
-        runtimeSource.write("""\
+        [0..10000].each {
+            def runtimeSource = new File(runtimeDirectory.path, "${packageDisplayName}${it}.cs")
+            runtimeSource.write("""\
             using System;
-            public class ${packageDisplayName} {
+            public class ${packageDisplayName}${it} {
             }
         """.stripIndent())
+        }
 
         def editorDirectory = new File(packageDir.path, "Editor")
         editorDirectory.mkdir()
-        def editorSource = new File(editorDirectory.path, "${packageDisplayName}Editor.cs")
-        editorSource.write("""\
+        [0..10000].each {
+            def editorSource = new File(editorDirectory.path, "${packageDisplayName}${it}Editor.cs")
+            editorSource.write("""\
             using System;
-            public class ${packageDisplayName}Editor {
+            public class ${packageDisplayName}${it}Editor {
             }
         """.stripIndent())
+        }
     }
 }

--- a/src/integrationTest/groovy/wooga/gradle/unity/testutils/SetupProjectLayoutTestTask.groovy
+++ b/src/integrationTest/groovy/wooga/gradle/unity/testutils/SetupProjectLayoutTestTask.groovy
@@ -63,10 +63,10 @@ class SetupProjectLayoutTestTask extends DefaultTask {
         def runtimeDirectory = new File(packageDir.path, "Runtime")
         runtimeDirectory.mkdir()
         [0..10000].each {
-            def runtimeSource = new File(runtimeDirectory.path, "${packageDisplayName}${it}.cs")
+            def runtimeSource = new File(runtimeDirectory.path, "${packageDisplayName}${it.iterator()}.cs")
             runtimeSource.write("""\
             using System;
-            public class ${packageDisplayName}${it} {
+            public class ${packageDisplayName}${it.iterator()} {
             }
         """.stripIndent())
         }
@@ -74,10 +74,10 @@ class SetupProjectLayoutTestTask extends DefaultTask {
         def editorDirectory = new File(packageDir.path, "Editor")
         editorDirectory.mkdir()
         [0..10000].each {
-            def editorSource = new File(editorDirectory.path, "${packageDisplayName}${it}Editor.cs")
+            def editorSource = new File(editorDirectory.path, "${packageDisplayName}${it.iterator()}Editor.cs")
             editorSource.write("""\
             using System;
-            public class ${packageDisplayName}${it}Editor {
+            public class ${packageDisplayName}${it.iterator()}Editor {
             }
         """.stripIndent())
         }

--- a/src/integrationTest/groovy/wooga/gradle/unity/testutils/SetupProjectLayoutTestTask.groovy
+++ b/src/integrationTest/groovy/wooga/gradle/unity/testutils/SetupProjectLayoutTestTask.groovy
@@ -62,22 +62,22 @@ class SetupProjectLayoutTestTask extends DefaultTask {
 
         def runtimeDirectory = new File(packageDir.path, "Runtime")
         runtimeDirectory.mkdir()
-        [0..10000].each {
-            def runtimeSource = new File(runtimeDirectory.path, "${packageDisplayName}${it.iterator()}.cs")
+        (0..10000).each {
+            def runtimeSource = new File(runtimeDirectory.path, "${packageDisplayName}${it}.cs")
             runtimeSource.write("""\
             using System;
-            public class ${packageDisplayName}${it.iterator()} {
+            public class ${packageDisplayName}${it} {
             }
         """.stripIndent())
         }
 
         def editorDirectory = new File(packageDir.path, "Editor")
         editorDirectory.mkdir()
-        [0..10000].each {
-            def editorSource = new File(editorDirectory.path, "${packageDisplayName}${it.iterator()}Editor.cs")
+        (0..10000).each {
+            def editorSource = new File(editorDirectory.path, "${packageDisplayName}${it}Editor.cs")
             editorSource.write("""\
             using System;
-            public class ${packageDisplayName}${it.iterator()}Editor {
+            public class ${packageDisplayName}${it}Editor {
             }
         """.stripIndent())
         }

--- a/src/integrationTest/groovy/wooga/gradle/unity/testutils/SetupProjectLayoutTestTask.groovy
+++ b/src/integrationTest/groovy/wooga/gradle/unity/testutils/SetupProjectLayoutTestTask.groovy
@@ -62,24 +62,20 @@ class SetupProjectLayoutTestTask extends DefaultTask {
 
         def runtimeDirectory = new File(packageDir.path, "Runtime")
         runtimeDirectory.mkdir()
-        (0..10000).each {
-            def runtimeSource = new File(runtimeDirectory.path, "${packageDisplayName}${it}.cs")
-            runtimeSource.write("""\
+        def runtimeSource = new File(runtimeDirectory.path, "${packageDisplayName}.cs")
+        runtimeSource.write("""\
             using System;
-            public class ${packageDisplayName}${it} {
+            public class ${packageDisplayName} {
             }
         """.stripIndent())
-        }
 
         def editorDirectory = new File(packageDir.path, "Editor")
         editorDirectory.mkdir()
-        (0..10000).each {
-            def editorSource = new File(editorDirectory.path, "${packageDisplayName}${it}Editor.cs")
-            editorSource.write("""\
+        def editorSource = new File(editorDirectory.path, "${packageDisplayName}Editor.cs")
+        editorSource.write("""\
             using System;
-            public class ${packageDisplayName}${it}Editor {
+            public class ${packageDisplayName}Editor {
             }
         """.stripIndent())
-        }
     }
 }

--- a/src/main/groovy/wooga/gradle/unity/tasks/GenerateUpmPackage.groovy
+++ b/src/main/groovy/wooga/gradle/unity/tasks/GenerateUpmPackage.groovy
@@ -4,21 +4,14 @@ import com.wooga.gradle.BaseSpec
 import groovy.json.JsonOutput
 import groovy.json.JsonSlurper
 
-import org.gradle.api.DefaultTask
-import org.gradle.api.file.Directory
-import org.gradle.api.file.DirectoryProperty
 import org.gradle.api.file.FileCollection
-import org.gradle.api.file.RegularFile
 import org.gradle.api.internal.file.copy.CopyAction
-import org.gradle.api.provider.MapProperty
-import org.gradle.api.provider.Property
 import org.gradle.api.provider.Provider
 import org.gradle.api.specs.Spec
 import org.gradle.api.tasks.*
 import org.gradle.api.tasks.bundling.AbstractArchiveTask
-import org.gradle.api.tasks.bundling.Compression
-import org.gradle.api.tasks.bundling.Tar
 import wooga.gradle.unity.traits.GenerateUpmPackageSpec
+
 import org.apache.commons.compress.archivers.tar.TarArchiveEntry
 import org.apache.commons.compress.archivers.tar.TarArchiveOutputStream
 import org.apache.commons.compress.compressors.gzip.GzipCompressorOutputStream

--- a/src/main/groovy/wooga/gradle/unity/tasks/GenerateUpmPackage.groovy
+++ b/src/main/groovy/wooga/gradle/unity/tasks/GenerateUpmPackage.groovy
@@ -59,12 +59,6 @@ class GenerateUpmPackage extends AbstractArchiveTask implements BaseSpec, Genera
     public static final packageManifestFileName = "package.json"
 
     GenerateUpmPackage() {
-
-        //setCompression(Compression.GZIP)
-
-        // Creates a root directory inside the package
-        //into("package")
-        // The name of the package, in reverse domain name notation
         Provider<String> packageNameOnFile = packageManifestFile.map({
             def slurper = new JsonSlurper()
             if (!it.asFile.exists()) {
@@ -85,14 +79,6 @@ class GenerateUpmPackage extends AbstractArchiveTask implements BaseSpec, Genera
         archiveVersion.set(packageVersionOnFile)
         archiveBaseName.set(packageName)
         archiveExtension.set("tgz")
-//        preserveFileTimestamps = false
-//        reproducibleFileOrder = true
-//
-//        filesMatching(packageManifestFileName) {
-//            if (it.getFile().absolutePath.startsWith(packageDirectory.get().asFile.absolutePath)) {
-//                it.exclude()
-//            }
-//        }
 
         onlyIf(new Spec<GenerateUpmPackage>() {
             @Override

--- a/src/main/groovy/wooga/gradle/unity/tasks/GenerateUpmPackage.groovy
+++ b/src/main/groovy/wooga/gradle/unity/tasks/GenerateUpmPackage.groovy
@@ -141,13 +141,16 @@ class GenerateUpmPackage extends AbstractArchiveTask implements BaseSpec, Genera
         def tarOutputStream = new TarArchiveOutputStream(new GzipCompressorOutputStream(new FileOutputStream(tarFile)))
         tarOutputStream.longFileMode = TarArchiveOutputStream.LONGFILE_POSIX
 
-        processSourceDirs(tarOutputStream, temporaryDir, "package", null)
-        processSourceDirs(tarOutputStream,packageDirectory.asFile.get(), "package", "package.json")
+        processSourceDir(tarOutputStream, temporaryDir, "package", null)
+        processSourceDir(tarOutputStream,packageDirectory.asFile.get(), "package", "package.json")
 
         tarOutputStream.close()
     }
 
-    protected void processSourceDirs(TarArchiveOutputStream stream, File dir, String prefix, String exclude){
+    /**
+     * Adds files to the tar stream recursively.
+     */
+    protected void processSourceDir(TarArchiveOutputStream stream, File dir, String prefix, String exclude){
         def sourceDirFile = dir
         def files = sourceDirFile.listFiles().sort { it.name }
 
@@ -168,7 +171,7 @@ class GenerateUpmPackage extends AbstractArchiveTask implements BaseSpec, Genera
                 stream.closeArchiveEntry()
             } else {
                 stream.closeArchiveEntry()
-                processSourceDirs(stream,file, "${prefix}/${file.name}".toString(),exclude)
+                processSourceDir(stream,file, "${prefix}/${file.name}".toString(),exclude)
             }
         }
     }

--- a/src/main/groovy/wooga/gradle/unity/tasks/GenerateUpmPackage.groovy
+++ b/src/main/groovy/wooga/gradle/unity/tasks/GenerateUpmPackage.groovy
@@ -15,6 +15,7 @@ import org.gradle.api.tasks.*
 import org.gradle.api.tasks.bundling.Compression
 import org.gradle.api.tasks.bundling.Tar
 import wooga.gradle.unity.traits.GenerateUpmPackageSpec
+import org.apache.tools.ant.DirectoryScanner
 /**
  * A task that will generate an UPM package from a given Unity project
  */
@@ -58,6 +59,8 @@ class GenerateUpmPackage extends Tar implements BaseSpec, GenerateUpmPackageSpec
     public static final packageManifestFileName = "package.json"
 
     GenerateUpmPackage() {
+
+        DirectoryScanner.defaultExcludes.each { if (it.endsWith("~")) {DirectoryScanner.removeDefaultExclude it} }
 
         setCompression(Compression.GZIP)
 


### PR DESCRIPTION
## Ticket
https://woogagmbh.atlassian.net/browse/ATLAS-1334

## Description
Replace the tar packer. This is done because we want to support samples in WDKs. For this, we need to support folders with "~" inside the name.

Since Gradle7, there is no way to modify the filter at runtime.

## Changes
* ![ADD] commons-compress reference
* ![CHANGE] Replace TAR packer with the commons-compress implementation

[NEW]:      https://resources.atlas.wooga.com/icons/icon_new.svg "New"
[ADD]:      https://resources.atlas.wooga.com/icons/icon_add.svg "Add"
[IMPROVE]:  https://resources.atlas.wooga.com/icons/icon_improve.svg "Improve"
[CHANGE]:   https://resources.atlas.wooga.com/icons/icon_change.svg "Change"
[FIX]:      https://resources.atlas.wooga.com/icons/icon_fix.svg "Fix"
[UPDATE]:   https://resources.atlas.wooga.com/icons/icon_update.svg "Update"

[BREAK]:    https://resources.atlas.wooga.com/icons/icon_break.svg "Remove"
[REMOVE]:   https://resources.atlas.wooga.com/icons/icon_remove.svg "Remove"
[IOS]:      https://resources.atlas.wooga.com/icons/icon_iOS.svg "iOS"
[ANDROID]:  https://resources.atlas.wooga.com/icons/icon_android.svg "Android"
[WEBGL]:    https://resources.atlas.wooga.com/icons/icon_webGL.svg "WebGL"
[GRADLE]:   https://resources.atlas.wooga.com/icons/icon_gradle.svg "GRADLE"
[UNITY]:    https://resources.atlas.wooga.com/icons/icon_unity.svg "Unity"
[LINUX]:    https://resources.atlas.wooga.com/icons/icon_linux.svg "Linux"
[WIN]:      https://resources.atlas.wooga.com/icons/icon_windows.svg "Windows"
[MACOS]:    https://resources.atlas.wooga.com/icons/icon_iOS.svg "macOS"
