### PR TITLE
Add a virtual method for customizing the exception message for unity task

### DIFF
--- a/src/integrationTest/groovy/com/wooga/spock/extensions/unity/DefaultUnityPluginTestOptions.groovy
+++ b/src/integrationTest/groovy/com/wooga/spock/extensions/unity/DefaultUnityPluginTestOptions.groovy
@@ -27,6 +27,7 @@ class DefaultUnityPluginTestOptions implements UnityPluginTestOptions {
     Boolean addMockTask = true
     Boolean forceMockTaskRun = true
     Boolean clearMockTaskActions = false
+    Boolean writeMockExecutable = true
 
     boolean applyPlugin() {
         applyPlugin
@@ -34,6 +35,11 @@ class DefaultUnityPluginTestOptions implements UnityPluginTestOptions {
 
     UnityPathResolution unityPath() {
         unityPath
+    }
+
+    @Override
+    boolean writeMockExecutable() {
+        writeMockExecutable
     }
 
     boolean addPluginTestDefaults() {

--- a/src/integrationTest/groovy/com/wooga/spock/extensions/unity/UnityPluginTestOptions.groovy
+++ b/src/integrationTest/groovy/com/wooga/spock/extensions/unity/UnityPluginTestOptions.groovy
@@ -41,6 +41,8 @@ import java.lang.annotation.Target
 
     UnityPathResolution unityPath() default UnityPathResolution.Mock
 
+    boolean writeMockExecutable() default true
+
     boolean addPluginTestDefaults() default true
 
     boolean disableAutoActivateAndLicense() default true

--- a/src/integrationTest/groovy/wooga/gradle/unity/UnityIntegrationSpec.groovy
+++ b/src/integrationTest/groovy/wooga/gradle/unity/UnityIntegrationSpec.groovy
@@ -19,23 +19,19 @@ package wooga.gradle.unity
 
 import com.wooga.gradle.PlatformUtils
 import com.wooga.gradle.test.IntegrationSpec
-import com.wooga.gradle.test.executable.FakeExecutables
 import com.wooga.gradle.test.mock.MockExecutable
 import com.wooga.spock.extensions.unity.DefaultUnityPluginTestOptions
 import com.wooga.spock.extensions.unity.UnityPathResolution
 import com.wooga.spock.extensions.unity.UnityPluginTestOptions
 import groovy.transform.stc.ClosureParams
-import groovy.transform.stc.ClosureSignatureHint
-import groovy.transform.stc.FirstParam
 import groovy.transform.stc.FromString
 import wooga.gradle.unity.tasks.Unity
 import wooga.gradle.unity.utils.ProjectSettingsFile
 
-import java.util.function.Function
-
 abstract class UnityIntegrationSpec extends IntegrationSpec {
 
-    MockExecutable mockUnityFile = createMockUnity()
+    MockExecutable mockUnity
+    File mockUnityFile
     final String mockUnityStartupMessage = "Mock Unity Started"
 
     File unityMainDirectory
@@ -126,14 +122,14 @@ abstract class UnityIntegrationSpec extends IntegrationSpec {
     /**
      * Writes the mock executable with a predetermined location
      */
-    protected void writeMockExecutable(@ClosureParams(value= FromString, options = "com.wooga.gradle.test.mock.MockExecutable")
+    protected void writeMockExecutable(@ClosureParams(value = FromString, options = "com.wooga.gradle.test.mock.MockExecutable")
                                            Closure<MockExecutable> configure = null) {
-        mockUnityFile = createMockUnity()
+        mockUnity = createMockUnity()
         if (configure != null) {
-            configure(mockUnityFile)
+            configure(mockUnity)
         }
-        def file = mockUnityFile.toDirectory(unityMainDirectory)
-        addUnityPathToExtension(file.path)
+        mockUnityFile = mockUnity.toDirectory(unityMainDirectory)
+        addUnityPathToExtension(mockUnityFile.path)
     }
 
     private void applyUnityPlugin() {
@@ -153,13 +149,13 @@ abstract class UnityIntegrationSpec extends IntegrationSpec {
         projectSettingsFile
     }
 
-    protected MockExecutable createMockUnity(String extraLog = null, int exitValue=0) {
+    protected MockExecutable createMockUnity(String extraLog = null, int exitValue = 0) {
 
         def mockFile = new MockExecutable("fakeUnity.bat")
         mockFile.withText(mockUnityStartupMessage)
         mockFile.withExitValue(exitValue)
         if (extraLog != null) {
-            mockFile.text += "\n${extraLog? extraLog.readLines().collect{"echo $it"}.join("\n") : ""}"
+            mockFile.text += "\n${extraLog ? extraLog.readLines().collect { "echo $it" }.join("\n") : ""}"
         }
         return mockFile
     }

--- a/src/integrationTest/groovy/wooga/gradle/unity/UnityIntegrationSpec.groovy
+++ b/src/integrationTest/groovy/wooga/gradle/unity/UnityIntegrationSpec.groovy
@@ -20,6 +20,7 @@ package wooga.gradle.unity
 import com.wooga.gradle.PlatformUtils
 import com.wooga.gradle.test.IntegrationSpec
 import com.wooga.gradle.test.executable.FakeExecutables
+import com.wooga.gradle.test.mock.MockExecutable
 import com.wooga.spock.extensions.unity.DefaultUnityPluginTestOptions
 import com.wooga.spock.extensions.unity.UnityPathResolution
 import com.wooga.spock.extensions.unity.UnityPluginTestOptions
@@ -133,38 +134,47 @@ abstract class UnityIntegrationSpec extends IntegrationSpec {
     }
 
     protected File createMockUnity(String extraLog = null, int exitValue=0) {
-        def mockUnityFile = createFile("fakeUnity.bat", unityMainDirectory).with {
-            delete()
-            createNewFile()
-            return it
+
+        def mockFile = new MockExecutable("fakeUnity.bat")
+        mockFile.withText(mockUnityStartupMessage)
+        mockFile.withExitValue(exitValue)
+        if (extraLog != null) {
+            mockFile.text += "\n${extraLog? extraLog.readLines().collect{"echo $it"}.join("\n") : ""}"
         }
-        mockUnityFile.executable = true
-        if (PlatformUtils.windows) {
-            mockUnityFile << """
-                @echo off
-                echo [ENVIRONMENT]:
-                set
-                echo [ARGUMENTS]:
-                echo %*
-                echo [LOG]:
-                echo ${mockUnityStartupMessage}
-                ${extraLog? extraLog.readLines().collect{"echo $it"}.join("\n") : ""}
-                EXIT /b $exitValue
-            """.readLines().collect{it.stripIndent().trim() }.findAll {!it.empty}.join("\n")
-        } else {
-            mockUnityFile << """
-                #!/usr/bin/env bash
-                echo [ENVIRONMENT]:
-                env
-                echo [ARGUMENTS]:
-                echo \$@
-                echo [LOG]:
-                echo ${mockUnityStartupMessage}
-                ${extraLog? "echo '$extraLog'" : ""}
-                exit $exitValue
-            """.readLines().collect{it.stripIndent().trim() }.findAll {!it.empty}.join("\n")
-        }
-        return mockUnityFile
+        mockFile.toDirectory(unityMainDirectory)
+
+//        def mockUnityFile = createFile("fakeUnity.bat", unityMainDirectory).with {
+//            delete()
+//            createNewFile()
+//            return it
+//        }
+//        mockUnityFile.executable = true
+//        if (PlatformUtils.windows) {
+//            mockUnityFile << """
+//                @echo off
+//                echo [ENVIRONMENT]:
+//                set
+//                echo [ARGUMENTS]:
+//                echo %*
+//                echo [LOG]:
+//                echo ${mockUnityStartupMessage}
+//                ${extraLog? extraLog.readLines().collect{"echo $it"}.join("\n") : ""}
+//                EXIT /b $exitValue
+//            """.readLines().collect{it.stripIndent().trim() }.findAll {!it.empty}.join("\n")
+//        } else {
+//            mockUnityFile << """
+//                #!/usr/bin/env bash
+//                echo [ENVIRONMENT]:
+//                env
+//                echo [ARGUMENTS]:
+//                echo \$@
+//                echo [LOG]:
+//                echo ${mockUnityStartupMessage}
+//                ${extraLog? "echo '$extraLog'" : ""}
+//                exit $exitValue
+//            """.readLines().collect{it.stripIndent().trim() }.findAll {!it.empty}.join("\n")
+//        }
+//        return mockUnityFile
 
     }
 

--- a/src/integrationTest/groovy/wooga/gradle/unity/UnityTaskIntegrationSpec.groovy
+++ b/src/integrationTest/groovy/wooga/gradle/unity/UnityTaskIntegrationSpec.groovy
@@ -353,7 +353,8 @@ abstract class UnityTaskIntegrationSpec<T extends UnityTask> extends UnityIntegr
     def "unity #message #maxRetries times with #retryWait wait times when line in log matches #retryRegexes"() {
         given:
         def fakeUnity = createMockUnity(unityLog, 1)
-        addUnityPathToExtension(fakeUnity.absolutePath)
+        def fakeUnityFile = fakeUnity.toDirectory(unityMainDirectory)
+        addUnityPathToExtension(fakeUnityFile.absolutePath)
         buildFile << """
         $subjectUnderTestName {
             maxRetries = ${wrapValue(maxRetries, Integer)}

--- a/src/integrationTest/groovy/wooga/gradle/unity/UnityTaskIntegrationSpec.groovy
+++ b/src/integrationTest/groovy/wooga/gradle/unity/UnityTaskIntegrationSpec.groovy
@@ -353,11 +353,6 @@ abstract class UnityTaskIntegrationSpec<T extends UnityTask> extends UnityIntegr
         def fakeUnity = createMockUnity(unityLog, 1)
         addUnityPathToExtension(fakeUnity.absolutePath)
 
-//        writeMockExecutable ({
-//            it.withText(unityLog)
-//            it.exitValue = 1
-//        })
-
         buildFile << """
         $subjectUnderTestName {
             maxRetries = ${wrapValue(maxRetries, Integer)}

--- a/src/integrationTest/groovy/wooga/gradle/unity/UnityTaskIntegrationSpec.groovy
+++ b/src/integrationTest/groovy/wooga/gradle/unity/UnityTaskIntegrationSpec.groovy
@@ -349,14 +349,14 @@ abstract class UnityTaskIntegrationSpec<T extends UnityTask> extends UnityIntegr
     @Unroll
     def "unity #message #maxRetries times with #retryWait wait times when line in log matches #retryRegexes"() {
         given:
-//        def fakeUnity = createMockUnity(unityLog, 1)
-//        def fakeUnityFile = fakeUnity.toDirectory(unityMainDirectory)
-//        addUnityPathToExtension(fakeUnityFile.absolutePath)
+        def fakeUnity = createMockUnity(unityLog, 1)
+        def fakeUnityFile = fakeUnity.toDirectory(unityMainDirectory)
+        addUnityPathToExtension(fakeUnityFile.absolutePath)
 
-        writeMockExecutable ({
-            it.withText(unityLog)
-            it.exitValue = 1
-        })
+//        writeMockExecutable ({
+//            it.withText(unityLog)
+//            it.exitValue = 1
+//        })
 
         buildFile << """
         $subjectUnderTestName {

--- a/src/integrationTest/groovy/wooga/gradle/unity/UnityTaskIntegrationSpec.groovy
+++ b/src/integrationTest/groovy/wooga/gradle/unity/UnityTaskIntegrationSpec.groovy
@@ -21,14 +21,11 @@ import com.wooga.gradle.PlatformUtils
 import com.wooga.gradle.test.PropertyQueryTaskWriter
 import com.wooga.gradle.test.TaskIntegrationSpec
 import com.wooga.gradle.test.writers.PropertyGetterTaskWriter
-import com.wooga.gradle.test.writers.PropertySetterWriter
 import org.gradle.api.logging.LogLevel
 import spock.lang.Unroll
 import wooga.gradle.unity.testutils.GradleRunResult
 import wooga.gradle.unity.models.UnityCommandLineOption
-import wooga.gradle.unity.tasks.Unity
 
-import java.lang.reflect.ParameterizedType
 import java.nio.file.Files
 import java.nio.file.StandardCopyOption
 import java.time.Duration
@@ -352,9 +349,15 @@ abstract class UnityTaskIntegrationSpec<T extends UnityTask> extends UnityIntegr
     @Unroll
     def "unity #message #maxRetries times with #retryWait wait times when line in log matches #retryRegexes"() {
         given:
-        def fakeUnity = createMockUnity(unityLog, 1)
-        def fakeUnityFile = fakeUnity.toDirectory(unityMainDirectory)
-        addUnityPathToExtension(fakeUnityFile.absolutePath)
+//        def fakeUnity = createMockUnity(unityLog, 1)
+//        def fakeUnityFile = fakeUnity.toDirectory(unityMainDirectory)
+//        addUnityPathToExtension(fakeUnityFile.absolutePath)
+
+        writeMockExecutable ({
+            it.withText(unityLog)
+            it.exitValue = 1
+        })
+
         buildFile << """
         $subjectUnderTestName {
             maxRetries = ${wrapValue(maxRetries, Integer)}

--- a/src/integrationTest/groovy/wooga/gradle/unity/UnityTaskIntegrationSpec.groovy
+++ b/src/integrationTest/groovy/wooga/gradle/unity/UnityTaskIntegrationSpec.groovy
@@ -349,9 +349,9 @@ abstract class UnityTaskIntegrationSpec<T extends UnityTask> extends UnityIntegr
     @Unroll
     def "unity #message #maxRetries times with #retryWait wait times when line in log matches #retryRegexes"() {
         given:
+
         def fakeUnity = createMockUnity(unityLog, 1)
-        def fakeUnityFile = fakeUnity.toDirectory(unityMainDirectory)
-        addUnityPathToExtension(fakeUnityFile.absolutePath)
+        addUnityPathToExtension(fakeUnity.absolutePath)
 
 //        writeMockExecutable ({
 //            it.withText(unityLog)

--- a/src/integrationTest/groovy/wooga/gradle/unity/tasks/FailTaskIntegrationSpec.groovy
+++ b/src/integrationTest/groovy/wooga/gradle/unity/tasks/FailTaskIntegrationSpec.groovy
@@ -40,7 +40,7 @@ class FailTaskIntegrationSpec extends UnityTaskIntegrationSpec<FailingTask>{
 
         given:
         writeMockExecutable({
-            it.text += "\n${FailingTask.expectedErrorMessage.readLines().collect{"echo $it 1>&2"}.join("\n")}"
+            it.text += "\n${FailingTask.expectedErrorMessage.readLines().collect{"echo $it >&2"}.join("\n")}"
             it.printEnvironment = false
             it.exitValue = 666
         })

--- a/src/integrationTest/groovy/wooga/gradle/unity/tasks/FailTaskIntegrationSpec.groovy
+++ b/src/integrationTest/groovy/wooga/gradle/unity/tasks/FailTaskIntegrationSpec.groovy
@@ -40,7 +40,7 @@ class FailTaskIntegrationSpec extends UnityTaskIntegrationSpec<FailingTask>{
 
         given:
         writeMockExecutable({
-            it.text += "\n${FailingTask.expectedErrorMessage.readLines().collect{"echo $it >&2"}.join("\n")}"
+            it.text += "\n${FailingTask.expectedErrorMessage.readLines().collect{"echo $it > /dev/stderr"}.join("\n")}"
             it.printEnvironment = false
             it.exitValue = 666
         })

--- a/src/integrationTest/groovy/wooga/gradle/unity/tasks/FailTaskIntegrationSpec.groovy
+++ b/src/integrationTest/groovy/wooga/gradle/unity/tasks/FailTaskIntegrationSpec.groovy
@@ -40,7 +40,7 @@ class FailTaskIntegrationSpec extends UnityTaskIntegrationSpec<FailingTask>{
 
         given:
         writeMockExecutable({
-            it.text += "\n${FailingTask.expectedErrorMessage.readLines().collect{"echo $it > /dev/stderr"}.join("\n")}"
+            it.text += "\n${FailingTask.expectedErrorMessage.readLines().collect{"echo $it >&2"}.join("\n")}"
             it.printEnvironment = false
             it.exitValue = 666
         })

--- a/src/integrationTest/groovy/wooga/gradle/unity/tasks/FailTaskIntegrationSpec.groovy
+++ b/src/integrationTest/groovy/wooga/gradle/unity/tasks/FailTaskIntegrationSpec.groovy
@@ -40,7 +40,7 @@ class FailTaskIntegrationSpec extends UnityTaskIntegrationSpec<FailingTask>{
 
         given:
         writeMockExecutable({
-            it.text += "\n${FailingTask.expectedErrorMessage.readLines().collect{"echo $it >&2"}.join("\n")}"
+            it.text += "\n${FailingTask.expectedErrorMessage.readLines().collect{"echo $it 1>&2"}.join("\n")}"
             it.printEnvironment = false
             it.exitValue = 666
         })

--- a/src/integrationTest/groovy/wooga/gradle/unity/tasks/FailTaskIntegrationSpec.groovy
+++ b/src/integrationTest/groovy/wooga/gradle/unity/tasks/FailTaskIntegrationSpec.groovy
@@ -1,52 +1,56 @@
 package wooga.gradle.unity.tasks
 
-import com.wooga.gradle.test.mock.MockExecutable
+
 import com.wooga.spock.extensions.unity.UnityPluginTestOptions
 import wooga.gradle.unity.UnityTaskIntegrationSpec
 
+import java.util.regex.Matcher
+import java.util.regex.Pattern
+
 class FailingTask extends Unity {
 
-    @Override
-    protected String composeExceptionMessage(String stdout, String stderr) {
-        return stderr ?: "Build failed because: ${stdout}"
-    }
-}
+    static Pattern pattern = Pattern.compile("<BUILD ERRORS>(?<summary>(.*\\s*)*)</BUILD ERRORS>")
 
-class FailTaskIntegrationSpec extends UnityTaskIntegrationSpec<FailingTask>{
-
-    String expectedErrorMessage = """[BuildEngine] Collected errors during build process:
-<BUILD ERRORS>
+    // Escape for ^<, ^>
+    public static String expectedErrorMessage = """[BuildEngine] Collected errors during build process:
+^<BUILD ERRORS^>
 [Error] FOO Wooga.UnifiedBuildSystem.Tests.Editor.BuildEngineTest+FailingBuildSteps:FailInElaborateWays (at Packages/com.wooga.unified-build-system/Tests/Editor/BuildEngine/BuildRequestOutputTest.cs:32)
 [Error] BAR Wooga.UnifiedBuildSystem.Tests.Editor.BuildEngineTest+FailingBuildSteps:FailInElaborateWays (at Packages/com.wooga.unified-build-system/Tests/Editor/BuildEngine/BuildRequestOutputTest.cs:32)
 [Exception] Exception: Boom! Wooga.UnifiedBuildSystem.Editor.BuildTask`1[[Wooga.UnifiedBuildSystem.Editor.BuildTaskArguments, Wooga.Build.Editor, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null]]:Execute (at Packages/com.wooga.build/Editor/Tasks/BuildTask.cs:73)
 [Error] Failed to execute task 'FailInElaborateWays' Wooga.UnifiedBuildSystem.Editor.BuildEngine+State:SetBuildFailure (at Packages/com.wooga.unified-build-system/Editor/BuildEngine/BuildEngine.cs:89)
-</BUILD ERRORS>
-    """.stripIndent()
+^</BUILD ERRORS^>""".stripIndent()
 
-    @UnityPluginTestOptions(forceMockTaskRun = true)
+    static String buildErrorStartMarker = "<BUILD ERRORS>"
+    static String buildErrorEndMarker = "</BUILD ERRORS>"
+
+    @Override
+    protected String composeExceptionMessage(String stdout, String stderr) {
+        Matcher matcher = pattern.matcher(stderr)
+        if (matcher.find()){
+            var summary = matcher.group(0)
+            return summary
+        }
+        return ""
+    }
+}
+
+class FailTaskIntegrationSpec extends UnityTaskIntegrationSpec<FailingTask>{
+    @UnityPluginTestOptions(writeMockExecutable = false)
     def "throws composited exception message"() {
 
         given:
-
-
-        MockExecutable executable = new MockExecutable("fail.bat")
-            .withEnvironment(false)
-            .withText("BOO!\n${expectedErrorMessage}")
-            .withExitValue(666)
-
-        def execFile = executable.toDirectory(projectDir)
-
-        buildFile << """
-        unity {
-            unityPath.set(${wrapFile(execFile)})            
-        }
-        """.stripIndent()
+        writeMockExecutable({
+            it.text += "\n${FailingTask.expectedErrorMessage.readLines().collect{"echo $it 1>&2"}.join("\n")}"
+            it.printEnvironment = false
+            it.exitValue = 666
+        })
 
         when:
         def result = runTasksWithFailure(subjectUnderTestName)
 
         then:
         result.wasExecuted(subjectUnderTestName)
-        result.standardOutput.contains(expectedErrorMessage)
+        result.standardError.contains(FailingTask.buildErrorStartMarker)
+        result.standardError.contains(FailingTask.buildErrorEndMarker)
     }
 }

--- a/src/integrationTest/groovy/wooga/gradle/unity/tasks/FailTaskIntegrationSpec.groovy
+++ b/src/integrationTest/groovy/wooga/gradle/unity/tasks/FailTaskIntegrationSpec.groovy
@@ -2,6 +2,7 @@ package wooga.gradle.unity.tasks
 
 
 import com.wooga.spock.extensions.unity.UnityPluginTestOptions
+import groovy.json.StringEscapeUtils
 import wooga.gradle.unity.UnityTaskIntegrationSpec
 
 import java.util.regex.Matcher
@@ -13,12 +14,12 @@ class FailingTask extends Unity {
 
     // Escape for ^<, ^>
     public static String expectedErrorMessage = """[BuildEngine] Collected errors during build process:
-^<BUILD ERRORS^>
+<BUILD ERRORS>
 [Error] FOO Wooga.UnifiedBuildSystem.Tests.Editor.BuildEngineTest+FailingBuildSteps:FailInElaborateWays (at Packages/com.wooga.unified-build-system/Tests/Editor/BuildEngine/BuildRequestOutputTest.cs:32)
 [Error] BAR Wooga.UnifiedBuildSystem.Tests.Editor.BuildEngineTest+FailingBuildSteps:FailInElaborateWays (at Packages/com.wooga.unified-build-system/Tests/Editor/BuildEngine/BuildRequestOutputTest.cs:32)
 [Exception] Exception: Boom! Wooga.UnifiedBuildSystem.Editor.BuildTask`1[[Wooga.UnifiedBuildSystem.Editor.BuildTaskArguments, Wooga.Build.Editor, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null]]:Execute (at Packages/com.wooga.build/Editor/Tasks/BuildTask.cs:73)
 [Error] Failed to execute task 'FailInElaborateWays' Wooga.UnifiedBuildSystem.Editor.BuildEngine+State:SetBuildFailure (at Packages/com.wooga.unified-build-system/Editor/BuildEngine/BuildEngine.cs:89)
-^</BUILD ERRORS^>""".stripIndent()
+</BUILD ERRORS>""".stripIndent()
 
     static String buildErrorStartMarker = "<BUILD ERRORS>"
     static String buildErrorEndMarker = "</BUILD ERRORS>"
@@ -35,13 +36,18 @@ class FailingTask extends Unity {
 }
 
 class FailTaskIntegrationSpec extends UnityTaskIntegrationSpec<FailingTask>{
+
+    static String echoError(String message) {
+        """echo "${StringEscapeUtils.escapeJava(message).replace("`", "\\`") }" 1>&2 """
+    }
+
     @UnityPluginTestOptions(writeMockExecutable = false)
     def "throws composited exception message"() {
 
         given:
         writeMockExecutable({
-            it.text += "\n${FailingTask.expectedErrorMessage.readLines().collect{"echo $it 1>&2"}.join("\n")}"
-            it.printEnvironment = false
+            it.text += "\n${FailingTask.expectedErrorMessage.readLines().collect{echoError(it) }.join("\n")}"
+            it.printEnvironment = false 
             it.exitValue = 666
         })
 

--- a/src/integrationTest/groovy/wooga/gradle/unity/tasks/FailTaskIntegrationSpec.groovy
+++ b/src/integrationTest/groovy/wooga/gradle/unity/tasks/FailTaskIntegrationSpec.groovy
@@ -1,0 +1,52 @@
+package wooga.gradle.unity.tasks
+
+import com.wooga.gradle.test.mock.MockExecutable
+import com.wooga.spock.extensions.unity.UnityPluginTestOptions
+import wooga.gradle.unity.UnityTaskIntegrationSpec
+
+class FailingTask extends Unity {
+
+    @Override
+    protected String composeExceptionMessage(String stdout, String stderr) {
+        return stderr ?: "Build failed because: ${stdout}"
+    }
+}
+
+class FailTaskIntegrationSpec extends UnityTaskIntegrationSpec<FailingTask>{
+
+    String expectedErrorMessage = """[BuildEngine] Collected errors during build process:
+<BUILD ERRORS>
+[Error] FOO Wooga.UnifiedBuildSystem.Tests.Editor.BuildEngineTest+FailingBuildSteps:FailInElaborateWays (at Packages/com.wooga.unified-build-system/Tests/Editor/BuildEngine/BuildRequestOutputTest.cs:32)
+[Error] BAR Wooga.UnifiedBuildSystem.Tests.Editor.BuildEngineTest+FailingBuildSteps:FailInElaborateWays (at Packages/com.wooga.unified-build-system/Tests/Editor/BuildEngine/BuildRequestOutputTest.cs:32)
+[Exception] Exception: Boom! Wooga.UnifiedBuildSystem.Editor.BuildTask`1[[Wooga.UnifiedBuildSystem.Editor.BuildTaskArguments, Wooga.Build.Editor, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null]]:Execute (at Packages/com.wooga.build/Editor/Tasks/BuildTask.cs:73)
+[Error] Failed to execute task 'FailInElaborateWays' Wooga.UnifiedBuildSystem.Editor.BuildEngine+State:SetBuildFailure (at Packages/com.wooga.unified-build-system/Editor/BuildEngine/BuildEngine.cs:89)
+</BUILD ERRORS>
+    """.stripIndent()
+
+    @UnityPluginTestOptions(forceMockTaskRun = true)
+    def "throws composited exception message"() {
+
+        given:
+
+
+        MockExecutable executable = new MockExecutable("fail.bat")
+            .withEnvironment(false)
+            .withText("BOO!\n${expectedErrorMessage}")
+            .withExitValue(666)
+
+        def execFile = executable.toDirectory(projectDir)
+
+        buildFile << """
+        unity {
+            unityPath.set(${wrapFile(execFile)})            
+        }
+        """.stripIndent()
+
+        when:
+        def result = runTasksWithFailure(subjectUnderTestName)
+
+        then:
+        result.wasExecuted(subjectUnderTestName)
+        result.standardOutput.contains(expectedErrorMessage)
+    }
+}

--- a/src/integrationTest/groovy/wooga/gradle/unity/testutils/GradleRunResult.groovy
+++ b/src/integrationTest/groovy/wooga/gradle/unity/testutils/GradleRunResult.groovy
@@ -1,5 +1,6 @@
 package wooga.gradle.unity.testutils
 
+import com.wooga.gradle.test.mock.MockExecutable
 import org.gradle.internal.impldep.org.apache.commons.lang.StringUtils
 
 class GradleRunResult {
@@ -46,14 +47,14 @@ class GradleRunResult {
     }
 
     private static ArrayList<String> loadArgs(String stdOutput) {
-        def argumentsStartToken = "[ARGUMENTS]:"
+        def argumentsStartToken = MockExecutable.ARGUMENTS_START_MARKER
         def lastExecutionOffset = stdOutput.lastIndexOf(argumentsStartToken)
         if(lastExecutionOffset < 0) {
             System.out.println(stdOutput)
             throw new IllegalArgumentException("couldn't find arguments list in stdout")
         }
         def lastExecTailString = stdOutput.substring(lastExecutionOffset)
-        def argsString = substringBetween(lastExecTailString, argumentsStartToken, "[LOG]").
+        def argsString = substringBetween(lastExecTailString, argumentsStartToken, MockExecutable.ARGUMENTS_END_MARKER).
                 replace(argumentsStartToken, "")
         def parts = argsString.split(" ").
                 findAll {!StringUtils.isEmpty(it) }.collect{ it.trim() }
@@ -61,8 +62,8 @@ class GradleRunResult {
     }
 
     private static Map<String, String> loadEnvs(String stdOutput) {
-        String environmentStartToken = "[ENVIRONMENT]:"
-        def argsString = substringBetween(stdOutput, environmentStartToken, "[ARGUMENTS]").
+        String environmentStartToken = MockExecutable.ENVIRONMENT_START_MARKER
+        def argsString = substringBetween(stdOutput, environmentStartToken, MockExecutable.ENVIRONMENT_END_MARKER).
                 replace(environmentStartToken, "")
         def parts = argsString.split(System.lineSeparator()).
                 findAll {!StringUtils.isEmpty(it) }.collect{ it.trim() }

--- a/src/main/groovy/wooga/gradle/unity/UnityTask.groovy
+++ b/src/main/groovy/wooga/gradle/unity/UnityTask.groovy
@@ -98,17 +98,25 @@ abstract class UnityTask extends DefaultTask
         })
 
         if (execResult.exitValue != 0) {
-            String message = ""
-            // Only write out the message if not already set to --info
-            if (!logger.infoEnabled) {
-                def stdout = logFile.text
-                def stderr = lastStderrStream? new String(lastStderrStream.toByteArray()) : ""
-                message = stderr ? stderr : stdout
-            }
+            def stdout = logFile.text
+            def stderr = lastStderrStream ? new String(lastStderrStream.toByteArray()) : ""
+            String message = composeExceptionMessage(stdout, stderr)
             throw new UnityExecutionException("Failed during execution of the Unity process with arguments:\n${_arguments}\n${message}")
         }
 
         postExecute(execResult)
+    }
+
+    /**
+     * Composes the message to be included in an exception thrown when the task fails
+     * Override this in your custom task in order to improve reporting.
+     */
+    protected String composeExceptionMessage(String stdout, String stderr) {
+        String message = ""
+        if (!logger.infoEnabled) {
+            message = stderr ? stderr : stdout
+        }
+        return message
     }
 
     /**


### PR DESCRIPTION
## Description
Add a method that can be overridden in the `UnityTask` for customizing the exception message.

## Changes
* ![ADD] `UnityTask.composeExceptionMessage,` virtual method for customizing the exception message when the task fails.

[NEW]:      https://resources.atlas.wooga.com/icons/icon_new.svg "New"
[ADD]:      https://resources.atlas.wooga.com/icons/icon_add.svg "Add"
[IMPROVE]:  https://resources.atlas.wooga.com/icons/icon_improve.svg "Improve"
[CHANGE]:   https://resources.atlas.wooga.com/icons/icon_change.svg "Change"
[FIX]:      https://resources.atlas.wooga.com/icons/icon_fix.svg "Fix"
[UPDATE]:   https://resources.atlas.wooga.com/icons/icon_update.svg "Update"

[BREAK]:    https://resources.atlas.wooga.com/icons/icon_break.svg "Remove"
[REMOVE]:   https://resources.atlas.wooga.com/icons/icon_remove.svg "Remove"
[IOS]:      https://resources.atlas.wooga.com/icons/icon_iOS.svg "iOS"
[ANDROID]:  https://resources.atlas.wooga.com/icons/icon_android.svg "Android"
[WEBGL]:    https://resources.atlas.wooga.com/icons/icon_webGL.svg "WebGL"
[GRADLE]:   https://resources.atlas.wooga.com/icons/icon_gradle.svg "GRADLE"
[UNITY]:    https://resources.atlas.wooga.com/icons/icon_unity.svg "Unity"
[LINUX]:    https://resources.atlas.wooga.com/icons/icon_linux.svg "Linux"
[WIN]:      https://resources.atlas.wooga.com/icons/icon_windows.svg "Windows"
[MACOS]:    https://resources.atlas.wooga.com/icons/icon_iOS.svg "macOS"
