### PR TITLE
Simpler, better fix for the generateSolution issue [ATLAS-1772]

### DIFF
--- a/src/main/groovy/wooga/gradle/unity/tasks/GenerateSolution.groovy
+++ b/src/main/groovy/wooga/gradle/unity/tasks/GenerateSolution.groovy
@@ -1,53 +1,15 @@
 package wooga.gradle.unity.tasks
 
-import org.gradle.api.file.Directory
-import org.gradle.api.file.DirectoryProperty
-import org.gradle.api.provider.Provider
-import org.gradle.api.tasks.InputDirectory
-import org.gradle.api.tasks.Optional
+import wooga.gradle.unity.UnityTask
 
-class GenerateSolution extends ExecuteCsharpScript {
-    private final DirectoryProperty assetsDir = objects.directoryProperty()
-
-    @InputDirectory
-    @Optional
-    DirectoryProperty getAssetsDir() {
-        return assetsDir
-    }
-
-    void setAssetsDir(Provider<Directory> assetsDir) {
-        this.assetsDir.set(assetsDir)
-    }
-
-    void setAssetsDir(Directory assetsDir) {
-        this.assetsDir.set(assetsDir)
-    }
-
-    void setAssetsDir(File assetsDir) {
-        this.assetsDir.set(assetsDir)
-    }
+class GenerateSolution extends UnityTask {
 
     GenerateSolution() {
         outputs.upToDateWhen { false }
 
-        // Not the usual approach we take. Usually we would like to put the default in the plugin conventions and such, but this
-        // task seems to be designed to be independent from plugin configuration, so we still apply plugin configuration,
-        // but we set __sensible defaults__.
-        // This runs before the config block in the plugin, so it can and will be overwritten by plugin configuration when the plugin is applied as well
-        this.assetsDir.convention(this.projectDirectory.dir("Assets").map {it.asFile.mkdirs();return it})
-
-        def defaultScript = this.assetsDir
-        .map { it.file("SolutionGenerator.cs") }
-        .map { script ->
-            script.asFile.text = GenerateSolution.classLoader.getResourceAsStream("DefaultSolutionGenerator.cs").text
-            script.asFile.deleteOnExit()
-            return script
-        }
-        this.sourceScript.convention(defaultScript)
-        this.destinationScript.convention(this.sourceScript)
         this.executeMethod.set(project.provider {
             unityVersion.majorVersion >= 2022?
-                    "Wooga.UnityPlugin.DefaultSolutionGenerator.GenerateSolution" :
+                    "Packages.Rider.Editor.RiderScriptEditor.SyncSolution" :
                     "UnityEditor.SyncVS.SyncSolution"
         })
 


### PR DESCRIPTION
## Description
Current generateSolution fix leaves a file behind in the project, which polutes the git, and potentially may add an extra script to the game. As this script is present when the solution is generated, its added to the solution as well, which can generate issues when the added script is removed in the cleanup task. As we need the rider extension anyway, its a better solution to just call it directly to generate a solution. 

## Changes
* ![IMPROVE] generateSolution doesn't need to inject a script anymore
* ![FIX] solutions generated with `generateSolution` task fails in dotnet builds

[NEW]:      https://resources.atlas.wooga.com/icons/icon_new.svg "New"
[ADD]:      https://resources.atlas.wooga.com/icons/icon_add.svg "Add"
[IMPROVE]:  https://resources.atlas.wooga.com/icons/icon_improve.svg "Improve"
[CHANGE]:   https://resources.atlas.wooga.com/icons/icon_change.svg "Change"
[FIX]:      https://resources.atlas.wooga.com/icons/icon_fix.svg "Fix"
[UPDATE]:   https://resources.atlas.wooga.com/icons/icon_update.svg "Update"

[BREAK]:    https://resources.atlas.wooga.com/icons/icon_break.svg "Remove"
[REMOVE]:   https://resources.atlas.wooga.com/icons/icon_remove.svg "Remove"
[IOS]:      https://resources.atlas.wooga.com/icons/icon_iOS.svg "iOS"
[ANDROID]:  https://resources.atlas.wooga.com/icons/icon_android.svg "Android"
[WEBGL]:    https://resources.atlas.wooga.com/icons/icon_webGL.svg "WebGL"
[GRADLE]:   https://resources.atlas.wooga.com/icons/icon_gradle.svg "GRADLE"
[UNITY]:    https://resources.atlas.wooga.com/icons/icon_unity.svg "Unity"
[LINUX]:    https://resources.atlas.wooga.com/icons/icon_linux.svg "Linux"
[WIN]:      https://resources.atlas.wooga.com/icons/icon_windows.svg "Windows"
[MACOS]:    https://resources.atlas.wooga.com/icons/icon_iOS.svg "macOS"
