### PR TITLE
FIx plugin crashing when Unity return non-zero

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,7 @@ ENV RUST_BACKTRACE=1
 ENV RUST_LOG="warning, uvm_core=trace, uvm_jni=trace"
 ENV IN_DOCKER="1"
 
+
 RUN curl -Lo "unity-version-manager-$UVM_VERSION.tar.gz" "https://github.com/Larusso/unity-version-manager/archive/v$UVM_VERSION.tar.gz"
 RUN tar -xzf "unity-version-manager-$UVM_VERSION.tar.gz" && rm "unity-version-manager-$UVM_VERSION.tar.gz"
 
@@ -16,9 +17,9 @@ FROM openjdk:8-jdk-buster
 ARG USER_ID=1001
 ARG GROUP_ID=100
 
-RUN useradd -u ${USER_ID} -g ${GROUP_ID} --create-home ci
+RUN useradd -u ${USER_ID} -g ${GROUP_ID} --create-home jenkins_agent
 
-USER ci
+USER jenkins_agent
 COPY --from=0 /usr/local/bin/uvm* ./usr/local/bin/
 
-RUN uvm install 2019.1.0a7 /home/ci/.local/share/Unity-2019.1.0a7
+RUN uvm install 2019.1.0a7 /home/jenkins_agent/.local/share/Unity-2019.1.0a7


### PR DESCRIPTION
## Description
Fixes bug where plugin crashes if unity execution fails due to a missing variable

## Changes
* ![FIX] Plugin crashes when unity return non-zero status

[NEW]:      https://resources.atlas.wooga.com/icons/icon_new.svg "New"
[ADD]:      https://resources.atlas.wooga.com/icons/icon_add.svg "Add"
[IMPROVE]:  https://resources.atlas.wooga.com/icons/icon_improve.svg "Improve"
[CHANGE]:   https://resources.atlas.wooga.com/icons/icon_change.svg "Change"
[FIX]:      https://resources.atlas.wooga.com/icons/icon_fix.svg "Fix"
[UPDATE]:   https://resources.atlas.wooga.com/icons/icon_update.svg "Update"

[BREAK]:    https://resources.atlas.wooga.com/icons/icon_break.svg "Remove"
[REMOVE]:   https://resources.atlas.wooga.com/icons/icon_remove.svg "Remove"
[IOS]:      https://resources.atlas.wooga.com/icons/icon_iOS.svg "iOS"
[ANDROID]:  https://resources.atlas.wooga.com/icons/icon_android.svg "Android"
[WEBGL]:    https://resources.atlas.wooga.com/icons/icon_webGL.svg "WebGL"
[GRADLE]:   https://resources.atlas.wooga.com/icons/icon_gradle.svg "GRADLE"
[UNITY]:    https://resources.atlas.wooga.com/icons/icon_unity.svg "Unity"
[LINUX]:    https://resources.atlas.wooga.com/icons/icon_linux.svg "Linux"
[WIN]:      https://resources.atlas.wooga.com/icons/icon_windows.svg "Windows"
[MACOS]:    https://resources.atlas.wooga.com/icons/icon_iOS.svg "macOS"
