### PR TITLE
Add task to remove dangling unity files in workspace before run

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ RUN tar -xzf "unity-version-manager-$UVM_VERSION.tar.gz" && rm "unity-version-ma
 
 RUN cd "unity-version-manager-$UVM_VERSION" && PATH="${HOME}/.cargo/bin:$PATH" make install
 
-FROM openjdk:8-jdk-buster
+FROM openjdk:11-jdk-buster
 ARG USER_ID=1001
 ARG GROUP_ID=100
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -28,5 +28,6 @@ withCredentials([usernameColonPassword(credentialsId: 'artifactory_publish', var
 
     buildGradlePlugin platforms: ['macos','windows','linux'],
                       sonarToken: sonar_token,
-                      testEnvironment: testEnvironment
+                      testEnvironment: testEnvironment,
+                      dockerArgs: [ dockerArgs: ['-v', '/home/jenkins_agent/.gradle:/home/jenkins_agent/.gradle'] ]
 }

--- a/build.gradle
+++ b/build.gradle
@@ -16,7 +16,7 @@
  */
 
 plugins {
-    id 'net.wooga.plugins' version '5.0.0-rc.2'
+    id 'net.wooga.plugins' version '5.0.0'
     id 'net.wooga.snyk' version '0.12.0'
     id 'net.wooga.snyk-gradle-plugin' version '0.6.0'
     id "net.wooga.cve-dependency-resolution" version "0.4.0"

--- a/build.gradle
+++ b/build.gradle
@@ -22,6 +22,9 @@ plugins {
     id "net.wooga.cve-dependency-resolution" version "0.4.0"
 }
 
+java.sourceCompatibility = JavaVersion.VERSION_11
+java.targetCompatibility = JavaVersion.VERSION_11
+
 group 'net.wooga.gradle'
 description = 'a Unity 3D gradle plugin.'
 

--- a/build.gradle
+++ b/build.gradle
@@ -58,7 +58,7 @@ dependencies {
     implementation 'net.wooga:unity-version-manager-jni:[1,2['
     implementation 'org.apache.commons:commons-compress:1.24.0'
 
-    testImplementation('org.jfrog.artifactory.client:artifactory-java-client-services:+') {
+    testImplementation('org.jfrog.artifactory.client:artifactory-java-client-services:2.19.0') {
         exclude module: 'logback-classic'
     }
 

--- a/src/integrationTest/groovy/wooga/gradle/unity/tasks/ClearDanglingUnityFilesIntegrationSpec.groovy
+++ b/src/integrationTest/groovy/wooga/gradle/unity/tasks/ClearDanglingUnityFilesIntegrationSpec.groovy
@@ -1,0 +1,99 @@
+package wooga.gradle.unity.tasks
+
+import com.wooga.gradle.PlatformUtils
+import com.wooga.gradle.test.IntegrationSpec
+
+import java.util.concurrent.TimeUnit
+
+class ClearDanglingUnityFilesIntegrationSpec extends IntegrationSpec {
+
+    def "#prefix unity project Temp folder if there is #suffix"() {
+        given:
+        def tempFolder = new File(projectDir, "Temp").with {
+            it.mkdir()
+            new File(it, "UnityLockfile").createNewFile()
+            return it
+        }
+        and:
+        Process fakeProcess = null
+        if (hasOpenProcess) {
+            def fakeUnityExec = createFakeFrozenUnityExecutable()
+            fakeProcess = "$fakeUnityExec.absolutePath -projectPath ${projectDir.absolutePath}".execute()
+            fakeProcess.waitFor(10, TimeUnit.MILLISECONDS)
+        }
+        File editorInstanceFile = new File(projectDir, "Library/EditorInstance.json")
+        if (hasEditorInstanceFile) {
+            editorInstanceFile.parentFile.mkdir()
+            editorInstanceFile << """
+            {
+                "process_id" : ${wrapValueBasedOnType(fakeProcess.pid(), Integer)},
+                "version" : "any",
+                "app_path" : "any",
+                "app_contents_path" : "any"
+            }  
+            """
+        }
+        and:
+        buildFile << """
+        tasks.register("testTask", wooga.gradle.unity.tasks.ClearDanglingUnityFiles) {
+            projectDirectory.set(${wrapValueBasedOnType(projectDir, File)})
+            terminateOpenProcess.set($terminateProcess)
+        }
+        """
+
+        when:
+        assert tempFolder.exists()
+        assert fakeProcess ? fakeProcess.alive : true
+        assert editorInstanceFile.exists() == hasEditorInstanceFile
+         runTasksSuccessfully("testTask")
+
+        then:
+        tempFolder.exists() == !shouldCleanup
+
+        cleanup:
+        fakeProcess?.destroy()
+        editorInstanceFile.delete()
+
+
+        where:
+        hasOpenProcess | hasEditorInstanceFile | terminateProcess | shouldCleanup | prefix            | suffix
+        false          | false                 | false            | true          | "should delete"   | "no running Unity process with the project [0]"
+        false          | false                 | true             | true          | "should delete"   | "no running Unity process with the project [1]"
+        true           | true                  | true             | true          | "should delete"   | "running process with the project [1]"
+        true           | false                 | false            | true          | "should delete"   | "running process with the project [2]"
+        true           | true                  | false            | false         | "shouldnt delete" | "running process with the project"
+    }
+
+    def createFakeFrozenUnityExecutable() {
+        def fakeFrozenUnity = new File(projectDir, "Unity").with {
+            it.createNewFile()
+            it.executable = true
+            return it
+        }
+        if (PlatformUtils.windows) {
+            fakeFrozenUnity <<
+                    """@echo off
+            echo 'started'
+            :loop
+            timeout /t 0.010 >nul
+            goto loop
+            """
+        } else {
+            fakeFrozenUnity <<
+                    """
+            #!/bin/bash
+            
+            # Trap the SIGINT signal (Ctrl+C) and execute a function
+            trap 'exit' SIGINT
+            
+            echo "started"
+            # Infinite loop
+            while true
+            do
+                sleep 0.010
+            done
+            """
+        }
+        return fakeFrozenUnity
+    }
+}

--- a/src/integrationTest/groovy/wooga/gradle/unity/tasks/ClearDanglingUnityFilesIntegrationSpec.groovy
+++ b/src/integrationTest/groovy/wooga/gradle/unity/tasks/ClearDanglingUnityFilesIntegrationSpec.groovy
@@ -2,11 +2,13 @@ package wooga.gradle.unity.tasks
 
 import com.wooga.gradle.PlatformUtils
 import com.wooga.gradle.test.IntegrationSpec
+import spock.lang.IgnoreIf
 
 import java.util.concurrent.TimeUnit
 
 class ClearDanglingUnityFilesIntegrationSpec extends IntegrationSpec {
 
+    @IgnoreIf({ os.windows })
     def "#prefix unity project Temp folder if there is #suffix"() {
         given:
         def tempFolder = new File(projectDir, "Temp").with {

--- a/src/main/groovy/wooga/gradle/unity/UnityPlugin.groovy
+++ b/src/main/groovy/wooga/gradle/unity/UnityPlugin.groovy
@@ -38,6 +38,7 @@ import wooga.gradle.unity.models.TestPlatform
 import wooga.gradle.unity.models.UnityCommandLineOption
 import wooga.gradle.unity.tasks.Activate
 import wooga.gradle.unity.tasks.AddUPMPackages
+import wooga.gradle.unity.tasks.ClearDanglingUnityFiles
 import wooga.gradle.unity.tasks.GenerateSolution
 import wooga.gradle.unity.tasks.ProjectManifestTask
 import wooga.gradle.unity.tasks.SetResolutionStrategy
@@ -90,7 +91,8 @@ class UnityPlugin implements Plugin<Project> {
         ensureProjectManifest(Unity),
         addUPMPackages(AddUPMPackages),
         addIdeUPMPackage(AddUPMPackages),
-        setResolutionStrategy(SetResolutionStrategy)
+        setResolutionStrategy(SetResolutionStrategy),
+        cleanupDanglingUnityFiles(ClearDanglingUnityFiles)
 
         private final Class taskClass
 
@@ -246,6 +248,7 @@ class UnityPlugin implements Plugin<Project> {
         addGenerateSolutionTask(project)
         addAddUPMPackageTasks(project, extension)
         addActivateAndReturnLicenseTasks(project, extension)
+        addCleanupDanglingUnityFilesTask(project, extension)
     }
 
     private static void addTestTasks(Project project, UnityPluginExtension extension) {
@@ -490,6 +493,14 @@ class UnityPlugin implements Plugin<Project> {
         project.tasks.register(Tasks.setResolutionStrategy.toString(), SetResolutionStrategy) {
             it.description = "Sets the project package resolution strategy"
             it.resolutionStrategy.convention(extension.resolutionStrategy)
+        }
+    }
+
+    public static void addCleanupDanglingUnityFilesTask(Project project, UnityPluginExtension extension) {
+        project.tasks.register(Tasks.cleanupDanglingUnityFiles.toString(), ClearDanglingUnityFiles) { it ->
+            it.group = GROUP
+            it.projectDirectory.convention(extension.projectDirectory)
+            it.terminateOpenProcess.set(false)
         }
     }
 

--- a/src/main/groovy/wooga/gradle/unity/tasks/ClearDanglingUnityFiles.groovy
+++ b/src/main/groovy/wooga/gradle/unity/tasks/ClearDanglingUnityFiles.groovy
@@ -1,0 +1,90 @@
+package wooga.gradle.unity.tasks;
+
+import com.wooga.gradle.BaseSpec
+import groovy.json.JsonException
+import groovy.json.JsonSlurper;
+import org.gradle.api.DefaultTask
+import org.gradle.api.file.Directory;
+import org.gradle.api.file.DirectoryProperty
+import org.gradle.api.provider.Property
+import org.gradle.api.provider.Provider
+import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.InputDirectory
+import org.gradle.api.tasks.Optional
+import org.gradle.api.tasks.TaskAction
+
+public class ClearDanglingUnityFiles extends DefaultTask implements BaseSpec {
+
+    @InputDirectory
+    public final DirectoryProperty projectDirectory = objects.directoryProperty();
+
+    DirectoryProperty getProjectDirectory() {
+        return projectDirectory
+    }
+
+    void setProjectDirectory(Provider<Directory> projectDirectory) {
+        this.projectDirectory.set(projectDirectory)
+    }
+
+    void setProjectDirectory(File projectDirectory) {
+        this.projectDirectory.set(projectDirectory)
+    }
+
+    public final Property<Boolean> terminateOpenProcess = objects.property(Boolean)
+
+    @Input
+    @Optional
+    Property<Boolean> getTerminateOpenProcess() {
+        return terminateOpenProcess
+    }
+
+    void setTerminateOpenProcess(Boolean terminateOpenProcesses) {
+        this.terminateOpenProcess.set(terminateOpenProcesses)
+    }
+
+    void setTerminateOpenProcess(Provider<Boolean> terminateOpenProcesses) {
+        this.terminateOpenProcess.set(terminateOpenProcesses)
+    }
+
+    @TaskAction
+    def apply() {
+        def projectDir = projectDirectory.get().asFile
+        def terminateProcess = terminateOpenProcess.getOrElse(false)
+
+        def maybeProjectProcess = findOpenUnityProcessForProject(projectDir)
+        if (terminateProcess && maybeProjectProcess.isPresent()) {
+            def terminated = destroyProcess(maybeProjectProcess.get())
+            if (!terminated) {
+                logger.warn("Failed to terminate Unity process with PID ${it.pid()}")
+            }
+        }
+        if(maybeProjectProcess.empty || terminateProcess) {
+            def tempFolder = new File(projectDir, "Temp")
+            tempFolder.deleteDir()
+        }
+    }
+
+
+    static boolean destroyProcess(ProcessHandle process) {
+        def terminated = process.destroy()
+        if (!terminated) {
+            return process.destroyForcibly()
+        }
+        return terminated
+    }
+
+    java.util.Optional<ProcessHandle> findOpenUnityProcessForProject(File projectDir) {
+        def editorInstanceFile = new File(projectDir, "Library/EditorInstance.json")
+        if (!editorInstanceFile.exists()) {
+            return java.util.Optional.empty()
+        }
+        try {
+            def editorInstance = new JsonSlurper().parse(editorInstanceFile)
+            def processId = java.util.Optional.ofNullable(Integer.parseInt(editorInstance["process_id"].toString()))
+            return processId.flatMap {ProcessHandle.of(it) }
+        } catch (JsonException | NumberFormatException e) {
+            logger.warn("invalid json file in Library/EditorInstance.json, counting it as non-existent : $e.message")
+            return java.util.Optional.empty()
+        }
+    }
+}


### PR DESCRIPTION
## Description
Add new task `clearDanglingUnityFiles` which removes the `Temp` dir from a Unity workspace before unity runs, when no other unity processes are running on this workspace.  
It checks for the `Library/EditorInstance.json` file for potential open Unity instances. If it doesn't find any matching unity processes, or if the file is not there, it deletes the `Temp/` directory in the workspace. This usually happens when a unity run crashes or is force-exited.

Also pins artifactory sdk to 2.19.0, as 2.19.1 uses groovy 4, for some reason. 

## Changes
* ![ADD] `clearDanglingUnityFiles` task
* ![CHANGE] pin `org.jfrog.artifactory.client:artifactory-java-client-services` dependency to `2.19.0`
* ![CHANGE] minimum Java version is now 11

[NEW]:      https://resources.atlas.wooga.com/icons/icon_new.svg "New"
[ADD]:      https://resources.atlas.wooga.com/icons/icon_add.svg "Add"
[IMPROVE]:  https://resources.atlas.wooga.com/icons/icon_improve.svg "Improve"
[CHANGE]:   https://resources.atlas.wooga.com/icons/icon_change.svg "Change"
[FIX]:      https://resources.atlas.wooga.com/icons/icon_fix.svg "Fix"
[UPDATE]:   https://resources.atlas.wooga.com/icons/icon_update.svg "Update"

[BREAK]:    https://resources.atlas.wooga.com/icons/icon_break.svg "Remove"
[REMOVE]:   https://resources.atlas.wooga.com/icons/icon_remove.svg "Remove"
[IOS]:      https://resources.atlas.wooga.com/icons/icon_iOS.svg "iOS"
[ANDROID]:  https://resources.atlas.wooga.com/icons/icon_android.svg "Android"
[WEBGL]:    https://resources.atlas.wooga.com/icons/icon_webGL.svg "WebGL"
[GRADLE]:   https://resources.atlas.wooga.com/icons/icon_gradle.svg "GRADLE"
[UNITY]:    https://resources.atlas.wooga.com/icons/icon_unity.svg "Unity"
[LINUX]:    https://resources.atlas.wooga.com/icons/icon_linux.svg "Linux"
[WIN]:      https://resources.atlas.wooga.com/icons/icon_windows.svg "Windows"
[MACOS]:    https://resources.atlas.wooga.com/icons/icon_iOS.svg "macOS"
